### PR TITLE
`FastMultiLayerNeighborSampler` not in `dgl.dataloading`

### DIFF
--- a/python/graphstorm/dataloading/dataloading.py
+++ b/python/graphstorm/dataloading/dataloading.py
@@ -335,7 +335,7 @@ class FastGSgnnLinkPredictionDataLoader(GSgnnLinkPredictionDataLoader):
             sampler = FastMultiLayerNeighborSampler(fanout,
                                                     mask=edge_mask_for_gnn_embeddings)
         else:
-            sampler = dgl.dataloading.FastMultiLayerNeighborSampler(fanout)
+            sampler = dgl.dataloading.MultiLayerNeighborSampler(fanout)
         negative_sampler = self._prepare_negative_sampler(num_negative_edges)
 
         # edge loader


### PR DESCRIPTION
*Issue #, if available:*

DGL package does not have `dgl.dataloading.FastMultiLayerNeighborSampler` 

*Description of changes:*

I am sure if this is a typo? Maybe we should change it to `dgl.dataloading.MultiLayerNeighborSampler`?

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
