### PR TITLE
Add gen_ogb_dataset.py which is used to generate built-in example dataset based on OGB.

### DIFF
--- a/tools/gen_mag_dataset.py
+++ b/tools/gen_mag_dataset.py
@@ -24,7 +24,7 @@ if __name__ == '__main__':
     parser.add_argument("--savepath", type=str, default=None)
     parser.add_argument("--edge_pct", type=float, default=1)
     args = parser.parse_args()
-    # only for test
+
     dataset = OGBMAGTextFeatDataset(args.filepath,
                                     edge_pct=args.edge_pct)
     dataset.save_graphs(args.savepath)

--- a/tools/gen_ogb_dataset.py
+++ b/tools/gen_ogb_dataset.py
@@ -29,7 +29,7 @@ if __name__ == '__main__':
     parser.add_argument("--max_sequence_length", type=int, default=512)
     parser.add_argument("--retain_original_features", type=lambda x: (str(x).lower() in ['true', '1']), default=True)
     args = parser.parse_args()
-    # only for test
+
     dataset = OGBTextFeatDataset(args.filepath,
                                  args.dataset,
                                  edge_pct=args.edge_pct,


### PR DESCRIPTION
*Description of changes:*

1. Add gen_ogb_dataset.py which is used to generate built-in example dataset based on OGB.
2. Add gen_mag_dataset.py which is used to generate built-in example dataset based on OGBN-MAG.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
