### PR TITLE
Handle errors in the worker processes in the graph construction pipeline

### DIFF
--- a/python/graphstorm/gconstruct/utils.py
+++ b/python/graphstorm/gconstruct/utils.py
@@ -183,7 +183,7 @@ def worker_fn(worker_id, task_queue, res_queue, user_parser):
             gc.collect()
     except queue.Empty:
         pass
-    except Exception as e:
+    except Exception as e:  # pylint: disable=broad-exception-caught
         print(e, flush=True)
         res_queue.put((i, None))
 

--- a/python/graphstorm/gconstruct/utils.py
+++ b/python/graphstorm/gconstruct/utils.py
@@ -252,7 +252,7 @@ def multiprocessing_data_read(in_files, num_processes, user_parser):
         while len(return_dict) < num_files:
             file_idx, vals= res_queue.get()
             if not isinstance(vals, tuple):
-                logging.error("Processing file % fails.", file_idx)
+                logging.error("Processing file %d fails.", file_idx)
                 logging.error(vals)
                 raise RuntimeError("One of the worker processes fails. Stop processing.")
             # If the size of `vals`` is larger than utils.SHARED_MEM_OBJECT_THRESHOLD

--- a/python/graphstorm/gconstruct/utils.py
+++ b/python/graphstorm/gconstruct/utils.py
@@ -164,6 +164,7 @@ def worker_fn(worker_id, task_queue, res_queue, user_parser):
         if worker_id >= num_gpus:
             logging.warning("There are more than 1 processes are attachd to GPU %d.", gpu)
     try:
+        i = 0
         while True:
             # If the queue is empty, it will raise the Empty exception.
             i, in_file = task_queue.get_nowait()
@@ -183,7 +184,7 @@ def worker_fn(worker_id, task_queue, res_queue, user_parser):
     except queue.Empty:
         pass
     except Exception as e:
-        print(e)
+        print(e, flush=True)
         res_queue.put((i, None))
 
 def update_two_phase_feat_ops(phase_one_info, ops):

--- a/python/graphstorm/gconstruct/utils.py
+++ b/python/graphstorm/gconstruct/utils.py
@@ -182,6 +182,9 @@ def worker_fn(worker_id, task_queue, res_queue, user_parser):
             gc.collect()
     except queue.Empty:
         pass
+    except Exception as e:
+        print(e)
+        res_queue.put((i, None))
 
 def update_two_phase_feat_ops(phase_one_info, ops):
     """ Update the ops for the second phase feat processing
@@ -246,6 +249,8 @@ def multiprocessing_data_read(in_files, num_processes, user_parser):
         return_dict = {}
         while len(return_dict) < num_files:
             file_idx, vals= res_queue.get()
+            if vals is None:
+                raise RuntimeError("One of the worker processes fails. Stop data processing.")
             # If the size of `vals`` is larger than utils.SHARED_MEM_OBJECT_THRESHOLD
             # we will automatically convert tensors in `vals` into torch tensor
             # and copy the tensor into shared memory.

--- a/tests/unit-tests/gconstruct/test_gconstruct_utils.py
+++ b/tests/unit-tests/gconstruct/test_gconstruct_utils.py
@@ -178,7 +178,12 @@ def dummy_read(in_file):
     assert False
 
 def test_multiprocessing_read():
-    multiprocessing_data_read([str(i) for i in range(10)], 2, dummy_read)
+    try:
+        multiprocessing_data_read([str(i) for i in range(10)], 2, dummy_read)
+    except RuntimeError as e:
+        print(e)
+        return
+    assert False
 
 if __name__ == '__main__':
     test_multiprocessing_read()

--- a/tests/unit-tests/gconstruct/test_gconstruct_utils.py
+++ b/tests/unit-tests/gconstruct/test_gconstruct_utils.py
@@ -21,6 +21,7 @@ import torch as th
 
 from graphstorm.gconstruct.utils import _estimate_sizeof, _to_numpy_array, _to_shared_memory
 from graphstorm.gconstruct.utils import HDF5Array, ExtNumpyWrapper
+from graphstorm.gconstruct.utils import multiprocessing_data_read
 from graphstorm.gconstruct.file_io import write_data_hdf5, read_data_hdf5
 
 def gen_data():
@@ -173,7 +174,14 @@ def test_ext_mem_array():
         data1 = read_data_hdf5(tensor_path, in_mem=False)
         check_ext_mem_array(data1['test'], data)
 
+def dummy_read(in_file):
+    assert False
+
+def test_multiprocessing_read():
+    multiprocessing_data_read([str(i) for i in range(10)], 2, dummy_read)
+
 if __name__ == '__main__':
+    test_multiprocessing_read()
     test_estimate_sizeof()
     test_object_conversion()
     test_ext_mem_array()


### PR DESCRIPTION
*Description of changes:*
If a worker process fails, the entire graph construction pipeline will hang. If a worker fails, we should fail the entire graph construction pipeline immediately.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
