### PR TITLE
[BugFix] save_topk does save the right model after evaluation.

### DIFF
--- a/python/graphstorm/config/argument.py
+++ b/python/graphstorm/config/argument.py
@@ -538,6 +538,19 @@ class GSConfig:
     @property
     def topk_model_to_save(self):
         """ the number of top k best validation performance model to save
+
+            If topk_model_to_save is set (save_model_per_iters is not set),
+            GraphStorm will try to save models after each epoch and keep at
+            most K models.
+            If save_model_per_iters is set, GraphStorm will try to save
+            models every #save_model_per_iters iterations and keep at
+            most K models.
+            By default, GraphStorm will save the latest K models unless
+            evaluation_frequency is set. When evaluation_frequency is set,
+            GraphStorm will evaluate the model performance every
+            #evaluation_frequency iterations. If at the same iteration,
+            #save_model_per_iters is reached, it will try to save the
+            best K model instead of the latest K model.
         """
         # pylint: disable=no-member
         if hasattr(self, "_topk_model_to_save"):
@@ -545,17 +558,19 @@ class GSConfig:
             assert self.save_model_path is not None, \
                 'To save models, please specify a valid path. But got None'
 
-            assert self.save_model_per_iters > 0, \
-                'save_model_per_iters should be larger than 0, ' \
-                'otherwise no model is going to be saved'
             if self.evaluation_frequency != sys.maxsize:
-                if self.save_model_per_iters != self.evaluation_frequency:
-                    print('WARNING: save_model_per_iters' \
+                assert self.save_model_per_iters >= self.evaluation_frequency and \
+                    self.save_model_per_iters % self.evaluation_frequency == 0, \
+                    'FATAL: save_model_per_iters' \
                           f'({self.save_model_per_iters}) ' \
                           'does not equal to evaluation_frequency' \
-                          f'({self.evaluation_frequency}).' \
-                          'GraphStorm will not try to save the best ' \
-                          'model after each evaluation cycle.')
+                          f'({self.evaluation_frequency}), or ' \
+                          f'save_model_per_iters ({self.save_model_per_iters}) ' \
+                          'is not divisible by evaluation_frequency ' \
+                          f'({self.evaluation_frequency}). ' \
+                          'GraphStorm can not guarentees that it will ' \
+                          'save the best model after evaluation cycles.'
+
             return self._topk_model_to_save
         else:
             # By default saving all models
@@ -707,7 +722,7 @@ class GSConfig:
         if hasattr(self, "_evaluation_frequency"):
             assert self._evaluation_frequency > 0, "evaluation_frequency should larger than 0"
             return self._evaluation_frequency
-        # set max value (Never save)
+        # set max value (Never do evaluation with in an epoch)
         return sys.maxsize
 
     @property

--- a/python/graphstorm/config/argument.py
+++ b/python/graphstorm/config/argument.py
@@ -544,8 +544,19 @@ class GSConfig:
             assert self._topk_model_to_save > 0, "Top K best model must > 0"
             assert self.save_model_path is not None, \
                 'To save models, please specify a valid path. But got None'
-            return self._topk_model_to_save
 
+            assert self.save_model_per_iters > 0, \
+                'save_model_per_iters should be larger than 0, ' \
+                'otherwise no model is going to be saved'
+            if self.evaluation_frequency != sys.maxsize:
+                if self.save_model_per_iters != self.evaluation_frequency:
+                    print('WARNING: save_model_per_iters' \
+                          f'({self.save_model_per_iters}) ' \
+                          'does not equal to evaluation_frequency' \
+                          f'({self.evaluation_frequency}).' \
+                          'GraphStorm will not try to save the best ' \
+                          'model after each evaluation cycle.')
+            return self._topk_model_to_save
         else:
             # By default saving all models
             return math.inf

--- a/python/graphstorm/trainer/ep_trainer.py
+++ b/python/graphstorm/trainer/ep_trainer.py
@@ -168,8 +168,16 @@ class GSgnnEdgePredictionTrainer(GSgnnTrainer):
                 # Every n iterations, check to save the top k models. If has validation score,
                 # will save # the best top k. But if no validation, will either save
                 # the last k model or all models depends on the setting of top k
-                if save_model_per_iters > 0 and i % save_model_per_iters == 0 and i != 0:
-                    self.save_topk_models(model, epoch, i, val_score, save_model_path)
+                if save_model_per_iters > 0 and \
+                    total_steps % save_model_per_iters == 0 and \
+                    total_steps != 0:
+                    if self.evaluator is None or val_score is not None:
+                        # We will save the best model when
+                        # 1. There is no evaluation, we will keep the
+                        #    latest K models.
+                        # 2. There is evaluaiton, we need to follow the
+                        #    guidance of validation score.
+                        self.save_topk_models(model, epoch, i, val_score, save_model_path)
 
                 # early_stop, exit current interation.
                 if early_stop is True:

