### PR TITLE
[SageMaker] Allow passing of SageMaker Estimator arguments during job…

### DIFF
--- a/python/graphstorm/sagemaker/utils.py
+++ b/python/graphstorm/sagemaker/utils.py
@@ -248,9 +248,11 @@ def download_graph(graph_data_s3, graph_name, part_id, local_path, sagemaker_ses
     s3_input_key = graph_data_s3.split("/", maxsplit=3)[3]
 
     s3_client = boto3.client('s3')
-    for graph_config  in [f"{graph_name}.json", "metadata.json"]:
+    for config_name  in [f"{graph_name}.json", "metadata.json"]:
         try:
-            s3_client.head_object(Bucket=s3_input_bucket, Key=f"{s3_input_key}/{graph_config}")
+            s3_client.head_object(Bucket=s3_input_bucket, Key=f"{s3_input_key}/{config_name}")
+            # This will only be accessed if the above doesn't trigger an exception
+            graph_config = config_name
         except ClientError as err:
             if err.response['ResponseMetadata']['HTTPStatusCode'] == 404:
                 # The key does not exist.

--- a/python/graphstorm/sagemaker/utils.py
+++ b/python/graphstorm/sagemaker/utils.py
@@ -248,6 +248,7 @@ def download_graph(graph_data_s3, graph_name, part_id, local_path, sagemaker_ses
     s3_input_key = graph_data_s3.split("/", maxsplit=3)[3]
 
     s3_client = boto3.client('s3')
+    graph_config = None
     for config_name  in [f"{graph_name}.json", "metadata.json"]:
         try:
             s3_client.head_object(Bucket=s3_input_bucket, Key=f"{s3_input_key}/{config_name}")

--- a/sagemaker/README.md
+++ b/sagemaker/README.md
@@ -8,6 +8,23 @@ Use scripts under graphstorm.sagemaker.launch to launch SageMaker tasks.
 Please make sure you already setup your SageMaker environment.
 Please refer to [Amazon SageMaker service](https://aws.amazon.com/pm/sagemaker) for how to get access to Amazon SageMaker.
 
+### Common task arguments
+
+All SageMaker tasks share some common arguments that can be found in `<gs-root>/sagemaker/launch/common_parser.py`
+
+* `image_url`: (required) The URI to the GraphStorm SageMaker image on ECR.
+* `role`: (required) The SageMaker execution role that will be used to run the job.
+* `instance-type`: The SageMaker instance type used to run the job.
+* `instance-count`: The number of SageMaker instances used to run the job.
+    For GConstruct jobs, the number is always 1.
+* `region`: The region in which we will launch the job. Default is `us-west-2`, but ensure it matches the
+    region of your image.
+* `task-name`: A user-defined task name for the job.
+* `sm-estimator-parameters`: Parameters that will be forwarded to the SageMaker Estimator/Processor.
+    See the section `Passing additional arguments to the SageMaker Estimator/Processor` for details.
+* `async-exection`: When this flag is set the job will run in async mode and return immediatelly.
+    Otherwise the job will block and logs will be printed to the console.
+
 ### Launch GraphStorm graph construction using Amazon SageMaker service
 
 #### Preparing the example dataset
@@ -35,14 +52,14 @@ Then, you can use the following command to launch a SageMaker graph construction
 ```bash
 python3 launch/launch_gconstruct.py \
         --image-url <AMAZON_ECR_IMAGE_URI> \
-        --region us-east-1 \
+        --region <region> \
         --entry-point run/gconstruct_entry.py \
         --role <ROLE_ARN> \
         --input-graph-s3 s3://PATH_TO/acm/ \
         --output-graph-s3 s3://PATH_TO/acm_output/ \
-        --volume-size-in-gb 10 \
         --graph-name acm \
-        --graph-config-file acm_raw/config.json
+        --graph-config-file acm_raw/config.json \
+        --sm-estimator-parameters "volume_size_in_gb=10"
 ```
 The processed graph data is stored at s3://PATH_TO/acm_output/.
 
@@ -61,7 +78,7 @@ python launch/launch_partition.py --graph-data-s3 ${DATASET_S3_PATH} \
     --output-data-s3 ${OUTPUT_PATH} --instance-type ${INSTANCE_TYPE} \
     --image-url ${IMAGE_URI} --region ${REGION} \
     --role ${ROLE}  --entry-point "run/partition_entry.py" \
-    --job-prefix part-${ALGORITHM}-${DATASET_NAME}-${NUM_PARTITIONS}parts --metadata-filename ${METADATA_FILE} \
+    --metadata-filename ${METADATA_FILE} \
     --log-level INFO --partition-algorithm ${ALGORITHM}
 ```
 
@@ -158,33 +175,53 @@ aws s3 ls s3://PATH_TO_SAVE_GENERATED_NODE_EMBEDDING/
 aws s3 ls s3://PATH_TO_SAVE_PREDICTION_RESULTS/
 ```
 
-### Passing additional arguments to the SageMaker Estimator
+### Passing additional arguments to the SageMaker Estimator/Processor
 
 Sometimes you might want to pass additional arguments to the constructor of the SageMaker
-Estimator object we use to launch SageMaker tasks, e.g. to set a max runtime, or
-set a VPC configuration. Our launch scripts support forwarding arguments to the estimator
+Estimator/Processor object we use to launch SageMaker tasks, e.g. to set a max runtime, or
+set a VPC configuration. Our launch scripts support forwarding arguments to the base class
 object through a `kwargs` dictionary.
 
-To pass additional `kwargs` directly to the Estimator object, you can use
+To pass additional `kwargs` directly to the Estimator/Processor constructor, you can use
 the `--sm-estimator-parameters` argument, providing a string of space-separated arguments
 (enclosed in double quotes `"` to ensure correct parsing) and the
 format `<argname>=<value>` for each argument.
 
-`<argname>` needs to be a valid SageMaker Estimator
+`<argname>` needs to be a valid SageMaker Estimator/Processor
 argument name and `<value>` a value that can be parsed as a Python literal, **without
 spaces**.
 
 For example, to pass a specific max runtime, subnet list, and enable inter-container
-traffic encryption you'd use:
+traffic encryption for a train, inference, or partition job you'd use:
 
 ```bash
-python3 launch/launch_[infer|train|partition|gconstruct] \
+python3 launch/launch_[infer|train|partition] \
+    <other arugments> \
     --sm-estimator-parameters "max_run=3600 volume_size=100 encrypt_inter_container_traffic=True subnets=['subnet-1234','subnet-4567']"
 ```
 
 Notice how we don't include any spaces in `['subnet-1234','subnet-4567']` to ensure correct parsing of the list.
 
-For a full list of Estimator parameters see: https://sagemaker.readthedocs.io/en/stable/api/training/estimators.html#sagemaker.estimator.EstimatorBase
+The train, inference and partition scripts launch SageMaker Training jobs that rely on the `Estimator` base class:
+For a full list of `Estimator` parameters see:
+https://sagemaker.readthedocs.io/en/stable/api/training/estimators.html#sagemaker.estimator.EstimatorBase
+
+The GConstruct job will launch a SageMaker Processing job that relies on the `Processor` base class, so its
+arguments are different, e.g. `volume_size_in_gb` for the `Processor` vs. `volume_size` for the `Estimator`.
+
+So the above example would become:
+
+```bash
+python3 launch/launch_gconstruct \
+    <other arugments> \
+    --sm-estimator-parameters "max_runtime_in_seconds=3600 volume_size_in_gb=100"
+```
+
+
+For a full list of `Processor` parameters see:
+https://sagemaker.readthedocs.io/en/stable/api/training/processing.html
+
+
 
 ---
 

--- a/sagemaker/launch/common_parser.py
+++ b/sagemaker/launch/common_parser.py
@@ -5,6 +5,14 @@ from typing import Any, Dict
 from ast import literal_eval
 import argparse
 
+SUPPORTED_TASKS = {
+    "node_classification",
+    "node_regression",
+    "edge_classification",
+    "edge_regression",
+    "link_prediction"
+}
+
 def get_common_parser() -> argparse.ArgumentParser:
     """
     Returns an argument parser that can be used by all
@@ -21,13 +29,12 @@ def get_common_parser() -> argparse.ArgumentParser:
         help="SageMaker execution role",
         required=True)
     common_args.add_argument("--instance-type", type=str,
-        help="instance type for the SageMaker job",
-        required=True)
+        help="instance type for the SageMaker job")
     common_args.add_argument("--instance-count", type=int,
         default=2,
         help="number of instances")
     common_args.add_argument("--region", type=str,
-        default="us-east-1",
+        default="us-west-2",
         help="Region")
     common_args.add_argument("--task-name", type=str,
         default=None, help="User defined SageMaker task name")
@@ -38,15 +45,18 @@ def get_common_parser() -> argparse.ArgumentParser:
             'security_group_ids=[\'sg-1234\',\'sg-3456\']"')
     common_args.add_argument("--async-execution", action='store_true',
         help="When set will launch the job in async mode, returning immediately. "
-            "When not set will block until the job completes")
+            "When not set, will block until the job completes")
 
     return parser
 
 def parse_estimator_kwargs(arg_string: str) -> Dict[str, Any]:
     """
-    Parses Estimator arguments for SageMaker. See
+    Parses Estimator/Processor arguments for SageMaker tasks. See
     https://sagemaker.readthedocs.io/en/stable/api/training/estimators.html
-    for the full list of arguments. Argument values are evaluated as Python
+    for the full list of arguments for train/infer/partition tasks.
+    For GConstruct see
+    https://sagemaker.readthedocs.io/en/stable/api/training/processing.html
+    Argument values are evaluated as Python
     literals using ast.literal_eval.
 
     :param arg_string: String of arguments in the form of

--- a/sagemaker/launch/common_parser.py
+++ b/sagemaker/launch/common_parser.py
@@ -1,0 +1,63 @@
+"""
+Common parsers for all launcher scripts.
+"""
+from typing import Any, Dict
+from ast import literal_eval
+import argparse
+
+def get_common_parser() -> argparse.ArgumentParser:
+    """
+    Returns an argument parser that can be used by all
+    GraphStorm SageMaker launcher scripts.
+    """
+    parser = argparse.ArgumentParser()
+
+    common_args = parser.add_argument_group("Common arguments")
+
+    common_args.add_argument("--image-url", type=str,
+        help="GraphStorm SageMaker docker image URI",
+        required=True)
+    common_args.add_argument("--role", type=str,
+        help="SageMaker execution role",
+        required=True)
+    common_args.add_argument("--instance-type", type=str,
+        help="instance type for the SageMaker job",
+        required=True)
+    common_args.add_argument("--instance-count", type=int,
+        default=2,
+        help="number of instances")
+    common_args.add_argument("--region", type=str,
+        default="us-east-1",
+        help="Region")
+    common_args.add_argument("--task-name", type=str,
+        default=None, help="User defined SageMaker task name")
+    common_args.add_argument("--sm-estimator-parameters", type=str,
+        default=None, help='Parameters to be passed to the SageMaker Estimator as kwargs, '
+            'in <key>=<val> format, separated by spaces. Do not include spaces in the values themselves, e.g.: '
+            '--sm-estimator-parameters "volume_size=100 subnets=[\'subnet-123\',\'subnet-345\'] '
+            'security_group_ids=[\'sg-1234\',\'sg-3456\']"')
+    common_args.add_argument("--async-execution", action='store_true',
+        help="When set will launch the job in async mode, returning immediately. "
+            "When not set will block until the job completes")
+
+    return parser
+
+def parse_estimator_kwargs(arg_string: str) -> Dict[str, Any]:
+    """
+    Parses Estimator arguments for SageMaker. See
+    https://sagemaker.readthedocs.io/en/stable/api/training/estimators.html
+    for the full list of arguments. Argument values are evaluated as Python
+    literals using ast.literal_eval.
+
+    :param arg_string: String of arguments in the form of
+        <key>=<val> separated by spaces.
+    :return: Dictionary of parsed arguments.
+    """
+    if arg_string is None:
+        return {}
+    typed_args_dict = {}
+    for param in arg_string.split(" "):
+        k, v =param.split("=")
+        typed_args_dict[k] = literal_eval(v)
+
+    return typed_args_dict

--- a/sagemaker/launch/launch_infer.py
+++ b/sagemaker/launch/launch_infer.py
@@ -71,7 +71,7 @@ def run_job(input_args, image, unknowargs):
 
     container_image_uri = image
 
-    prefix = f"graphstorm-train-{sm_task_name}"
+    prefix = f"graphstorm-infer-{sm_task_name}"
 
     # In Link Prediction, no prediction outputs
     if task_type == "link_prediction":

--- a/sagemaker/launch/launch_partition.py
+++ b/sagemaker/launch/launch_partition.py
@@ -1,7 +1,6 @@
 """ Launch SageMaker training task
 """
 import os
-import argparse
 import json
 import logging
 import boto3 # pylint: disable=import-error
@@ -10,6 +9,7 @@ from sagemaker.pytorch.estimator import PyTorch
 from sagemaker.s3 import S3Downloader
 import sagemaker
 
+from common_parser import get_common_parser, parse_estimator_kwargs
 
 INSTANCE_TYPE = "ml.m5.12xlarge"
 
@@ -39,7 +39,6 @@ def run_job(input_args, image):
     output_data_s3 = output_data_s3[:-1] if output_data_s3[-1] == '/' \
         else output_data_s3 # The output will be an S3 folder
     metadata_filename = input_args.metadata_filename # graph metadata filename
-    prefix = input_args.job_prefix
 
     sagemaker_session = sagemaker.Session(boto3.Session(region_name=region))
 
@@ -70,6 +69,8 @@ def run_job(input_args, image):
 
     print(f"Parameters {params}")
 
+    estimator_kwargs = parse_estimator_kwargs(args.sm_estimator_parameters)
+
     est = PyTorch(
         disable_profiler=True,
         debugger_hook_config=False,
@@ -79,68 +80,50 @@ def run_job(input_args, image):
         role=role,
         instance_count=instance_count,
         instance_type=instance_type,
-        max_run=input_args.max_runtime,
         py_version="py3",
-        base_job_name=prefix,
         hyperparameters=params,
         sagemaker_session=sagemaker_session,
         tags=[{"Key":"GraphStorm", "Value":"beta"},
               {"Key":"GraphStorm_Task", "Value":"Partition"}],
         container_log_level=logging.getLevelName(input_args.log_level),
-        volume_size=args.volume_size
+        **estimator_kwargs
     )
 
-    est.fit(job_name=sm_task_name, wait=input_args.wait_for_job)
+    est.fit(job_name=sm_task_name, wait=input_args.async_execution)
 
 def get_partition_parser():
-    """ Add arguments
     """
-    parser = argparse.ArgumentParser()
+    Get GraphStorm partition task parser.
+    """
+    parser = get_common_parser()
 
-    parser.add_argument("--image-url", type=str,
-        required=True,
-        help="GraphStorm ECR image URI")
-    parser.add_argument("--role", type=str,
-        required=True,
-        help="SageMaker role")
-    parser.add_argument("--instance-type", type=str,
-        default=INSTANCE_TYPE,
-        help="instance type used to train models")
-    parser.add_argument("--instance-count", type=int,
-        required=True,
-        help="number of training instances")
-    parser.add_argument("--region", type=str,
-        required=True,
-        help="Region to launch the task")
-    parser.add_argument("--entry-point", type=str,
-        default="graphstorm/sagemaker/run/partition_entry.py",
-        help="PATH-TO graphstorm/sagemaker/run/partition_entry.py")
-    parser.add_argument("--task-name", type=str,
-        default=None, help="User defined SageMaker task name")
-    parser.add_argument("--wait-for-job", action='store_true',
-        help="When set will wait for the job to finish before returning")
+    partition_args = parser.add_argument_group("Partition Arguments")
 
-
-    # task specific
-    parser.add_argument("--graph-data-s3", type=str,
+    partition_args.add_argument("--graph-data-s3", type=str,
         required=True,
         help="S3 location of input training graph in chunked format")
-    parser.add_argument("--metadata-filename", type=str,
+    partition_args.add_argument("--output-data-s3", type=str,
+        required=True,
+        help="Output S3 location to store the partitioned graph")
+    partition_args.add_argument("--num-parts", type=int, help="Number of partitions",
+                                required=True)
+
+    partition_args.add_argument("--entry-point", type=str,
+        default="graphstorm/sagemaker/run/partition_entry.py",
+        help="PATH-TO graphstorm/sagemaker/run/partition_entry.py")
+
+    partition_args.add_argument("--metadata-filename", type=str,
         default="updated_row_counts_metadata.json",
         help="File name of metadata config file for chunked format data")
-    parser.add_argument("--num-parts", type=int, help="Number of partitions")
-    parser.add_argument("--partition-algorithm", type=str, default='random',
-        help="Partition algorithm to use.", choices=['metis', 'random'])
-    parser.add_argument("--skip-partitioning", action='store_true',
+
+    partition_args.add_argument("--partition-algorithm", type=str, default='random',
+        help="Partition algorithm to use.", choices=['random'])
+
+    partition_args.add_argument("--skip-partitioning", action='store_true',
         help="When set, we skip the partitioning step. "
              "Partition assignments for all node types need to exist on S3.")
-    parser.add_argument("--output-data-s3", type=str,
-        help="Output S3 location to store the partitioned graph")
-    parser.add_argument("--volume-size", type=int, default=30,
-        help="Volume size for each instance in GB.")
-    parser.add_argument("--job-prefix", help="Job name prefix", type=str, default='partition')
-    parser.add_argument("--max-runtime", help="Maximum runtime in seconds", type=int, default=86400)
-    parser.add_argument('--log-level', default='INFO',
+
+    partition_args.add_argument('--log-level', default='INFO',
         type=str, choices=['DEBUG', 'INFO', 'WARNING', 'CRITICAL', 'FATAL'])
 
     return parser.parse_args()
@@ -156,4 +139,7 @@ if __name__ == "__main__":
         )
 
     train_image = args.image_url
+    if not args.instance_type:
+        args.instance_type = INSTANCE_TYPE
+
     run_job(args, train_image)

--- a/sagemaker/launch/launch_train.py
+++ b/sagemaker/launch/launch_train.py
@@ -16,11 +16,12 @@
     Launch SageMaker training task
 """
 import os
-import argparse
 
 import boto3 # pylint: disable=import-error
 from sagemaker.pytorch.estimator import PyTorch
 import sagemaker
+
+from common_parser import get_common_parser, parse_estimator_kwargs
 
 INSTANCE_TYPE = "ml.g4dn.12xlarge"
 SUPPORTED_TASKS = {
@@ -65,7 +66,7 @@ def run_job(input_args, image, unknowargs):
 
     container_image_uri = image
 
-    prefix = "script-mode-container"
+    prefix = f"graphstorm-train-{sm_task_name}"
 
     params = {"task-type": task_type,
               "graph-name": graph_name,
@@ -92,6 +93,10 @@ def run_job(input_args, image, unknowargs):
 
     print(f"Parameters {params}")
     print(f"GraphStorm Parameters {unknowargs}")
+    if args.sm_estimator_parameters:
+        print(f"SageMaker Estimator parameters: '{args.sm_estimator_parameters}'")
+
+    estimator_kwargs = parse_estimator_kwargs(args.sm_estimator_parameters)
 
     est = PyTorch(
         entry_point=os.path.basename(entry_point),
@@ -107,57 +112,49 @@ def run_job(input_args, image, unknowargs):
         sagemaker_session=sess,
         tags=[{"Key":"GraphStorm", "Value":"oss"},
               {"Key":"GraphStorm_Task", "Value":"Training"}],
+        **estimator_kwargs
     )
 
-    est.fit({"train": train_yaml_s3}, job_name=sm_task_name, wait=True)
+    est.fit({"train": train_yaml_s3}, job_name=sm_task_name, wait=input_args.async_execution)
 
-def parse_args():
-    """ Add arguments
+def get_train_parser():
     """
-    parser = argparse.ArgumentParser()
+    Return a parser for a GraphStorm training task.
+    """
+    parser = get_common_parser()
 
-    parser.add_argument("--image-url", type=str,
-        help="Training docker image")
-    parser.add_argument("--role", type=str,
-        help="SageMaker role")
-    parser.add_argument("--instance-type", type=str,
-        default=INSTANCE_TYPE,
-        help="instance type used to train models")
+    training_args = parser.add_argument_group("Training Arguments")
 
-    parser.add_argument("--instance-count", type=int,
-        default=2,
-        help="number of infernece instances")
-    parser.add_argument("--region", type=str,
-        default="us-east-1",
-        help="Region")
-    parser.add_argument("--entry-point", type=str,
+    training_args.add_argument("--entry-point", type=str,
         default="graphstorm/sagemaker/run/train_entry.py",
         help="PATH-TO graphstorm/sagemaker/scripts/sagemaker_train.py")
-    parser.add_argument("--task-name", type=str,
-        default=None, help="User defined SageMaker task name")
 
     # task specific
-    parser.add_argument("--graph-name", type=str, help="Graph name")
-    parser.add_argument("--graph-data-s3", type=str,
-        help="S3 location of input training graph")
-    parser.add_argument("--task-type", type=str,
-        help=f"Task type in {SUPPORTED_TASKS}")
-    parser.add_argument("--yaml-s3", type=str,
+    training_args.add_argument("--graph-name", type=str, help="Graph name",
+        required=True)
+    training_args.add_argument("--graph-data-s3", type=str,
+        help="S3 location of input training graph", required=True)
+    training_args.add_argument("--task-type", type=str,
+        help=f"Task type in {SUPPORTED_TASKS}", required=True)
+    training_args.add_argument("--yaml-s3", type=str,
         help="S3 location of training yaml file. "
-             "Do not store it with partitioned graph")
-    parser.add_argument("--model-artifact-s3", type=str, default=None,
+             "Do not store it with partitioned graph", required=True)
+    training_args.add_argument("--model-artifact-s3", type=str, default=None,
         help="S3 bucket to save model artifacts")
-    parser.add_argument("--custom-script", type=str, default=None,
+    training_args.add_argument("--custom-script", type=str, default=None,
         help="Custom training script provided by a customer to run customer training logic. \
             Please provide the path of the script within the docker image")
 
     return parser
 
 if __name__ == "__main__":
-    arg_parser = parse_args()
+    arg_parser = get_train_parser()
     args, unknownargs = arg_parser.parse_known_args()
     print(args)
 
     train_image = args.image_url
+
+    if not args.instance_type:
+        args.instance_type = INSTANCE_TYPE
 
     run_job(args, train_image, unknownargs)

--- a/sagemaker/launch/launch_train.py
+++ b/sagemaker/launch/launch_train.py
@@ -21,16 +21,9 @@ import boto3 # pylint: disable=import-error
 from sagemaker.pytorch.estimator import PyTorch
 import sagemaker
 
-from common_parser import get_common_parser, parse_estimator_kwargs
+from common_parser import get_common_parser, parse_estimator_kwargs, SUPPORTED_TASKS
 
 INSTANCE_TYPE = "ml.g4dn.12xlarge"
-SUPPORTED_TASKS = {
-    "node_classification",
-    "node_regression",
-    "edge_classification",
-    "edge_regression",
-    "link_prediction"
-}
 
 def run_job(input_args, image, unknowargs):
     """ Run job using SageMaker estimator.PyTorch
@@ -66,7 +59,7 @@ def run_job(input_args, image, unknowargs):
 
     container_image_uri = image
 
-    prefix = f"graphstorm-train-{sm_task_name}"
+    prefix = f"gs-train-{graph_name}"
 
     params = {"task-type": task_type,
               "graph-name": graph_name,
@@ -93,10 +86,10 @@ def run_job(input_args, image, unknowargs):
 
     print(f"Parameters {params}")
     print(f"GraphStorm Parameters {unknowargs}")
-    if args.sm_estimator_parameters:
-        print(f"SageMaker Estimator parameters: '{args.sm_estimator_parameters}'")
+    if input_args.sm_estimator_parameters:
+        print(f"SageMaker Estimator parameters: '{input_args.sm_estimator_parameters}'")
 
-    estimator_kwargs = parse_estimator_kwargs(args.sm_estimator_parameters)
+    estimator_kwargs = parse_estimator_kwargs(input_args.sm_estimator_parameters)
 
     est = PyTorch(
         entry_point=os.path.basename(entry_point),
@@ -115,7 +108,7 @@ def run_job(input_args, image, unknowargs):
         **estimator_kwargs
     )
 
-    est.fit({"train": train_yaml_s3}, job_name=sm_task_name, wait=input_args.async_execution)
+    est.fit({"train": train_yaml_s3}, job_name=sm_task_name, wait=not input_args.async_execution)
 
 def get_train_parser():
     """


### PR DESCRIPTION
… launch

*Issue #, if available:*
Fixes #309 

*Description of changes:*
Allow forwarding of SageMaker Estimator arguments during job launch.

To achieve this we create a common parser for all launch scripts, that includes a new argument `sm-estimator-parameters`. End users can provide a space-separated list of SageMaker Estimator arguments here, in the format
`arg_name1=arg_val1 arg_name2=arg_val2`.

We use space as the entry separator, and the values themselves must not contain extra spaces. 

So a list of strings needs to be passed as `subnets=['subnet-123456','subnet-567799']` and not `subnets=['subnet-123456', 'subnet-567799']`.
We note this detail in the README. 

We parse the values as Python literals allowing them to interpreted with the expected type (str, int, list(str), bool) 

Tested by running SageMaker jobs where we pass e.g. `--sm-estimator-parameters "max_run=3600 volume_size=100 encrypt_inter_container_traffic=True subnets=['subnet-123456','subnet-567799']"`


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
