### PR TITLE
Asynchronous data loading in mini-batch prediction 

### DIFF
--- a/python/graphstorm/dataloading/dataloading.py
+++ b/python/graphstorm/dataloading/dataloading.py
@@ -499,7 +499,7 @@ class GSgnnLinkPredictionTestDataLoader():
         negative_sampler = GlobalUniform(num_negative_edges)
         return negative_sampler
 
-    def __iter__(self):
+    def __aiter__(self):
         self._reinit_dataset()
         return self
 
@@ -516,11 +516,12 @@ class GSgnnLinkPredictionTestDataLoader():
         self._current_pos[etype] += self._batch_size
         return pos_neg_tuple, end_of_etype
 
-    def __next__(self):
+    async def __anext__(self):
         if len(self.remaining_etypes) == 0:
-            raise StopIteration
+            raise StopAsyncIteration
 
         curr_etype = self.remaining_etypes[0]
+        # cur_iter, end_of_etype = await self._next_data(curr_etype)
         cur_iter, end_of_etype = self._next_data(curr_etype)
         if end_of_etype:
             self.remaining_etypes.pop(0)

--- a/python/graphstorm/dataloading/dataloading.py
+++ b/python/graphstorm/dataloading/dataloading.py
@@ -503,7 +503,7 @@ class GSgnnLinkPredictionTestDataLoader():
         self._reinit_dataset()
         return self
 
-    def _next_data(self, etype):
+    async def _next_data(self, etype):
         """ Get postive edges for the next iteration for a specific edge type
         """
         g = self._data.g
@@ -522,7 +522,7 @@ class GSgnnLinkPredictionTestDataLoader():
 
         curr_etype = self.remaining_etypes[0]
         # cur_iter, end_of_etype = await self._next_data(curr_etype)
-        cur_iter, end_of_etype = self._next_data(curr_etype)
+        cur_iter, end_of_etype = await self._next_data(curr_etype)
         if end_of_etype:
             self.remaining_etypes.pop(0)
 

--- a/python/graphstorm/inference/lp_infer.py
+++ b/python/graphstorm/inference/lp_infer.py
@@ -17,6 +17,7 @@
 """
 import time
 import torch as th
+import asyncio
 
 from .graphstorm_infer import GSInfer
 from ..model.utils import save_embeddings as save_gsgnn_embeddings
@@ -78,7 +79,7 @@ class GSgnnLinkPredictionInfer(GSInfer):
             test_start = time.time()
             device = th.device(f"cuda:{self.dev_id}") \
                 if self.dev_id >= 0 else th.device("cpu")
-            test_scores = lp_mini_batch_predict(self._model, embs, loader, device)
+            test_scores = asyncio.run(lp_mini_batch_predict(self._model, embs, loader, device))
             val_mrr, test_mrr = self.evaluator.evaluate(None, test_scores, 0)
             sys_tracker.check('run evaluation')
             if self.rank == 0:

--- a/python/graphstorm/inference/lp_infer.py
+++ b/python/graphstorm/inference/lp_infer.py
@@ -16,8 +16,8 @@
     Infer wrapper for link predicion.
 """
 import time
-import torch as th
 import asyncio
+import torch as th
 
 from .graphstorm_infer import GSInfer
 from ..model.utils import save_embeddings as save_gsgnn_embeddings

--- a/python/graphstorm/model/lp_gnn.py
+++ b/python/graphstorm/model/lp_gnn.py
@@ -106,7 +106,7 @@ class GSgnnLinkPredictionModel(GSgnnModel, GSgnnLinkPredictionModelInterface):
         # weighted addition to the total loss
         return pred_loss + alpha_l2norm * reg_loss
 
-def lp_mini_batch_predict(model, emb, loader, device):
+async def lp_mini_batch_predict(model, emb, loader, device):
     """ Perform mini-batch prediction.
 
         This function follows full-grain GNN embedding inference.
@@ -133,7 +133,7 @@ def lp_mini_batch_predict(model, emb, loader, device):
     decoder = model.decoder
     with th.no_grad():
         scores = {}
-        for pos_neg_tuple, neg_sample_type in loader:
+        async for pos_neg_tuple, neg_sample_type in loader:
             score = \
                 decoder.calc_test_scores(
                     emb, pos_neg_tuple, neg_sample_type, device)


### PR DESCRIPTION
Load  the node embeddings of different batches asynchronously in the inference pipeline for link prediction.

Update: This optimization is not very impactful anymore as in [this](https://github.com/awslabs/graphstorm/pull/101) PR we are fusing multiple batches to load embeddings from remote machines in one pull.

