### PR TITLE
[Fix] fix hgt get_rank error and cleanup script typo

### DIFF
--- a/examples/customized_models/HGT/hgt_nc.py
+++ b/examples/customized_models/HGT/hgt_nc.py
@@ -305,7 +305,7 @@ def main(args):
 
     # Create a trainer for the node classification task.
     trainer = GSgnnNodePredictionTrainer(model, gs.get_rank(), topk_model_to_save=config.topk_model_to_save)
-    trainer.setup_cuda(dev_id=gs.get_rank())
+    trainer.setup_cuda(dev_id=config.local_rank)
     device = 'cuda:%d' % trainer.dev_id
 
     # Define the GraphStorm train dataloader

--- a/tools/kill_cleanup_disttrain.sh
+++ b/tools/kill_cleanup_disttrain.sh
@@ -12,7 +12,7 @@ done < "$1"
 
 graph_name=$2
 
-if [ -z "$3"]; then
+if [ -z "$3" ]; then
     port_num=2222
 else
     port_num=$3


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Fix two errors:
- hgt_nc.py uses gs.get_rank(), which should be config.local_rank for multiple instances.
- kill_cleanup.sh, should have a white space in line 15.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
