### PR TITLE
Remove tqdm in dist_inference

### DIFF
--- a/python/graphstorm/model/gnn_encoder_base.py
+++ b/python/graphstorm/model/gnn_encoder_base.py
@@ -15,8 +15,6 @@
 
     Relational GNN
 """
-import tqdm
-
 import dgl
 import torch as th
 from torch import nn
@@ -125,7 +123,7 @@ def dist_inference(g, gnn_encoder, get_input_embeds, batch_size, fanout,
                                                             shuffle=False,
                                                             drop_last=False)
 
-            for iter_l, (input_nodes, output_nodes, blocks) in enumerate(tqdm.tqdm(dataloader)):
+            for iter_l, (input_nodes, output_nodes, blocks) in enumerate(dataloader):
                 if task_tracker is not None:
                     task_tracker.keep_alive(report_step=iter_l)
                 block = blocks[0].to(device)

--- a/python/graphstorm/utils.py
+++ b/python/graphstorm/utils.py
@@ -237,8 +237,7 @@ class SysTracker:
         if len(self._checkpoints) >= 2 and self._rank == 0:
             checkpoint1 = self._checkpoints[-2]
             checkpoint2 = self._checkpoints[-1]
-            # TODO: change to use logging to avoid printing too many info
-            print("{}: elapsed time: {:.3f}, mem (curr: {:.3f}, peak: {:.3f}, \
+            logging.debug("{}: elapsed time: {:.3f}, mem (curr: {:.3f}, peak: {:.3f}, \
                     shared: {:.3f}, global curr: {:.3f}, global shared: {:.3f}) GB".format(
                 name, checkpoint2[1] - checkpoint1[1],
                 checkpoint2[2]/1024/1024/1024, checkpoint2[4]/1024/1024,

--- a/python/graphstorm/utils.py
+++ b/python/graphstorm/utils.py
@@ -237,7 +237,8 @@ class SysTracker:
         if len(self._checkpoints) >= 2 and self._rank == 0:
             checkpoint1 = self._checkpoints[-2]
             checkpoint2 = self._checkpoints[-1]
-            logging.debug("{}: elapsed time: {:.3f}, mem (curr: {:.3f}, peak: {:.3f}, \
+            # TODO: change to use logging to avoid printing too many info
+            print("{}: elapsed time: {:.3f}, mem (curr: {:.3f}, peak: {:.3f}, \
                     shared: {:.3f}, global curr: {:.3f}, global shared: {:.3f}) GB".format(
                 name, checkpoint2[1] - checkpoint1[1],
                 checkpoint2[2]/1024/1024/1024, checkpoint2[4]/1024/1024,


### PR DESCRIPTION
*Issue #, if available:*
Using tqdm in dist_inference will cause `deadlock` (barrier timeout) on large graph link prediction inference. 

*Description of changes:*
Remove tqdm.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
