### PR TITLE
BugFix: evaluation_frequency needs to work with save_model_per_iters set to -1

### DIFF
--- a/python/graphstorm/config/argument.py
+++ b/python/graphstorm/config/argument.py
@@ -595,7 +595,9 @@ class GSConfig:
             assert self.save_model_path is not None, \
                 'To save models, please specify a valid path. But got None'
 
-            if self.evaluation_frequency != sys.maxsize:
+            if self.evaluation_frequency != sys.maxsize and self.save_model_per_iters > 0:
+                # save model within an epoch need to collaborate with evaluation
+                # within an epoch
                 assert self.save_model_per_iters >= self.evaluation_frequency and \
                     self.save_model_per_iters % self.evaluation_frequency == 0, \
                     'FATAL: save_model_per_iters' \

--- a/tests/unit-tests/test_config.py
+++ b/tests/unit-tests/test_config.py
@@ -432,6 +432,15 @@ def create_train_config(tmp_path, file_name):
     with open(os.path.join(tmp_path, file_name+"2.yaml"), "w") as f:
         yaml.dump(yaml_object, f)
 
+    # evaluation_frequency = 1000 and save_model_per_iters uses default (-1)
+    yaml_object["gsf"]["hyperparam"] = {
+        "evaluation_frequency": 1000,
+        "topk_model_to_save": 5,
+        "save_model_path": os.path.join(tmp_path, "save"),
+    }
+    with open(os.path.join(tmp_path, file_name+"3.yaml"), "w") as f:
+        yaml.dump(yaml_object, f)
+
     # for failures
     yaml_object["gsf"]["hyperparam"] = {
         "dropout" : -1.0,
@@ -513,6 +522,14 @@ def test_train_info():
 
         args = Namespace(yaml_config_file=os.path.join(Path(tmpdirname), 'train_test2.yaml'), local_rank=0)
         config = GSConfig(args)
+        assert config.evaluation_frequency == 1000
+        assert config.save_model_per_iters == 2000
+        assert config.topk_model_to_save == 5
+
+        args = Namespace(yaml_config_file=os.path.join(Path(tmpdirname), 'train_test3.yaml'), local_rank=0)
+        config = GSConfig(args)
+        assert config.evaluation_frequency == 1000
+        assert config.save_model_per_iters == -1
         assert config.topk_model_to_save == 5
 
         args = Namespace(yaml_config_file=os.path.join(Path(tmpdirname), 'train_test_fail.yaml'), local_rank=0)


### PR DESCRIPTION
By default save_model_per_iters is set to -1 which means GFS will not save models within an epoch. In this case, evaluation_frequency should be able to use any positive integer.

#20 

*Description of changes:*
Fix the bug


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
