### PR TITLE
Use cached BERT model in CI-docker image to do testing instead of downloading it

### DIFF
--- a/tests/end2end-tests/data_process/data_gen.py
+++ b/tests/end2end-tests/data_process/data_gen.py
@@ -177,7 +177,7 @@ node_conf = [
                 # tokenize_hf generates multiple features.
                 # It defines feature names itself.
                 "transform": {"name": "tokenize_hf",
-                              "bert_model": "bert-base-uncased",
+                              "bert_model": "/root/.cache/huggingface/hub/models--bert-base-uncased/snapshots/a265f773a47193eed794233aa2a0f0bb6d3eaa63/",
                               "max_seq_length": 16},
             },
             {
@@ -185,7 +185,7 @@ node_conf = [
                 "feature_name": "bert",
                 "out_dtype": 'float32',
                 "transform": {"name": "bert_hf",
-                              "bert_model": "bert-base-uncased",
+                              "bert_model": "/root/.cache/huggingface/hub/models--bert-base-uncased/snapshots/a265f773a47193eed794233aa2a0f0bb6d3eaa63/",
                               "max_seq_length": 16},
             },
             {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