--- a/python/graphstorm/trainer/lp_trainer.py
+++ b/python/graphstorm/trainer/lp_trainer.py
@@ -163,8 +163,16 @@ class GSgnnLinkPredictionTrainer(GSgnnTrainer):
                 # Every n iterations, check to save the top k models. If has validation score,
                 # will save the best top k. But if no validation, will either save
                 # the last k model or all models depends on the setting of top k
-                if save_model_per_iters > 0 and i % save_model_per_iters == 0 and i != 0:
-                    self.save_topk_models(model, epoch, i, val_score, save_model_path)
+                if save_model_per_iters > 0 and \
+                    total_steps % save_model_per_iters == 0 and \
+                    total_steps != 0:
+                    if self.evaluator is None or val_score is not None:
+                        # We will save the best model when
+                        # 1. There is no evaluation, we will keep the
+                        #    latest K models.
+                        # 2. There is evaluaiton, we need to follow the
+                        #    guidance of validation score.
+                        self.save_topk_models(model, epoch, i, val_score, save_model_path)
 
                 # early_stop, exit current interation.
                 if early_stop is True:

--- a/python/graphstorm/trainer/np_trainer.py
+++ b/python/graphstorm/trainer/np_trainer.py
@@ -159,8 +159,16 @@ class GSgnnNodePredictionTrainer(GSgnnTrainer):
                 # Every n iterations, check to save the top k models. If has validation score,
                 # will save the best top k. But if no validation, will either save
                 # the last k model or all models depends on the setting of top k
-                if save_model_per_iters > 0 and i % save_model_per_iters == 0 and i != 0:
-                    self.save_topk_models(model, epoch, i, val_score, save_model_path)
+                if save_model_per_iters > 0 and \
+                    total_steps % save_model_per_iters == 0 and \
+                    total_steps != 0:
+                    if self.evaluator is None or val_score is not None:
+                        # We will save the best model when
+                        # 1. There is no evaluation, we will keep the
+                        #    latest K models.
+                        # 2. There is evaluaiton, we need to follow the
+                        #    guidance of validation score.
+                        self.save_topk_models(model, epoch, i, val_score, save_model_path)
 
                 # early_stop, exit current interation.
                 if early_stop is True:

--- a/tests/end2end-tests/graphstorm-er/test.sh
+++ b/tests/end2end-tests/graphstorm-er/test.sh
@@ -43,7 +43,7 @@ python3 $DGL_HOME/tools/launch.py --workspace $GS_HOME/training_scripts/gsgnn_ep
 error_and_exit $?
 
 echo "**************dataset: Test edge regression, RGCN layer: 1, node feat: fixed HF BERT, BERT nodes: movie, inference: full-graph, save model and emb"
-python3 $DGL_HOME/tools/launch.py --workspace $GS_HOME/training_scripts/gsgnn_ep/ --num_trainers $NUM_TRAINERS --num_servers 1 --num_samplers 0 --part_config /data/movielen_100k_er_1p_4t/movie-lens-100k.json --ip_config ip_list.txt --ssh_port 2222 "python3 gsgnn_ep.py --cf ml_er.yaml --num-gpus 1 --part-config /data/movielen_100k_er_1p_4t/movie-lens-100k.json --mini-batch-infer false --save-model-path ./model/er_model/ --topk-model-to-save 3 --save-embed-path ./model/ml-emb/ --n-epochs 1"
+python3 $DGL_HOME/tools/launch.py --workspace $GS_HOME/training_scripts/gsgnn_ep/ --num_trainers $NUM_TRAINERS --num_servers 1 --num_samplers 0 --part_config /data/movielen_100k_er_1p_4t/movie-lens-100k.json --ip_config ip_list.txt --ssh_port 2222 "python3 gsgnn_ep.py --cf ml_er.yaml --num-gpus 1 --part-config /data/movielen_100k_er_1p_4t/movie-lens-100k.json --mini-batch-infer false --save-model-path ./model/er_model/ --topk-model-to-save 3 --save-embed-path ./model/ml-emb/ --n-epochs 1 --save-model-per-iters 1000"
 
 error_and_exit $?
 

--- a/tests/unit-tests/test_config.py
+++ b/tests/unit-tests/test_config.py
@@ -402,6 +402,7 @@ def create_train_config(tmp_path, file_name):
         "eval_batch_size": 128,
         "wd_l2norm": 0.1,
         "alpha_l2norm": 0.00001,
+        "evaluation_frequency": 1000,
         'save_model_per_iters': 1000,
         "topk_model_to_save": 3,
         "sparse_lr": 0.001,
@@ -414,6 +415,22 @@ def create_train_config(tmp_path, file_name):
     with open(os.path.join(tmp_path, file_name+".yaml"), "w") as f:
         yaml.dump(yaml_object, f)
 
