### PR TITLE
Updating CUDA  docker image tag to 11.3.1

### DIFF
--- a/docker/Dockerfile.local
+++ b/docker/Dockerfile.local
@@ -1,4 +1,4 @@
-FROM nvidia/cuda:11.3.0-devel-ubuntu20.04
+FROM nvidia/cuda:11.3.1-devel-ubuntu20.04
 ENV DEBIAN_FRONTEND=noninteractive
 ENV HOME=/root
 


### PR DESCRIPTION
*Description of changes:*

11.3.0 does not seem to be supported anymore.
https://gitlab.com/nvidia/container-images/cuda/blob/master/doc/supported-tags.md

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
