### PR TITLE
[Bug Fix] Fix error code check of CI script

### DIFF
--- a/.github/workflow_scripts/e2e_check.sh
+++ b/.github/workflow_scripts/e2e_check.sh
@@ -8,8 +8,8 @@ sh ./tests/end2end-tests/create_data.sh
 sh ./tests/end2end-tests/tools/test_mem_est.sh
 sh ./tests/end2end-tests/data_process/test.sh
 sh ./tests/end2end-tests/custom-gnn/run_test.sh
-sh ./tests/end2end-tests/graphstorm-nc/test.sh
-sh ./tests/end2end-tests/graphstorm-lp/test.sh
-sh ./tests/end2end-tests/graphstorm-ec/test.sh
-sh ./tests/end2end-tests/graphstorm-er/test.sh
+bash ./tests/end2end-tests/graphstorm-nc/test.sh
+bash ./tests/end2end-tests/graphstorm-lp/test.sh
+bash ./tests/end2end-tests/graphstorm-ec/test.sh
+bash ./tests/end2end-tests/graphstorm-er/test.sh
 

--- a/.github/workflow_scripts/e2e_mgpu_check.sh
+++ b/.github/workflow_scripts/e2e_mgpu_check.sh
@@ -5,7 +5,7 @@ set -ex
 
 sh ./tests/end2end-tests/setup.sh
 sh ./tests/end2end-tests/create_data.sh
-sh ./tests/end2end-tests/graphstorm-lp/mgpu_test.sh
-sh ./tests/end2end-tests/graphstorm-nc/mgpu_test.sh
-sh ./tests/end2end-tests/graphstorm-ec/mgpu_test.sh
+bash ./tests/end2end-tests/graphstorm-lp/mgpu_test.sh
+bash ./tests/end2end-tests/graphstorm-nc/mgpu_test.sh
+bash ./tests/end2end-tests/graphstorm-ec/mgpu_test.sh
 

