### PR TITLE
[Bug Fix] Fix EntityRegression with --return-proba

### DIFF
--- a/python/graphstorm/config/argument.py
+++ b/python/graphstorm/config/argument.py
@@ -977,6 +977,12 @@ class GSConfig:
         if hasattr(self, "_return_proba"):
             assert self._return_proba in [True, False], \
                 "Return all the predictions when True else return the maximum prediction."
+
+            if self._return_proba is True and \
+                self.task_type in [BUILTIN_TASK_NODE_REGRESSION, BUILTIN_TASK_EDGE_REGRESSION]:
+                print("WARNING: node regression and edge regression tasks "
+                      "automatically ignore --return-proba flag. Regression "
+                      "prediction results will be returned.")
             return self._return_proba
         # By default, return all the predictions
         return True

--- a/python/graphstorm/model/node_decoder.py
+++ b/python/graphstorm/model/node_decoder.py
@@ -144,6 +144,21 @@ class EntityRegression(GSLayer):
         """
         return th.matmul(inputs, self.decoder)
 
+    def predict_proba(self, inputs):
+        """ Make prediction on input data.
+            For regression task, it is same as predict
+
+        Parameters
+        ----------
+        inputs : tensor
+            The input features
+
+        Returns
+        -------
+        Tensor : all normalized predicted results
+        """
+        return self.predict(inputs)
+
     @property
     def in_dims(self):
         """ The number of input dimensions.


### PR DESCRIPTION
*Issue #, if available:*
Node regression tasks with --return-proba flag will crash.

*Description of changes:*
Add predict_proba in EntityRegression


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
