### PR TITLE
change the way of saving ID map.

### DIFF
--- a/python/graphstorm/gconstruct/construct_graph.py
+++ b/python/graphstorm/gconstruct/construct_graph.py
@@ -31,8 +31,7 @@ import dgl
 
 from ..utils import sys_tracker
 from .file_io import parse_node_file_format, parse_edge_file_format
-from .file_io import get_in_files, write_data_parquet
-from .file_io import HDF5Array
+from .file_io import get_in_files, HDF5Array
 from .transform import parse_feat_ops, process_features, preprocess_features
 from .transform import parse_label_ops, process_labels
 from .transform import do_multiprocess_transform, TwoPhaseFeatTransform

--- a/python/graphstorm/gconstruct/construct_graph.py
+++ b/python/graphstorm/gconstruct/construct_graph.py
@@ -532,12 +532,8 @@ def process_graph(args):
     else:
         raise ValueError('Unknown output format: {}'.format(args.output_format))
     for ntype in node_id_map:
-        kv_pairs = node_id_map[ntype].get_key_vals()
-        if kv_pairs is not None:
-            map_data = {}
-            map_data["orig"], map_data["new"] = kv_pairs
-            map_file = os.path.join(args.output_dir, ntype + "_id_remap.parquet")
-            write_data_parquet(map_data, map_file)
+        map_file = os.path.join(args.output_dir, ntype + "_id_remap.parquet")
+        if node_id_map[ntype].save(map_file):
             logging.info("Graph construction generates new node IDs for '%s'. " + \
                     "The ID map is saved in %s.", ntype, map_file)
 

--- a/python/graphstorm/gconstruct/id_map.py
+++ b/python/graphstorm/gconstruct/id_map.py
@@ -59,8 +59,12 @@ class NoopMap:
 
     def save(self, file_path):
         """ Save the ID map.
+
+        Parameters
+        ----------
+        file_path : str
+            The file where the ID map is saved to.
         """
-        return False
 
 class IdMap:
     """ Map an ID to a new ID.

--- a/python/graphstorm/gconstruct/id_map.py
+++ b/python/graphstorm/gconstruct/id_map.py
@@ -18,6 +18,9 @@
 """
 import logging
 
+import pandas as pd
+import pyarrow as pa
+import pyarrow.parquet as pq
 import numpy as np
 
 from .file_io import HDF5Array
@@ -54,10 +57,10 @@ class NoopMap:
         """
         return ids, np.arange(len(ids))
 
-    def get_key_vals(self):
-        """ Get the key value pairs.
+    def save(self, file_path):
+        """ Save the ID map.
         """
-        return None
+        return False
 
 class IdMap:
     """ Map an ID to a new ID.
@@ -118,14 +121,25 @@ class IdMap:
                 idx.append(i)
         return np.array(new_ids), np.array(idx)
 
-    def get_key_vals(self):
-        """ Get the key value pairs.
+    def save(self, file_path):
+        """ Save the ID map to a parquet file.
+
+        Parameters
+        ----------
+        file_path : str
+            The file where the ID map will be saved to.
+        file_format : str
+            The file format that the ID map will be saved with.
 
         Returns
         -------
-        tuple of tensors : The first one has keys and the second has corresponding values.
+        bool : whether the ID map is saved to a file.
         """
-        return np.array(list(self._ids.keys())), np.array(list(self._ids.values()))
+        keys = list(self._ids.keys())
+        vals = list(self._ids.values())
+        table = pa.Table.from_pandas(pd.DataFrame({'orig': keys, 'new': vals}))
+        pq.write_table(table, file_path)
+        return True
 
 def map_node_ids(src_ids, dst_ids, edge_type, node_id_map, skip_nonexist_edges):
     """ Map node IDs of source and destination nodes of edges.

--- a/tests/unit-tests/test_construct_graph.py
+++ b/tests/unit-tests/test_construct_graph.py
@@ -16,6 +16,7 @@
 import random
 import os
 import tempfile
+import pyarrow.parquet as pq
 import numpy as np
 import graphstorm as gs
 import dgl


### PR DESCRIPTION
*Description of changes:*
We cannot convert the ID map to numpy arrays first. Numpy arrays consume a large amount of memory to store a large string array.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
