### PR TITLE
Fix the case when dtype of predict and label does not match in regression tasks.

### DIFF
--- a/python/graphstorm/eval/eval_func.py
+++ b/python/graphstorm/eval/eval_func.py
@@ -20,6 +20,7 @@ from functools import partial
 import operator
 import numpy as np
 import torch as th
+import warnings
 from sklearn.metrics import roc_auc_score
 from sklearn.metrics import precision_recall_curve, auc, classification_report
 
@@ -338,17 +339,31 @@ def compute_acc(pred, labels, multilabel):
 def compute_rmse(pred, labels):
     """ compute RMSE for regression.
     """
-    assert pred.dtype == labels.dtype, \
-            "prediction and labels have different data types. {} vs. {}".format(pred.dtype,
-                                                                                labels.dtype)
+    assert th.is_floating_point(pred) and th.is_floating_point(labels), \
+        "prediction and labels must be floating points"
+
     assert pred.shape == labels.shape, \
             "prediction and labels have different shapes. {} vs. {}".format(pred.shape,
                                                                             labels.shape)
+    if pred.dtype != labels.dtype:
+        warnings.warn(f"prediction and labels have different data types. {pred.dtype} vs. {labels.dtype}")
+        pred = pred.type(labels.dtype) # cast pred to the same dtype as labels.
+
     diff = pred.cpu() - labels.cpu()
     return th.sqrt(th.mean(diff * diff)).cpu().item()
 
 def compute_mse(pred, labels):
     """ compute MSE for regression
     """
+    assert th.is_floating_point(pred) and th.is_floating_point(labels), \
+        "prediction and labels must be floating points"
+
+    assert pred.shape == labels.shape, \
+            "prediction and labels have different shapes. {} vs. {}".format(pred.shape,
+                                                                            labels.shape)
+    if pred.dtype != labels.dtype:
+        warnings.warn(f"prediction and labels have different data types. {pred.dtype} vs. {labels.dtype}")
+        pred = pred.type(labels.dtype) # cast pred to the same dtype as labels.
+
     diff = pred.cpu() - labels.cpu()
     return th.mean(diff * diff).cpu().item()

--- a/python/graphstorm/eval/eval_func.py
+++ b/python/graphstorm/eval/eval_func.py
@@ -339,14 +339,16 @@ def compute_acc(pred, labels, multilabel):
 def compute_rmse(pred, labels):
     """ compute RMSE for regression.
     """
+    # TODO: check dtype of label before training or evaluation
     assert th.is_floating_point(pred) and th.is_floating_point(labels), \
         "prediction and labels must be floating points"
 
     assert pred.shape == labels.shape, \
-            "prediction and labels have different shapes. {} vs. {}".format(pred.shape,
-                                                                            labels.shape)
+        f"prediction and labels have different shapes. {pred.shape} vs. {labels.shape}"
     if pred.dtype != labels.dtype:
-        warnings.warn(f"prediction and labels have different data types. {pred.dtype} vs. {labels.dtype}")
+        warnings.warn("prediction and labels have different data types: "
+                      f"{pred.dtype} vs. {labels.dtype}")
+        warnings.warn("casting pred to the same dtype as labels")
         pred = pred.type(labels.dtype) # cast pred to the same dtype as labels.
 
     diff = pred.cpu() - labels.cpu()
@@ -355,14 +357,16 @@ def compute_rmse(pred, labels):
 def compute_mse(pred, labels):
     """ compute MSE for regression
     """
+    # TODO: check dtype of label before training or evaluation
     assert th.is_floating_point(pred) and th.is_floating_point(labels), \
         "prediction and labels must be floating points"
 
     assert pred.shape == labels.shape, \
-            "prediction and labels have different shapes. {} vs. {}".format(pred.shape,
-                                                                            labels.shape)
+        f"prediction and labels have different shapes. {pred.shape} vs. {labels.shape}"
     if pred.dtype != labels.dtype:
-        warnings.warn(f"prediction and labels have different data types. {pred.dtype} vs. {labels.dtype}")
+        warnings.warn("prediction and labels have different data types: "
+                      f"{pred.dtype} vs. {labels.dtype}")
+        warnings.warn("casting pred to the same dtype as labels")
         pred = pred.type(labels.dtype) # cast pred to the same dtype as labels.
 
     diff = pred.cpu() - labels.cpu()

--- a/python/graphstorm/eval/eval_func.py
+++ b/python/graphstorm/eval/eval_func.py
@@ -18,9 +18,9 @@
 from enum import Enum
 from functools import partial
 import operator
+import warnings
 import numpy as np
 import torch as th
-import warnings
 from sklearn.metrics import roc_auc_score
 from sklearn.metrics import precision_recall_curve, auc, classification_report
 

--- a/tests/unit-tests/test_eval_func.py
+++ b/tests/unit-tests/test_eval_func.py
@@ -1,0 +1,52 @@
+"""
+    Copyright 2023 Contributors
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+"""
+import numpy as np
+import torch as th
+
+from numpy.testing import assert_almost_equal
+from graphstorm.eval.eval_func import compute_mse, compute_rmse
+
+def test_compute_mse():
+    pred64 = th.rand((100,1), dtype=th.float64)
+    label64 = pred64 + th.rand((100,1), dtype=th.float64) / 10
+
+    pred32 = pred64.type(th.float32)
+    label32 = label64.type(th.float32)
+    mse32 = compute_mse(pred32, label32)
+
+    mse_pred64 = compute_mse(pred64, label32)
+    mse_label64 = compute_mse(pred32, label64)
+
+    assert_almost_equal(mse32, mse_pred64)
+    assert_almost_equal(mse32, mse_label64)
+
+def test_compute_rmse():
+    pred64 = th.rand((100,1), dtype=th.float64)
+    label64 = pred64 + th.rand((100,1), dtype=th.float64) / 10
+
+    pred32 = pred64.type(th.float32)
+    label32 = label64.type(th.float32)
+    rmse32 = compute_rmse(pred32, label32)
+
+    rmse_pred64 = compute_rmse(pred64, label32)
+    rmse_label64 = compute_rmse(pred32, label64)
+
+    assert_almost_equal(rmse32, rmse_pred64)
+    assert_almost_equal(rmse32, rmse_label64)
+
+if __name__ == '__main__':
+    test_compute_mse()
+    test_compute_rmse()


### PR DESCRIPTION
*Issue #, if available:*
When dtype of predict and label does not match, compute_mse and compute_rmse will crash

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
