### PR TITLE
Fix a bug of parse_node_feature

### DIFF
--- a/python/graphstorm/gconstruct/construct_graph.py
+++ b/python/graphstorm/gconstruct/construct_graph.py
@@ -211,9 +211,10 @@ def process_node_data(process_confs, arr_merger, remap_id, num_processes=1):
         num_proc = num_processes if multiprocessing else 0
 
         two_phase_feat_ops = []
-        for op in feat_ops:
-            if isinstance(op, TwoPhaseFeatTransform):
-                two_phase_feat_ops.append(op)
+        if feat_ops is not None:
+            for op in feat_ops:
+                if isinstance(op, TwoPhaseFeatTransform):
+                    two_phase_feat_ops.append(op)
         if len(two_phase_feat_ops) > 0:
             user_pre_parser = partial(prepare_node_data, feat_ops=two_phase_feat_ops,
                                       read_file=read_file)

--- a/tests/end2end-tests/data_process/data_gen.py
+++ b/tests/end2end-tests/data_process/data_gen.py
@@ -65,6 +65,12 @@ node_data3 = {
     'data1': node_id3,
 }
 
+node_id4 = np.unique(np.random.randint(0, 1000000000, 5000))
+node_id4_str = np.array([str(nid) for nid in node_id3])
+node_data4 = {
+    'id': node_id4_str,
+}
+
 src1 = node_data1['id'][np.random.randint(0, 9999, 100000)]
 dst1 = node_data2['id'][np.random.randint(0, 19999, 100000)]
 edge_data1 = {
@@ -106,6 +112,8 @@ for i, node_data in enumerate(split_data(node_data2, 5)):
     write_data_hdf5(node_data, os.path.join(in_dir, f'node_data2_{i}.hdf5'))
 for i, node_data in enumerate(split_data(node_data3, 10)):
     write_data_json(node_data, os.path.join(in_dir, f'node_data3_{i}.json'))
+for i, node_data in enumerate(split_data(node_data4, 10)):
+    write_data_json(node_data, os.path.join(in_dir, f'node_data4_{i}.json'))
 for i, edge_data in enumerate(split_data(edge_data1, 10)):
     write_data_parquet(edge_data, os.path.join(in_dir, f'edge_data1_{i}.parquet'))
 for i, edge_data in enumerate(split_data(edge_data2, 10)):
@@ -206,6 +214,13 @@ node_conf = [
                 "feature_name": "feat",
             },
         ],
+    },
+    {
+        "node_id_col": "id",
+        "node_type": "node4",
+        "format": {"name": "json"},
+        "files": os.path.join(in_dir, "node_data4_*.json"),
+        # No feature
     },
 ]
 edge_conf = [

--- a/tests/end2end-tests/data_process/test_data.py
+++ b/tests/end2end-tests/data_process/test_data.py
@@ -99,6 +99,9 @@ assert data.shape[1] == 5
 for i in range(data.shape[1]):
     assert np.all(data[:,i] == orig_ids)
 
+# id remap for node4 exists
+assert os.path.isfile(os.path.join(out_dir, "node4_id_remap.parquet"))
+
 # Test the edge data of edge type 1
 src_ids, dst_ids = g.edges(etype=('node1', 'relation1', 'node2'))
 assert 'label' in g.edges[('node1', 'relation1', 'node2')].data


### PR DESCRIPTION
When no node feature is provided for a node type, the process_node_data will fail

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
