### PR TITLE
Fix Device or resource busy: '/opt/ml/model' bug when running SageMaker training and inference

### DIFF
--- a/python/graphstorm/sagemaker/sagemaker_infer.py
+++ b/python/graphstorm/sagemaker/sagemaker_infer.py
@@ -154,7 +154,9 @@ def run_infer(args, unknownargs):
     num_gpus = args.num_gpus
     data_path = args.data_path
     model_path = '/opt/ml/gsgnn_model'
-    output_path = '/opt/ml/checkpoints'
+    output_path = '/opt/ml/infer_output'
+    os.makedirs(model_path, exist_ok=True)
+    os.makedirs(output_path, exist_ok=True)
 
     # start the ssh server
     subprocess.run(["service", "ssh", "start"], check=True)

--- a/python/graphstorm/sagemaker/sagemaker_infer.py
+++ b/python/graphstorm/sagemaker/sagemaker_infer.py
@@ -45,8 +45,7 @@ from .utils import (download_yaml_config,
                     update_gs_params,
                     download_model,
                     upload_embs,
-                    remove_embs,
-                    remove_data)
+                    remove_embs)
 
 def launch_infer_task(task_type, num_gpus, graph_config,
     load_model_path, save_emb_path, ip_list,
@@ -154,7 +153,7 @@ def run_infer(args, unknownargs):
     """
     num_gpus = args.num_gpus
     data_path = args.data_path
-    model_path = '/opt/ml/model'
+    model_path = '/opt/ml/gsgnn_model'
     output_path = '/opt/ml/checkpoints'
 
     # start the ssh server
@@ -293,5 +292,3 @@ def run_infer(args, unknownargs):
         upload_data_to_s3(output_prediction_s3,
                           os.path.join(output_path, "predict"),
                           sagemaker_session)
-    remove_data(output_path)
-    remove_data(model_path)

--- a/python/graphstorm/sagemaker/sagemaker_train.py
+++ b/python/graphstorm/sagemaker/sagemaker_train.py
@@ -39,8 +39,7 @@ from .utils import (download_yaml_config,
                     barrier,
                     terminate_workers,
                     wait_for_exit,
-                    upload_model_artifacts,
-                    remove_data)
+                    upload_model_artifacts)
 
 def launch_train_task(task_type, num_gpus, graph_config,
     save_model_path, ip_list, yaml_path,
@@ -146,7 +145,7 @@ def run_train(args, unknownargs):
     """
     num_gpus = args.num_gpus
     data_path = args.data_path
-    output_path = "/opt/ml/model/"
+    output_path = "/opt/ml/gsgnn_model/"
 
     # start the ssh server
     subprocess.run(["service", "ssh", "start"], check=True)
@@ -260,5 +259,3 @@ def run_train(args, unknownargs):
     # If there are saved models
     if os.path.exists(save_model_path):
         upload_model_artifacts(model_artifact_s3, save_model_path, sagemaker_session)
-
-        remove_data(save_model_path)

--- a/python/graphstorm/sagemaker/sagemaker_train.py
+++ b/python/graphstorm/sagemaker/sagemaker_train.py
@@ -146,6 +146,7 @@ def run_train(args, unknownargs):
     num_gpus = args.num_gpus
     data_path = args.data_path
     output_path = "/opt/ml/gsgnn_model/"
+    os.makedirs(output_path, exist_ok=True)
 
     # start the ssh server
     subprocess.run(["service", "ssh", "start"], check=True)


### PR DESCRIPTION
*Issue #, if available:*
Commit 32c2baa995e331db1bfff574ddd0de2dae20816e tries to remove the trained model or generated node embeddings under /opt/ml/model/ and /opt/ml/checkpoints/ to avoid uploading the trained model or node embeddings using SageMaker default model saving mechanism which is slow. However, this may trigger the "Device or resource busy: '/opt/ml/model'" error.


*Description of changes:*
In this PR, we change the training/inference output path to /opt/ml/gsgnn_model/ and /opt/ml/infer_output respectively to avoid the above problem.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
