### PR TITLE
[Fix] fix a bug: using the num_negative_edges for test evaluation when do inference

### DIFF
--- a/inference_scripts/lp_infer/lp_infer_gnn.py
+++ b/inference_scripts/lp_infer/lp_infer_gnn.py
@@ -66,7 +66,7 @@ def main(args):
 
     dataloader = test_dataloader_cls(infer_data, infer_data.test_idxs,
                                      batch_size=config.eval_batch_size,
-                                     num_negative_edges=config.num_negative_edges)
+                                     num_negative_edges=config.num_negative_edges_eval)
     # Preparing input layer for training or inference.
     # The input layer can pre-compute node features in the preparing step if needed.
     # For example pre-compute all BERT embeddings

--- a/inference_scripts/lp_infer/lp_infer_lm.py
+++ b/inference_scripts/lp_infer/lp_infer_lm.py
@@ -67,7 +67,7 @@ def main(args):
 
     dataloader = test_dataloader_cls(infer_data, infer_data.test_idxs,
                                      batch_size=config.eval_batch_size,
-                                     num_negative_edges=config.num_negative_edges)
+                                     num_negative_edges=config.num_negative_edges_eval)
     # Preparing input layer for training or inference.
     # The input layer can pre-compute node features in the preparing step if needed.
     # For example pre-compute all BERT embeddings


### PR DESCRIPTION
*Issue #57,:*

*Description of changes:*
The LP inference script use "num_negative_edges" for test evaluation, but it should use "num_negative_edges_eval" same as the trainer scripts.
After fix this bug, the MRR values of trainer and infer are similar.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
