### PR TITLE
Remove GSF dependency from SageMaker launch scripts.

### DIFF
--- a/sagemaker/launch/launch_infer.py
+++ b/sagemaker/launch/launch_infer.py
@@ -16,16 +16,20 @@
     Launch SageMaker training task
 """
 import os
-import sagemaker
 import argparse
+
 import boto3 # pylint: disable=import-error
-
-from graphstorm.config import SUPPORTED_TASKS
-
-from sagemaker.pytorch.estimator import PyTorch
 import sagemaker
+from sagemaker.pytorch.estimator import PyTorch
 
 INSTANCE_TYPE = "ml.g4dn.12xlarge"
+SUPPORTED_TASKS = {
+    "node_classification",
+    "node_regression",
+    "edge_classification",
+    "edge_regression",
+    "link_prediction"
+}
 
 def run_job(input_args, image, unknowargs):
     """ Run job using SageMaker estimator.PyTorch

--- a/sagemaker/launch/launch_train.py
+++ b/sagemaker/launch/launch_train.py
@@ -17,14 +17,19 @@
 """
 import os
 import argparse
+
 import boto3 # pylint: disable=import-error
-
-from graphstorm.config import SUPPORTED_TASKS
-
 from sagemaker.pytorch.estimator import PyTorch
 import sagemaker
 
 INSTANCE_TYPE = "ml.g4dn.12xlarge"
+SUPPORTED_TASKS = {
+    "node_classification",
+    "node_regression",
+    "edge_classification",
+    "edge_regression",
+    "link_prediction"
+}
 
 def run_job(input_args, image, unknowargs):
     """ Run job using SageMaker estimator.PyTorch


### PR DESCRIPTION
*Description of changes:*

We remove the import of the graphstorm module, allowing the scripts to be ran from a Python environment that doesn't have GraphStorm installed.
Small re-arrangement of the imports to match PEP8 guidelines.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
