### PR TITLE
Fix a bug that distributed tensors/embeddings are destroyed unexpectedly.

### DIFF
--- a/python/graphstorm/model/gnn.py
+++ b/python/graphstorm/model/gnn.py
@@ -16,6 +16,7 @@
     GNN model in GraphStorm
 """
 
+import copy
 import abc
 import time
 import torch as th
@@ -56,6 +57,18 @@ class GSOptimizer():
         assert len(all_opts) > 0, "Optimizer list need to be defined"
         for optimizer in all_opts:
             assert optimizer is not None
+
+    def __deepcopy__(self, memo):
+        """ Override deep copy.
+
+        The sparse optimizer contains many distributed tensors.
+        We don't want to have deep copy of the distributed tensors
+        because if a DistTensor object is destroyed, the data in the server
+        will be destroyed as well.
+        """
+        cp = copy.copy(self)
+        cp.dense_opts = copy.deepcopy(self.dense_opts)
+        return cp
 
     def zero_grad(self):
         """ Setting the gradient to zero


### PR DESCRIPTION
*Issue #, if available:*
When we have a deep copy of a model object, it has a deep copy of DistTensor and DistEmbedding objects. When such a local object is destroyed, the data in the remote server will be destroyed as well. To fix the issue, we should avoid deep copy of these objects locally when a model is deep copied.

*Description of changes:*
Avoid deep copy of DistTensor and DistEmbedding objects.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