+    yaml_object["gsf"]["hyperparam"] = {
+        "topk_model_to_save": 4,
+        "save_model_path": os.path.join(tmp_path, "save"),
+    }
+    with open(os.path.join(tmp_path, file_name+"1.yaml"), "w") as f:
+        yaml.dump(yaml_object, f)
+
+    yaml_object["gsf"]["hyperparam"] = {
+        "evaluation_frequency": 1000,
+        'save_model_per_iters': 2000,
+        "topk_model_to_save": 5,
+        "save_model_path": os.path.join(tmp_path, "save"),
+    }
+    with open(os.path.join(tmp_path, file_name+"2.yaml"), "w") as f:
+        yaml.dump(yaml_object, f)
+
     # for failures
     yaml_object["gsf"]["hyperparam"] = {
         "dropout" : -1.0,
@@ -424,6 +441,8 @@ def create_train_config(tmp_path, file_name):
         "sparse_lr": 0.,
         "use_node_embeddings": True,
         "use_self_loop": "error",
+        "evaluation_frequency": 1000,
+        'save_model_per_iters': 700,
         "topk_model_to_save": 3,
         "enable_early_stop": True,
         "call_to_consider_early_stop": -1,
@@ -431,6 +450,15 @@ def create_train_config(tmp_path, file_name):
     }
 
     with open(os.path.join(tmp_path, file_name+"_fail.yaml"), "w") as f:
+        yaml.dump(yaml_object, f)
+
+    yaml_object["gsf"]["hyperparam"] = {
+        "evaluation_frequency": 1100,
+        'save_model_per_iters': 2000,
+        "topk_model_to_save": 3,
+        "save_model_path": os.path.join(tmp_path, "save"),
+    }
+    with open(os.path.join(tmp_path, file_name+"_fail1.yaml"), "w") as f:
         yaml.dump(yaml_object, f)
 
 
@@ -475,6 +503,14 @@ def test_train_info():
         assert config.call_to_consider_early_stop == 0
         assert config.window_for_early_stop == 3
 
+        args = Namespace(yaml_config_file=os.path.join(Path(tmpdirname), 'train_test1.yaml'), local_rank=0)
+        config = GSConfig(args)
+        assert config.topk_model_to_save == 4
+
+        args = Namespace(yaml_config_file=os.path.join(Path(tmpdirname), 'train_test2.yaml'), local_rank=0)
+        config = GSConfig(args)
+        assert config.topk_model_to_save == 5
+
         args = Namespace(yaml_config_file=os.path.join(Path(tmpdirname), 'train_test_fail.yaml'), local_rank=0)
         config = GSConfig(args)
         check_failure(config, "dropout")
@@ -491,6 +527,10 @@ def test_train_info():
         check_failure(config, "topk_model_to_save")
         check_failure(config, "call_to_consider_early_stop")
         check_failure(config, "window_for_early_stop")
+
+        args = Namespace(yaml_config_file=os.path.join(Path(tmpdirname), 'train_test_fail1.yaml'), local_rank=0)
+        config = GSConfig(args)
+        check_failure(config, "topk_model_to_save")
 
 def create_rgcn_config(tmp_path, file_name):
     yaml_object = create_dummpy_config_obj()

--- a/tests/unit-tests/test_config.py
+++ b/tests/unit-tests/test_config.py
@@ -402,6 +402,7 @@ def create_train_config(tmp_path, file_name):
         "eval_batch_size": 128,
         "wd_l2norm": 0.1,
         "alpha_l2norm": 0.00001,
+        'save_model_per_iters': 1000,
         "topk_model_to_save": 3,
         "sparse_lr": 0.001,
         "use_node_embeddings": False,
@@ -423,6 +424,7 @@ def create_train_config(tmp_path, file_name):
         "sparse_lr": 0.,
         "use_node_embeddings": True,
         "use_self_loop": "error",
+        "topk_model_to_save": 3,
         "enable_early_stop": True,
         "call_to_consider_early_stop": -1,
         "window_for_early_stop": 0,
@@ -486,6 +488,7 @@ def test_train_info():
         config._dropout = 1.0
         check_failure(config, "dropout")
         assert config.enable_early_stop == True
+        check_failure(config, "topk_model_to_save")
         check_failure(config, "call_to_consider_early_stop")
         check_failure(config, "window_for_early_stop")
 

--- a/tests/unit-tests/test_evaluator.py
+++ b/tests/unit-tests/test_evaluator.py
@@ -671,6 +671,7 @@ def test_get_val_score_rank():
                                     num_negative_edges_eval=config.num_negative_edges_eval,
                                     use_dot_product=config.use_dot_product,
                                     enable_early_stop=config.enable_early_stop)
+
     # For MRR, the bigger the better
     val_score = {"mrr": 0.47}
     assert evaluator.get_val_score_rank(val_score) == 1
@@ -694,4 +695,4 @@ if __name__ == '__main__':
     test_early_stop_cons_increase_judge()
     test_early_stop_evaluator()
     test_early_stop_lp_evaluator()
-    test_get_val_score_rank
+    test_get_val_score_rank()


### PR DESCRIPTION
When both save_model_per_iters and evaluation_frequency are set to the same value, save_topk actually does not save the best model according to the evaluation, as there is a mismatch in its way of counting the iterations.

*Description of changes:*
This PR fixes that bug.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
