### PR TITLE
Fix wrong graph partition config filename bug

### DIFF
--- a/python/graphstorm/sagemaker/utils.py
+++ b/python/graphstorm/sagemaker/utils.py
@@ -255,10 +255,10 @@ def download_graph(graph_data_s3, graph_name, part_id, local_path, sagemaker_ses
     except ClientError as err:
         if err.response['ResponseMetadata']['HTTPStatusCode'] == 404:
             # The key does not exist.
-            raise Exception(f"Metadata key {s3_input_key}/{graph_config} does not exist")
+            raise RuntimeError(f"Metadata key {s3_input_key}/{graph_config} does not exist")
         if err.response['Error']['Code'] == 403:
             # Unauthorized, including invalid bucket
-            raise Exception("Authorization error, check the path and auth again:" \
+            raise RuntimeError("Authorization error, check the path and auth again:" \
                             f"{s3_input_key}/{graph_config}")
         raise err
 

--- a/python/graphstorm/sagemaker/utils.py
+++ b/python/graphstorm/sagemaker/utils.py
@@ -256,13 +256,11 @@ def download_graph(graph_data_s3, graph_name, part_id, local_path, sagemaker_ses
         if err.response['ResponseMetadata']['HTTPStatusCode'] == 404:
             # The key does not exist.
             raise Exception(f"Metadata key {s3_input_key}/{graph_config} does not exist")
-        elif err.response['Error']['Code'] == 403:
+        if err.response['Error']['Code'] == 403:
             # Unauthorized, including invalid bucket
             raise Exception("Authorization error, check the path and auth again:" \
                             f"{s3_input_key}/{graph_config}")
-        else:
-            # Something else went wrong.
-            raise err
+        raise err
 
     S3Downloader.download(os.path.join(graph_data_s3, graph_config),
             graph_path, sagemaker_session=sagemaker_session)

--- a/python/graphstorm/sagemaker/utils.py
+++ b/python/graphstorm/sagemaker/utils.py
@@ -233,6 +233,7 @@ def download_graph(graph_data_s3, graph_name, part_id, local_path, sagemaker_ses
     """
     # Download partitioned graph data.
     # Each training instance only download 1 partition.
+    graph_config = f"{graph_name}.json"
     graph_part = f"part{part_id}"
 
     graph_path = os.path.join(local_path, graph_name)
@@ -248,21 +249,20 @@ def download_graph(graph_data_s3, graph_name, part_id, local_path, sagemaker_ses
     s3_input_key = graph_data_s3.split("/", maxsplit=3)[3]
 
     s3_client = boto3.client('s3')
-    for graph_config  in [f"{graph_name}.json", "metadata.json"]:
-        try:
-            s3_client.head_object(Bucket=s3_input_bucket, Key=f"{s3_input_key}/{graph_config}")
-        except ClientError as err:
-            if err.response['ResponseMetadata']['HTTPStatusCode'] == 404:
-                # The key does not exist.
-                logging.debug("Metadata key %s does not exist",
+
+    try:
+        s3_client.head_object(Bucket=s3_input_bucket, Key=f"{s3_input_key}/{graph_config}")
+    except ClientError as err:
+        if err.response['ResponseMetadata']['HTTPStatusCode'] == 404:
+            # The key does not exist.
+            raise Exception(f"Metadata key {s3_input_key}/{graph_config} does not exist")
+        elif err.response['Error']['Code'] == 403:
+            # Unauthorized, including invalid bucket
+            raise Exception("Authorization error, check the path and auth again:" \
                             f"{s3_input_key}/{graph_config}")
-            elif err.response['Error']['Code'] == 403:
-                # Unauthorized, including invalid bucket
-                logging.error("Authorization error, check the path again: %s",
-                            f"{s3_input_key}/{graph_config}")
-            else:
-                # Something else has gone wrong.
-                raise err
+        else:
+            # Something else went wrong.
+            raise err
 
     S3Downloader.download(os.path.join(graph_data_s3, graph_config),
             graph_path, sagemaker_session=sagemaker_session)


### PR DESCRIPTION
*Issue #, if available:*
There is a logic error in [python/graphstorm/sagemaker/utils.py:L251](https://github.com/awslabs/graphstorm/pull/332/files#diff-3bd5dedc90be6c0508ab83d0a94ed14e7dfd5857db7eeb9eb32ea4aed46fdeb5). The graph_config will always be "metadata.json", which actually is no longer used. The actual graph_config name should be f"{graph_name}.json"

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
