### PR TITLE
[Fix] fix the v0.1 setup.py dependencies

### DIFF
--- a/python/graphstorm/__init__.py
+++ b/python/graphstorm/__init__.py
@@ -15,7 +15,7 @@
 
     Graphstorm package.
 """
-__version__ = "0.1.0.1"
+__version__ = "0.1.0.post1"
 
 from .utils import get_rank
 from .gsf import initialize, get_feat_size

--- a/python/graphstorm/__init__.py
+++ b/python/graphstorm/__init__.py
@@ -15,7 +15,7 @@
 
     Graphstorm package.
 """
-__version__ = "0.1"
+__version__ = "0.1.0.1"
 
 from .utils import get_rank
 from .gsf import initialize, get_feat_size

--- a/setup.py
+++ b/setup.py
@@ -29,12 +29,12 @@ requirements = [
     'boto3==1.26.126',
     'botocore==1.29.126',
     'h5py==3.8.0',
-    'scipy==1.10.1',
+    'scipy',
     'tqdm==4.65.0',
     'pyarrow==12.0.0',
     'transformers==4.28.1',
-    'pandas==2.0.1',
-    'scikit-learn==1.2.2',
+    'pandas',
+    'scikit-learn',
     'ogb==1.3.6',
     'psutil==5.9.5'
 ]


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- After push v0.1, the pip package fail to be installed. So have to loss some dependencies' version.
- Because v0.1 was pushed to PYPI, so cannot use v0.1 any more

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
