### PR TITLE
Use python -u option to force stdout and stderr streams to be unbuffered

### DIFF
--- a/python/graphstorm/run/launch.py
+++ b/python/graphstorm/run/launch.py
@@ -375,7 +375,7 @@ def wrap_udf_in_torch_dist_launcher(
     # to:
     #     python -m torch.distributed.launch [DIST TORCH ARGS] path/to/dist_trainer.py arg0 arg1
     udf_command = " ".join(udf_command)
-    new_udf_command = f"{python_bin} {torch_dist_cmd} {udf_command}"
+    new_udf_command = f"{python_bin} -u {torch_dist_cmd} {udf_command}"
 
     return new_udf_command
 
@@ -677,9 +677,9 @@ def submit_jobs(args, udf_command):
 
     udf_command = update_udf_command(udf_command, args)
     # launch server tasks
-    server_cmd = f"{sys.executable} {' '.join(udf_command)}" \
+    server_cmd = f"{sys.executable} -u {' '.join(udf_command)}" \
         if sys.executable is not None and sys.executable != "" \
-        else f"python3 {' '.join(udf_command)}"
+        else f"python3 -u {' '.join(udf_command)}"
 
     server_env_vars = construct_dgl_server_env_vars(
         num_samplers=args.num_samplers,

--- a/python/graphstorm/sagemaker/sagemaker_infer.py
+++ b/python/graphstorm/sagemaker/sagemaker_infer.py
@@ -92,7 +92,7 @@ def launch_infer_task(task_type, num_gpus, graph_config,
     else:
         raise RuntimeError(f"Unsupported task type {task_type}")
 
-    launch_cmd = ["python3", "-m", cmd,
+    launch_cmd = ["python3", "-u",  "-m", cmd,
         "--num-trainers", f"{num_gpus}",
         "--num-servers", "1",
         "--num-samplers", "0",

--- a/python/graphstorm/sagemaker/sagemaker_train.py
+++ b/python/graphstorm/sagemaker/sagemaker_train.py
@@ -87,7 +87,7 @@ def launch_train_task(task_type, num_gpus, graph_config,
     else:
         raise RuntimeError(f"Unsupported task type {task_type}")
 
-    launch_cmd = ["python3", "-m", cmd,
+    launch_cmd = ["python3", "-u", "-m", cmd,
         "--num-trainers", f"{num_gpus}",
         "--num-servers", "1",
         "--num-samplers", "0",


### PR DESCRIPTION
*Issue #, if available:*
By default, python processes buffer stdout and stderr streams. When a trainer or server crashes, the buffered prints will be lost. This makes debugging distributed training/inference difficult.

*Description of changes:*
Use python -u option to force stdout and stderr streams to be unbuffered.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
