### PR TITLE
Add / in the concatenated path in build_docker_oss4local.sh

### DIFF
--- a/docker/build_docker_oss4local.sh
+++ b/docker/build_docker_oss4local.sh
@@ -24,18 +24,18 @@ else
 fi
 
 # Copy scripts and tools codes to the docker folder 
-mkdir -p $GSF_HOME"docker/code"
-cp -r $GSF_HOME"python" $GSF_HOME"docker/code/python"
-cp -r $GSF_HOME"examples" $GSF_HOME"docker/code/examples"
-cp -r $GSF_HOME"inference_scripts" $GSF_HOME"docker/code/inference_scripts"
-cp -r $GSF_HOME"tools" $GSF_HOME"docker/code/tools"
-cp -r $GSF_HOME"training_scripts" $GSF_HOME"docker/code/training_scripts"
+mkdir -p $GSF_HOME"/docker/code"
+cp -r $GSF_HOME"/python" $GSF_HOME"/docker/code/python"
+cp -r $GSF_HOME"/examples" $GSF_HOME"/docker/code/examples"
+cp -r $GSF_HOME"/inference_scripts" $GSF_HOME"/docker/code/inference_scripts"
+cp -r $GSF_HOME"/tools" $GSF_HOME"/docker/code/tools"
+cp -r $GSF_HOME"/training_scripts" $GSF_HOME"/docker/code/training_scripts"
 
 # Build OSS docker for EC2 instances that an pull ECR docker images
 DOCKER_FULLNAME="${IMAGE_NAME}:${TAG}"
 
 echo "Build a local docker image ${DOCKER_FULLNAME}"
-docker build --no-cache -f $GSF_HOME"docker/Dockerfile.local" . -t $DOCKER_FULLNAME
+docker build --no-cache -f $GSF_HOME"/docker/Dockerfile.local" . -t $DOCKER_FULLNAME
 
 # remove the temporary code folder
-rm -rf $GSF_HOME"docker/code"
+rm -rf $GSF_HOME"/docker/code"


### PR DESCRIPTION
Add / between the concatenated path in case $GSF_HOME is not end with /

*Issue #, if available:*

*Description of changes:*
Add / between the concatenated path in build_docker_oss4local.sh in case $GSF_HOME is not end with /

Since in bash, multiple /// in path is same as single /

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