--- a/tests/end2end-tests/graphstorm-ec/mgpu_test.sh
+++ b/tests/end2end-tests/graphstorm-ec/mgpu_test.sh
@@ -26,7 +26,7 @@ error_and_exit () {
 echo "**************dataset: Generated multilabel MovieLens EC, RGCN layer: 1, node feat: generated feature, inference: full graph, exclude-training-targets: True"
 python3 $DGL_HOME/tools/launch.py --workspace $GS_HOME/training_scripts/gsgnn_ep/ --num_trainers $NUM_TRAINERS --num_servers 1 --num_samplers 0 --part_config /data/movielen_100k_multi_label_ec/movie-lens-100k.json --ip_config ip_list.txt --ssh_port 2222 "python3 gsgnn_ep.py --cf ml_ec.yaml --num-gpus $NUM_TRAINERS --part-config /data/movielen_100k_multi_label_ec/movie-lens-100k.json --exclude-training-targets True --multilabel true --num-classes 6 --feat-name feat --mini-batch-infer false --topk-model-to-save 1  --save-embed-path /data/gsgnn_ec/emb/ --save-model-path /data/gsgnn_ec/ --save-model-per-iter 1000" | tee train_log.txt
 
-error_and_exit $?
+error_and_exit ${PIPESTATUS[0]}
 
 # check prints
 cnt=$(grep "save_embed_path: /data/gsgnn_ec/emb/" train_log.txt | wc -l)
@@ -77,7 +77,7 @@ echo "The best model is saved in epoch $best_epoch"
 echo "**************dataset: Generated multilabel MovieLens EC, do inference on saved model"
 python3 $DGL_HOME/tools/launch.py --workspace $GS_HOME/inference_scripts/ep_infer --num_trainers $NUM_INFO_TRAINERS --num_servers 1 --num_samplers 0 --part_config /data/movielen_100k_multi_label_ec/movie-lens-100k.json --ip_config ip_list.txt --ssh_port 2222 "python3 ep_infer_gnn.py --cf ml_ec_infer.yaml --num-gpus $NUM_INFO_TRAINERS --part-config /data/movielen_100k_multi_label_ec/movie-lens-100k.json --multilabel true --num-classes 6 --feat-name feat --mini-batch-infer false --save-embed-path /data/gsgnn_ec/infer-emb/ --restore-model-path /data/gsgnn_ec/epoch-$best_epoch/" | tee log.txt
 
-error_and_exit $?
+error_and_exit ${PIPESTATUS[0]}
 
 cnt=$(grep "| Test accuracy" log.txt | wc -l)
 if test $cnt -ne 1
@@ -124,7 +124,7 @@ rm -fr /data/gsgnn_ec/*
 echo "**************dataset: Generated MovieLens EC, RGCN layer: 1, node feat: generated feature and text feature, inference: full graph, exclude-training-targets: True, train_nodes 10"
 python3 $DGL_HOME/tools/launch.py --workspace $GS_HOME/training_scripts/gsgnn_ep/ --num_trainers $NUM_TRAINERS --num_servers 1 --num_samplers 0 --part_config /data/movielen_100k_ec_1p_4t_text/movie-lens-100k-text.json --ip_config ip_list.txt --ssh_port 2222 "python3 gsgnn_ep.py --cf ml_ec_text.yaml --num-gpus $NUM_TRAINERS --part-config /data/movielen_100k_ec_1p_4t_text/movie-lens-100k-text.json --exclude-training-targets True --num-classes 6 --feat-name feat --mini-batch-infer false --topk-model-to-save 1  --save-embed-path /data/gsgnn_ec_text/emb/ --save-model-path /data/gsgnn_ec_text/ --save-model-per-iter 1000" | tee train_log.txt
 
-error_and_exit $?
+error_and_exit ${PIPESTATUS[0]}
 
 best_epoch=$(grep "successfully save the model to" train_log.txt | tail -1 | tr -d '\n' | tail -c 1)
 echo "The best model is saved in epoch $best_epoch"
@@ -132,10 +132,12 @@ echo "The best model is saved in epoch $best_epoch"
 echo "**************dataset: Generated MovieLens EC, node feat: generated feature and text feature, do inference on saved model"
 python3 $DGL_HOME/tools/launch.py --workspace $GS_HOME/inference_scripts/ep_infer --num_trainers $NUM_INFO_TRAINERS --num_servers 1 --num_samplers 0 --part_config /data/movielen_100k_ec_1p_4t_text/movie-lens-100k-text.json --ip_config ip_list.txt --ssh_port 2222 "python3 ep_infer_gnn.py --cf ml_ec_text_infer.yaml --num-gpus $NUM_INFO_TRAINERS --part-config /data/movielen_100k_ec_1p_4t_text/movie-lens-100k-text.json --num-classes 6 --feat-name feat --mini-batch-infer false --save-embed-path /data/gsgnn_ec_text/infer-emb/ --restore-model-path /data/gsgnn_ec_text/epoch-$best_epoch/" | tee log.txt
 
-error_and_exit $?
+error_and_exit ${PIPESTATUS[0]}
 
 cd $GS_HOME/tests/end2end-tests/
 python3 check_infer.py --train_embout /data/gsgnn_ec_text/emb/ --infer_embout /data/gsgnn_ec_text/infer-emb/
+
+error_and_exit $?
 
 echo "**************dataset: Generated MovieLens EC, RGCN layer: 1, node feat: generated feature and text feature, inference: full graph, exclude-training-targets: True, train nodes: 0"
 python3 $DGL_HOME/tools/launch.py --workspace $GS_HOME/training_scripts/gsgnn_ep/ --num_trainers $NUM_TRAINERS --num_servers 1 --num_samplers 0 --part_config /data/movielen_100k_ec_1p_4t_text/movie-lens-100k-text.json --ip_config ip_list.txt --ssh_port 2222 "python3 gsgnn_ep.py --cf ml_ec_text.yaml --num-gpus $NUM_TRAINERS --part-config /data/movielen_100k_ec_1p_4t_text/movie-lens-100k-text.json --exclude-training-targets True --num-classes 6 --feat-name feat --mini-batch-infer false --topk-model-to-save 1  --save-embed-path /data/gsgnn_ec_text/emb/ --save-model-path /data/gsgnn_ec_text/ --save-model-per-iter 1000 --lm-train-nodes 0" | tee train_log.txt
@@ -145,7 +147,7 @@ rm -fr /data/gsgnn_ec_text/*
 echo "**************dataset: Generated MovieLens EC, RGCN layer: 1, node feat: text feature, inference: full graph, exclude-training-targets: True, train_nodes 10"
 python3 $DGL_HOME/tools/launch.py --workspace $GS_HOME/training_scripts/gsgnn_ep/ --num_trainers $NUM_TRAINERS --num_servers 1 --num_samplers 0 --part_config /data/movielen_100k_ec_1p_4t_text/movie-lens-100k-text.json --ip_config ip_list.txt --ssh_port 2222 "python3 gsgnn_lm_ep.py --cf ml_lm_ec.yaml --num-gpus $NUM_TRAINERS --part-config /data/movielen_100k_ec_1p_4t_text/movie-lens-100k-text.json --exclude-training-targets True --num-classes 6 --feat-name feat --mini-batch-infer false --topk-model-to-save 1  --save-embed-path /data/gsgnn_ec_lm/emb/ --save-model-path /data/gsgnn_ec_lm/ --save-model-per-iter 1000" | tee train_log.txt
 
-error_and_exit $?
+error_and_exit ${PIPESTATUS[0]}
 
 best_epoch=$(grep "successfully save the model to" train_log.txt | tail -1 | tr -d '\n' | tail -c 1)
 echo "The best model is saved in epoch $best_epoch"
@@ -153,9 +155,11 @@ echo "The best model is saved in epoch $best_epoch"
 echo "**************dataset: Generated MovieLens EC, node feat: text feature, do inference on saved model"
 python3 $DGL_HOME/tools/launch.py --workspace $GS_HOME/inference_scripts/ep_infer --num_trainers $NUM_INFO_TRAINERS --num_servers 1 --num_samplers 0 --part_config /data/movielen_100k_ec_1p_4t_text/movie-lens-100k-text.json --ip_config ip_list.txt --ssh_port 2222 "python3 ep_infer_lm.py --cf ml_lm_ec_infer.yaml --num-gpus $NUM_INFO_TRAINERS --part-config /data/movielen_100k_ec_1p_4t_text/movie-lens-100k-text.json --num-classes 6 --feat-name feat --mini-batch-infer false --save-embed-path /data/gsgnn_ec_lm/infer-emb/ --restore-model-path /data/gsgnn_ec_lm/epoch-$best_epoch/" | tee log.txt
 
-error_and_exit $?
+error_and_exit ${PIPESTATUS[0]}
 
 cd $GS_HOME/tests/end2end-tests/
 python3 check_infer.py --train_embout /data/gsgnn_ec_lm/emb/ --infer_embout /data/gsgnn_ec_lm/infer-emb/
+
+error_and_exit $?
 
 rm -fr /data/gsgnn_ec_lm/*

--- a/tests/end2end-tests/graphstorm-ec/mgpu_test.sh
+++ b/tests/end2end-tests/graphstorm-ec/mgpu_test.sh
@@ -142,6 +142,7 @@ error_and_exit $?
 echo "**************dataset: Generated MovieLens EC, RGCN layer: 1, node feat: generated feature and text feature, inference: full graph, exclude-training-targets: True, train nodes: 0"
 python3 $DGL_HOME/tools/launch.py --workspace $GS_HOME/training_scripts/gsgnn_ep/ --num_trainers $NUM_TRAINERS --num_servers 1 --num_samplers 0 --part_config /data/movielen_100k_ec_1p_4t_text/movie-lens-100k-text.json --ip_config ip_list.txt --ssh_port 2222 "python3 gsgnn_ep.py --cf ml_ec_text.yaml --num-gpus $NUM_TRAINERS --part-config /data/movielen_100k_ec_1p_4t_text/movie-lens-100k-text.json --exclude-training-targets True --num-classes 6 --feat-name feat --mini-batch-infer false --topk-model-to-save 1  --save-embed-path /data/gsgnn_ec_text/emb/ --save-model-path /data/gsgnn_ec_text/ --save-model-per-iter 1000 --lm-train-nodes 0" | tee train_log.txt
 
+error_and_exit ${PIPESTATUS[0]}
 rm -fr /data/gsgnn_ec_text/*
 
 echo "**************dataset: Generated MovieLens EC, RGCN layer: 1, node feat: text feature, inference: full graph, exclude-training-targets: True, train_nodes 10"
@@ -161,14 +162,13 @@ cd $GS_HOME/tests/end2end-tests/
 python3 check_infer.py --train_embout /data/gsgnn_ec_lm/emb/ --infer_embout /data/gsgnn_ec_lm/infer-emb/
 
 error_and_exit $?
-
 rm -fr /data/gsgnn_ec_lm/*
 rm train_log.txt
 
 echo "**************dataset: Generated MovieLens EC, RGCN layer: 1, node feat: text feature, with warmup, inference: full graph, exclude-training-targets: True, train_nodes 10"
 python3 $DGL_HOME/tools/launch.py --workspace $GS_HOME/training_scripts/gsgnn_ep/ --num_trainers $NUM_TRAINERS --num_servers 1 --num_samplers 0 --part_config /data/movielen_100k_ec_1p_4t_text/movie-lens-100k-text.json --ip_config ip_list.txt --ssh_port 2222 "python3 gsgnn_lm_ep.py --cf ml_lm_ec.yaml --num-gpus $NUM_TRAINERS --part-config /data/movielen_100k_ec_1p_4t_text/movie-lens-100k-text.json --exclude-training-targets True --num-classes 6 --feat-name feat --mini-batch-infer false --topk-model-to-save 1  --save-embed-path /data/gsgnn_ec_lm/emb/ --save-model-path /data/gsgnn_ec_lm/ --save-model-per-iter 1000  --freeze-lm-encoder-epochs 1" | tee train_log.txt
 
-error_and_exit $?
+error_and_exit ${PIPESTATUS[0]}
 
 best_epoch=$(grep "successfully save the model to" train_log.txt | tail -1 | tr -d '\n' | tail -c 1)
 echo "The best model is saved in epoch $best_epoch"
@@ -176,10 +176,11 @@ echo "The best model is saved in epoch $best_epoch"
 echo "**************dataset: Generated MovieLens EC, node feat: text feature, do inference on saved model"
 python3 $DGL_HOME/tools/launch.py --workspace $GS_HOME/inference_scripts/ep_infer --num_trainers $NUM_INFO_TRAINERS --num_servers 1 --num_samplers 0 --part_config /data/movielen_100k_ec_1p_4t_text/movie-lens-100k-text.json --ip_config ip_list.txt --ssh_port 2222 "python3 ep_infer_lm.py --cf ml_lm_ec_infer.yaml --num-gpus $NUM_INFO_TRAINERS --part-config /data/movielen_100k_ec_1p_4t_text/movie-lens-100k-text.json --num-classes 6 --feat-name feat --mini-batch-infer false --save-embed-path /data/gsgnn_ec_lm/infer-emb/ --restore-model-path /data/gsgnn_ec_lm/epoch-$best_epoch/" | tee log.txt
 
-error_and_exit $?
+error_and_exit ${PIPESTATUS[0]}
 
 cd $GS_HOME/tests/end2end-tests/
 python3 check_infer.py --train_embout /data/gsgnn_ec_lm/emb/ --infer_embout /data/gsgnn_ec_lm/infer-emb/
 
+error_and_exit $?
 rm -fr /data/gsgnn_ec_lm/*
 rm train_log.txt

--- a/tests/end2end-tests/graphstorm-ec/test.sh
+++ b/tests/end2end-tests/graphstorm-ec/test.sh
@@ -78,7 +78,7 @@ error_and_exit $?
 echo "**************dataset: Test edge classification, RGCN layer: 1, node feat: fixed HF BERT, BERT nodes: movie, inference: mini-batch early stop"
 python3 $DGL_HOME/tools/launch.py --workspace $GS_HOME/training_scripts/gsgnn_ep/ --num_trainers $NUM_TRAINERS --num_servers 1 --num_samplers 0 --part_config /data/movielen_100k_ec_1p_4t/movie-lens-100k.json --ip_config ip_list.txt --ssh_port 2222 "python3 gsgnn_ep.py --cf ml_ec.yaml --num-gpus 1 --part-config /data/movielen_100k_ec_1p_4t/movie-lens-100k.json --enable-early-stop True --call-to-consider-early-stop 2 -e 30 --window-for-early-stop 3 --evaluation-frequency 100 --lr 0.01" | tee exec.log
 
-error_and_exit $?
+error_and_exit ${PIPESTATUS[0]}
 
 # check early stop
 cnt=$(cat exec.log | grep "Evaluation step" | wc -l)

--- a/tests/end2end-tests/graphstorm-er/mgpu_test.sh
+++ b/tests/end2end-tests/graphstorm-er/mgpu_test.sh
@@ -26,7 +26,7 @@ error_and_exit () {
 echo "**************dataset: ML edge regression, RGCN layer: 1, node feat: fixed HF BERT, BERT nodes: movie, inference: mini-batch"
 python3 $DGL_HOME/tools/launch.py --workspace $GS_HOME/training_scripts/gsgnn_ep/ --num_trainers $NUM_TRAINERS --num_servers 1 --num_samplers 0 --part_config /data/movielen_100k_er_1p_4t/movie-lens-100k.json --ip_config ip_list.txt --ssh_port 2222 "python3 gsgnn_ep.py --cf ml_er.yaml --num-gpus $NUM_TRAINERS --part-config /data/movielen_100k_er_1p_4t/movie-lens-100k.json --save-embed-path /data/gsgnn_er/emb/ --save-model-path /data/gsgnn_er/ --topk-model-to-save 1 --save-model-per-iter 1000 --n-epochs 3" | tee train_log.txt
 
-error_and_exit $?
+error_and_exit ${PIPESTATUS[0]}
 
 # check prints
 cnt=$(grep "save_embed_path: /data/gsgnn_er/emb/" train_log.txt | wc -l)
@@ -91,7 +91,7 @@ echo "The best model is saved in epoch $best_epoch"
 echo "**************dataset: ML edge regression, do inference on saved model"
 python3 $DGL_HOME/tools/launch.py --workspace $GS_HOME/inference_scripts/ep_infer --num_trainers $NUM_INFO_TRAINERS --num_servers 1 --num_samplers 0 --part_config /data/movielen_100k_er_1p_4t/movie-lens-100k.json --ip_config ip_list.txt --ssh_port 2222 "python3 ep_infer_gnn.py --cf ml_er_infer.yaml --num-gpus $NUM_INFO_TRAINERS --part-config /data/movielen_100k_er_1p_4t/movie-lens-100k.json --mini-batch-infer false --save-embed-path /data/gsgnn_er/infer-emb/ --restore-model-path /data/gsgnn_er/epoch-$best_epoch/" | tee log.txt
 
-error_and_exit $?
+error_and_exit ${PIPESTATUS[0]}
 
 cnt=$(grep "| Test rmse" log.txt | wc -l)
 if test $cnt -ne 1

--- a/tests/end2end-tests/graphstorm-lp/mgpu_test.sh
+++ b/tests/end2end-tests/graphstorm-lp/mgpu_test.sh
@@ -27,7 +27,7 @@ error_and_exit () {
 echo "**************dataset: Movielens, RGCN layer 2, node feat: fixed HF BERT & sparse embed, BERT nodes: movie, inference: full-graph, negative_sampler: joint, exclude_training_targets: true, save model"
 python3 $DGL_HOME/tools/launch.py --workspace $GS_HOME/training_scripts/gsgnn_lp --num_trainers $NUM_TRAINERS --num_servers 1 --num_samplers 0 --part_config /data/movielen_100k_lp_train_val_1p_4t/movie-lens-100k.json --ip_config ip_list.txt --ssh_port 2222 "python3 gsgnn_lp.py --cf ml_lp.yaml --fanout '10,15' --n-layers 2 --mini-batch-infer false  --use-node-embeddings true --exclude-training-targets True --reverse-edge-types-map user,rating,rating-rev,movie --num-gpus $NUM_TRAINERS --part-config /data/movielen_100k_lp_train_val_1p_4t/movie-lens-100k.json --save-model-path /data/gsgnn_lp_ml_dot/ --topk-model-to-save 1 --save-model-per-iter 1000 --save-embed-path /data/gsgnn_lp_ml_dot/emb/" | tee train_log.txt
 
-error_and_exit $?
+error_and_exit ${PIPESTATUS[0]}
 
 # check prints
 cnt=$(grep "save_embed_path: /data/gsgnn_lp_ml_dot/emb/" train_log.txt | wc -l)
@@ -92,7 +92,7 @@ echo "The best model is saved in epoch $best_epoch_dot"
 echo "**************dataset: Movielens, RGCN layer 2, node feat: fixed HF BERT & sparse embed, BERT nodes: movie, inference: full-graph, negative_sampler: joint, decoder: DistMult, exclude_training_targets: true, save model"
 python3 $DGL_HOME/tools/launch.py --workspace $GS_HOME/training_scripts/gsgnn_lp --num_trainers $NUM_TRAINERS --num_servers 1 --num_samplers 0 --part_config /data/movielen_100k_lp_train_val_1p_4t/movie-lens-100k.json --ip_config ip_list.txt --ssh_port 2222 "python3 gsgnn_lp.py --cf ml_lp.yaml --fanout '10,15' --n-layers 2 --mini-batch-infer false  --use-node-embeddings true --num-gpus $NUM_TRAINERS --part-config /data/movielen_100k_lp_train_val_1p_4t/movie-lens-100k.json --save-model-path /data/gsgnn_lp_ml_distmult/ --topk-model-to-save 1 --save-model-per-iter 1000 --save-embed-path /data/gsgnn_lp_ml_distmult/emb/ --use-dot-product False --train-etype user,rating,movie movie,rating-rev,user" | tee train_log.txt
 
-error_and_exit $?
+error_and_exit ${PIPESTATUS[0]}
 
 cnt=$(ls -l /data/gsgnn_lp_ml_distmult/ | grep epoch | wc -l)
 if test $cnt != 1
@@ -107,7 +107,7 @@ echo "The best model is saved in epoch $best_epoch_distmult"
 echo "**************dataset: Movielens, do inference on saved model, decoder: dot"
 python3 $DGL_HOME/tools/launch.py --workspace $GS_HOME/inference_scripts/lp_infer --num_trainers $NUM_INFO_TRAINERS --num_servers 1 --num_samplers 0 --part_config /data/movielen_100k_lp_train_val_1p_4t/movie-lens-100k.json --ip_config ip_list.txt --ssh_port 2222 "python3 lp_infer_gnn.py --cf ml_lp_infer.yaml --fanout '10,15' --n-layers 2 --mini-batch-infer false  --use-node-embeddings true --num-gpus $NUM_INFO_TRAINERS --part-config /data/movielen_100k_lp_train_val_1p_4t/movie-lens-100k.json --save-embed-path /data/gsgnn_lp_ml_dot/infer-emb/ --restore-model-path /data/gsgnn_lp_ml_dot/epoch-$best_epoch_dot/" | tee log.txt
 
-error_and_exit $?
+error_and_exit ${PIPESTATUS[0]}
 
 cnt=$(grep "| Test mrr" log.txt | wc -l)
 if test $cnt -ne 1
@@ -147,7 +147,7 @@ fi
 echo "**************dataset: Movielens, do inference on saved model, decoder: DistMult"
 python3 $DGL_HOME/tools/launch.py --workspace $GS_HOME/inference_scripts/lp_infer --num_trainers $NUM_INFO_TRAINERS --num_servers 1 --num_samplers 0 --part_config /data/movielen_100k_lp_train_val_1p_4t/movie-lens-100k.json --ip_config ip_list.txt --ssh_port 2222 "python3 lp_infer_gnn.py --cf ml_lp_infer.yaml --fanout '10,15' --n-layers 2 --mini-batch-infer false  --use-node-embeddings true --num-gpus $NUM_INFO_TRAINERS --part-config /data/movielen_100k_lp_train_val_1p_4t/movie-lens-100k.json --save-embed-path /data/gsgnn_lp_ml_distmult/infer-emb/ --restore-model-path /data/gsgnn_lp_ml_distmult/epoch-$best_epoch_distmult/ --use-dot-product False --no-validation True --train-etype user,rating,movie movie,rating-rev,user" | tee log2.txt
 
-error_and_exit $?
+error_and_exit ${PIPESTATUS[0]}
 
 cd $GS_HOME/tests/end2end-tests/graphstorm-lp/
 python3 $GS_HOME/tests/end2end-tests/check_infer.py --train_embout /data/gsgnn_lp_ml_dot/emb/ --infer_embout /data/gsgnn_lp_ml_dot/infer-emb/ --link_prediction
@@ -182,7 +182,7 @@ fi
 echo "**************dataset: Movielens, RGCN layer 2, node feat: fixed HF BERT & sparse embed, BERT nodes: movie, inference: full-graph, negative_sampler: joint, exclude_training_targets: true, save model, early stop"
 python3 $DGL_HOME/tools/launch.py --workspace $GS_HOME/training_scripts/gsgnn_lp --num_trainers $NUM_TRAINERS --num_servers 1 --num_samplers 0 --part_config /data/movielen_100k_lp_train_val_1p_4t/movie-lens-100k.json --ip_config ip_list.txt --ssh_port 2222 "python3 gsgnn_lp.py --cf ml_lp.yaml --fanout '10,15' --n-layers 2 --mini-batch-infer false  --use-node-embeddings true --exclude-training-targets True --reverse-edge-types-map user,rating,rating-rev,movie --num-gpus $NUM_TRAINERS --part-config /data/movielen_100k_lp_train_val_1p_4t/movie-lens-100k.json --save-model-path /data/gsgnn_lp_ml_dot/ --topk-model-to-save 3 --save-model-per-iter 1000 --save-embed-path /data/gsgnn_lp_ml_dot/emb/ --enable-early-stop True --call-to-consider-early-stop 3 -e 30 --window-for-early-stop 2 --early-stop-strategy consecutive_increase" | tee exec.log
 
-error_and_exit $?
+error_and_exit ${PIPESTATUS[0]}
 
 # check early stop
 cnt=$(cat exec.log | grep "Evaluation step" | wc -l)
@@ -203,7 +203,7 @@ rm -fr /data/gsgnn_lp_ml_dot/*
 echo "**************dataset: Movielens, RGCN layer 1, BERT nodes: movie, user , inference: full-graph, negative_sampler: joint, decoder: DistMult, exclude_training_targets: true, save model"
 python3 $DGL_HOME/tools/launch.py --workspace $GS_HOME/training_scripts/gsgnn_lp --num_trainers $NUM_TRAINERS --num_servers 1 --num_samplers 0 --part_config /data/movielen_100k_text_lp_train_val_1p_4t/movie-lens-100k-text.json --ip_config ip_list.txt --ssh_port 2222 "python3 gsgnn_lp.py --cf ml_lp_text.yaml --fanout '10' --n-layers 1 --mini-batch-infer false  --use-node-embeddings true --num-gpus $NUM_TRAINERS --part-config /data/movielen_100k_text_lp_train_val_1p_4t/movie-lens-100k-text.json --save-model-path /data/gsgnn_lp_ml_distmult_text/ --topk-model-to-save 1 --save-model-per-iter 1000 --save-embed-path /data/gsgnn_lp_ml_distmult_text/emb/ --use-dot-product False --train-etype user,rating,movie movie,rating-rev,user" | tee train_log.txt
 
-error_and_exit $?
+error_and_exit ${PIPESTATUS[0]}
 
 best_epoch_distmult=$(grep "successfully save the model to" train_log.txt | tail -1 | tr -d '\n' | tail -c 1)
 echo "The best model is saved in epoch $best_epoch_distmult"
@@ -211,7 +211,7 @@ echo "The best model is saved in epoch $best_epoch_distmult"
 echo "**************dataset: Movielens text, do inference on saved model, decoder: DistMult"
 python3 $DGL_HOME/tools/launch.py --workspace $GS_HOME/inference_scripts/lp_infer --num_trainers $NUM_INFO_TRAINERS --num_servers 1 --num_samplers 0 --part_config /data/movielen_100k_text_lp_train_val_1p_4t/movie-lens-100k-text.json --ip_config ip_list.txt --ssh_port 2222 "python3 lp_infer_gnn.py --cf ml_lp_text_infer.yaml --fanout '10' --n-layers 1 --mini-batch-infer false --use-node-embeddings true --num-gpus $NUM_INFO_TRAINERS --part-config /data/movielen_100k_text_lp_train_val_1p_4t/movie-lens-100k-text.json --save-embed-path /data/gsgnn_lp_ml_distmult_text/infer-emb/ --restore-model-path /data/gsgnn_lp_ml_distmult_text/epoch-$best_epoch_distmult/ --use-dot-product False --no-validation True --train-etype user,rating,movie movie,rating-rev,user" | tee log2.txt
 
-error_and_exit $?
+error_and_exit ${PIPESTATUS[0]}
 
 python3 $GS_HOME/tests/end2end-tests/check_infer.py --train_embout /data/gsgnn_lp_ml_distmult_text/emb/ --infer_embout /data/gsgnn_lp_ml_distmult_text/infer-emb/ --link_prediction
 
@@ -252,7 +252,7 @@ error_and_exit $?
 echo "**************dataset: Movielens, RGCN layer 2, node feat: fixed HF BERT & sparse embed, BERT nodes: movie, inference: full-graph, negative_sampler: joint, decoder: DistMult, exclude_training_targets: true, save model, train_etype: None"
 python3 $DGL_HOME/tools/launch.py --workspace $GS_HOME/training_scripts/gsgnn_lp --num_trainers $NUM_TRAINERS --num_servers 1 --num_samplers 0 --part_config /data/movielen_100k_lp_train_val_1p_4t/movie-lens-100k.json --ip_config ip_list.txt --ssh_port 2222 "python3 gsgnn_lp.py --cf ml_lp_none_train_etype.yaml --fanout '10,15' --n-layers 2 --mini-batch-infer false  --use-node-embeddings true --num-gpus $NUM_TRAINERS --part-config /data/movielen_100k_lp_train_val_1p_4t/movie-lens-100k.json --save-model-path /data/gsgnn_lp_ml_distmult_all_etype/ --topk-model-to-save 1 --save-model-per-iter 1000 --save-embed-path /data/gsgnn_lp_ml_distmult_all_etype/emb/ --use-dot-product False" | tee train_log.txt
 
-error_and_exit $?
+error_and_exit ${PIPESTATUS[0]}
 
 cnt=$(ls -l /data/gsgnn_lp_ml_distmult_all_etype/ | grep epoch | wc -l)
 if test $cnt != 1
@@ -267,7 +267,7 @@ echo "The best model is saved in epoch $best_epoch_distmult"
 echo "**************dataset: Movielens, do inference on saved model, decoder: DistMult, eval_etype: None"
 python3 $DGL_HOME/tools/launch.py --workspace $GS_HOME/inference_scripts/lp_infer --num_trainers $NUM_INFO_TRAINERS --num_servers 1 --num_samplers 0 --part_config /data/movielen_100k_lp_train_val_1p_4t/movie-lens-100k.json --ip_config ip_list.txt --ssh_port 2222 "python3 lp_infer_gnn.py --cf ml_lp_none_train_etype_infer.yaml --fanout '10,15' --n-layers 2 --mini-batch-infer false  --use-node-embeddings true --num-gpus $NUM_INFO_TRAINERS --part-config /data/movielen_100k_lp_train_val_1p_4t/movie-lens-100k.json --save-embed-path /data/gsgnn_lp_ml_distmult_all_etype/infer-emb/ --restore-model-path /data/gsgnn_lp_ml_distmult_all_etype/epoch-$best_epoch_distmult/ --use-dot-product False --no-validation True" | tee log2.txt
 
-error_and_exit $?
+error_and_exit ${PIPESTATUS[0]}
 
 python3 $GS_HOME/tests/end2end-tests/check_infer.py --train_embout /data/gsgnn_lp_ml_distmult_all_etype/emb/ --infer_embout /data/gsgnn_lp_ml_distmult_all_etype/infer-emb/ --link_prediction
 
@@ -279,7 +279,7 @@ rm train_log.txt
 echo "**************dataset: Movielens, Bert only, inference: full-graph, negative_sampler: joint, decoder: Dot, save model"
 python3 $DGL_HOME/tools/launch.py --workspace $GS_HOME/training_scripts/gsgnn_lp --num_trainers $NUM_TRAINERS --num_servers 1 --num_samplers 0 --part_config /data/movielen_100k_text_lp_train_val_1p_4t/movie-lens-100k-text.json --ip_config ip_list.txt --ssh_port 2222 "python3 gsgnn_lm_lp.py --cf ml_lm_lp.yaml --num-gpus $NUM_TRAINERS --part-config /data/movielen_100k_text_lp_train_val_1p_4t/movie-lens-100k-text.json --save-model-path /data/gsgnn_lp_ml_lm_dot_all_etype/ --topk-model-to-save 1 --save-model-per-iter 1000 --save-embed-path /data/gsgnn_lp_ml_lm_dot_all_etype/emb/ --use-dot-product True" | tee train_log.txt
 
-error_and_exit $?
+error_and_exit ${PIPESTATUS[0]}
 
 cnt=$(ls -l /data/gsgnn_lp_ml_lm_dot_all_etype/ | grep epoch | wc -l)
 if test $cnt != 1
@@ -306,7 +306,7 @@ rm train_log.txt
 echo "**************dataset: Movielens, input encoder with Bert, inference: full-graph, negative_sampler: joint, decoder: Dot, save model"
 python3 $DGL_HOME/tools/launch.py --workspace $GS_HOME/training_scripts/gsgnn_lp --num_trainers $NUM_TRAINERS --num_servers 1 --num_samplers 0 --part_config /data/movielen_100k_text_lp_train_val_1p_4t/movie-lens-100k-text.json --ip_config ip_list.txt --ssh_port 2222 "python3 gsgnn_lm_lp.py --cf ml_lm_lp.yaml --num-gpus $NUM_TRAINERS --part-config /data/movielen_100k_text_lp_train_val_1p_4t/movie-lens-100k-text.json --save-model-path /data/gsgnn_lp_ml_lmmlp_dot_all_etype/ --topk-model-to-save 1 --save-model-per-iter 1000 --save-embed-path /data/gsgnn_lp_ml_lmmlp_dot_all_etype/emb/ --use-dot-product True --model-encoder-type mlp" | tee train_log.txt
 
-error_and_exit $?
+error_and_exit ${PIPESTATUS[0]}
 
 cnt=$(ls -l /data/gsgnn_lp_ml_lmmlp_dot_all_etype/ | grep epoch | wc -l)
 if test $cnt != 1

--- a/tests/end2end-tests/graphstorm-nc/mgpu_test.sh
+++ b/tests/end2end-tests/graphstorm-nc/mgpu_test.sh
@@ -27,7 +27,7 @@ error_and_exit () {
 echo "**************dataset: MovieLens classification, RGCN layer: 1, node feat: fixed HF BERT, BERT nodes: movie, inference: mini-batch save model save emb node"
 python3 $DGL_HOME/tools/launch.py --workspace $GS_HOME/training_scripts/gsgnn_np/ --num_trainers $NUM_TRAINERS --num_servers 1 --num_samplers 0 --part_config /data/movielen_100k_train_val_1p_4t/movie-lens-100k.json --ip_config ip_list.txt --ssh_port 2222 "python3 gsgnn_np.py --cf ml_nc.yaml --num-gpus $NUM_TRAINERS --part-config /data/movielen_100k_train_val_1p_4t/movie-lens-100k.json --save-model-path /data/gsgnn_nc_ml/ --topk-model-to-save 1 --save-embed-path /data/gsgnn_nc_ml/emb/ --n-epochs 3" | tee train_log.txt
 
-error_and_exit $?
+error_and_exit ${PIPESTATUS[0]}
 
 # check prints
 cnt=$(grep "save_embed_path: /data/gsgnn_nc_ml/emb/" train_log.txt | wc -l)
@@ -92,7 +92,7 @@ echo "The best model is saved in epoch $best_epoch"
 echo "**************dataset: Movielens, do inference on saved model"
 python3 $DGL_HOME/tools/launch.py --workspace $GS_HOME/inference_scripts/np_infer/ --num_trainers $NUM_INFERs --num_servers 1 --num_samplers 0 --part_config /data/movielen_100k_train_val_1p_4t/movie-lens-100k.json --ip_config ip_list.txt --ssh_port 2222 "python3 np_infer_gnn.py --cf ml_nc_infer.yaml --mini-batch-infer false --num-gpus $NUM_INFERs --part-config /data/movielen_100k_train_val_1p_4t/movie-lens-100k.json --save-embed-path /data/gsgnn_nc_ml/infer-emb/ --restore-model-path /data/gsgnn_nc_ml/epoch-$best_epoch/ --save-predict-path /data/gsgnn_nc_ml/prediction/" | tee log.txt
 
-error_and_exit $?
+error_and_exit ${PIPESTATUS[0]}
 
 cnt=$(grep "| Test accuracy" log.txt | wc -l)
 if test $cnt -ne 1
@@ -136,6 +136,8 @@ error_and_exit $?
 echo "**************dataset: Movielens, do inference on saved model, decoder: dot with a single process"
 python3 $DGL_HOME/tools/launch.py --workspace $GS_HOME/inference_scripts/np_infer/ --num_trainers 1 --num_servers 1 --num_samplers 0 --part_config /data/movielen_100k_train_val_1p_4t/movie-lens-100k.json --ip_config ip_list.txt --ssh_port 2222 "python3 np_infer_gnn.py --cf ml_nc_infer.yaml --mini-batch-infer false --num-gpus 1 --part-config /data/movielen_100k_train_val_1p_4t/movie-lens-100k.json --save-embed-path /data/gsgnn_nc_ml/infer-emb-1p/ --restore-model-path /data/gsgnn_nc_ml/epoch-$best_epoch/ --save-predict-path /data/gsgnn_nc_ml/prediction-1p/" | tee log.txt
 
+error_and_exit ${PIPESTATUS[0]}
+
 python3 $GS_HOME/tests/end2end-tests/check_infer.py --train_embout /data/gsgnn_nc_ml/emb/ --infer_embout /data/gsgnn_nc_ml/infer-emb-1p/
 
 error_and_exit $?
@@ -143,7 +145,7 @@ error_and_exit $?
 echo "**************dataset: MovieLens classification, RGCN layer: 1, node feat: fixed HF BERT, BERT nodes: movie, inference: mini-batch save model save emb node, early stop"
 python3 $DGL_HOME/tools/launch.py --workspace $GS_HOME/training_scripts/gsgnn_np/ --num_trainers $NUM_TRAINERS --num_servers 1 --num_samplers 0 --part_config /data/movielen_100k_train_val_1p_4t/movie-lens-100k.json --ip_config ip_list.txt --ssh_port 2222 "python3 gsgnn_np.py --cf ml_nc.yaml --num-gpus $NUM_TRAINERS --part-config /data/movielen_100k_train_val_1p_4t/movie-lens-100k.json --save-model-path /data/gsgnn_nc_ml/ --topk-model-to-save 3 --save-embed-path /data/gsgnn_nc_ml/emb/ --enable-early-stop True --call-to-consider-early-stop 2 -e 20 --window-for-early-stop 3 --early-stop-strategy consecutive_increase" | tee exec.log
 
-error_and_exit $?
+error_and_exit ${PIPESTATUS[0]}
 
 # check early stop
 cnt=$(cat exec.log | grep "Evaluation step" | wc -l)
@@ -171,7 +173,7 @@ rm -fr /data/gsgnn_nc_ml/*
 echo "**************dataset: MovieLens classification, RGCN layer: 1, node feat: BERT nodes: movie, user inference: mini-batch save model save emb node"
 python3 $DGL_HOME/tools/launch.py --workspace $GS_HOME/training_scripts/gsgnn_np/ --num_trainers $NUM_TRAINERS --num_servers 1 --num_samplers 0 --part_config /data/movielen_100k_text_train_val_1p_4t/movie-lens-100k-text.json --ip_config ip_list.txt --ssh_port 2222 "python3 gsgnn_np.py --cf ml_nc_utext.yaml --num-gpus $NUM_TRAINERS --part-config /data/movielen_100k_text_train_val_1p_4t/movie-lens-100k-text.json --save-model-path /data/gsgnn_nc_ml_text/ --topk-model-to-save 1 --save-embed-path /data/gsgnn_nc_ml_text/emb/ --n-epochs 3" | tee train_log.txt
 
-error_and_exit $?
+error_and_exit ${PIPESTATUS[0]}
 
 cnt=$(ls -l /data/gsgnn_nc_ml_text/ | grep epoch | wc -l)
 if test $cnt != 1
@@ -186,7 +188,7 @@ echo "The best model is saved in epoch $best_epoch"
 echo "**************dataset: Movielens, do inference on saved model, decoder: dot"
 python3 $DGL_HOME/tools/launch.py --workspace $GS_HOME/inference_scripts/np_infer/ --num_trainers $NUM_INFERs --num_servers 1 --num_samplers 0 --part_config /data/movielen_100k_text_train_val_1p_4t/movie-lens-100k-text.json --ip_config ip_list.txt --ssh_port 2222 "python3 np_infer_gnn.py --cf ml_nc_text_infer.yaml --mini-batch-infer false --num-gpus $NUM_INFERs --part-config /data/movielen_100k_text_train_val_1p_4t/movie-lens-100k-text.json --save-embed-path /data/gsgnn_nc_ml_text/infer-emb/ --restore-model-path /data/gsgnn_nc_ml_text/epoch-$best_epoch/ --save-predict-path /data/gsgnn_nc_ml_text/prediction/" | tee log.txt
 
-error_and_exit $?
+error_and_exit ${PIPESTATUS[0]}
 
 cnt=$(grep "| Test accuracy" log.txt | wc -l)
 if test $cnt -ne 1
@@ -201,5 +203,7 @@ error_and_exit $?
 
 echo "**************dataset: MovieLens classification, RGCN layer: 1, node feat: BERT nodes: movie, user inference: mini-batch save model save emb node, train_nodes 0"
 python3 $DGL_HOME/tools/launch.py --workspace $GS_HOME/training_scripts/gsgnn_np/ --num_trainers $NUM_TRAINERS --num_servers 1 --num_samplers 0 --part_config /data/movielen_100k_text_train_val_1p_4t/movie-lens-100k-text.json --ip_config ip_list.txt --ssh_port 2222 "python3 gsgnn_np.py --cf ml_nc_utext.yaml --num-gpus $NUM_TRAINERS --part-config /data/movielen_100k_text_train_val_1p_4t/movie-lens-100k-text.json --save-model-path /data/gsgnn_nc_ml_text/ --topk-model-to-save 1 --save-embed-path /data/gsgnn_nc_ml_text/emb/ --n-epochs 3 --lm-train-nodes 0" | tee train_log.txt
+
+error_and_exit ${PIPESTATUS[0]}
 
 rm -fr /data/gsgnn_nc_ml_text/*


### PR DESCRIPTION
If the output of training launch script is redirected to a file through `tee` command, the error code got from `$?` is from tee instead of the training script. We need to get the error code through `${PIPESTATUS[0]}`.

*Description of changes:*
Change integration test code to use `${PIPESTATUS[0]}` instead of `$?`


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
