### PR TITLE
Allow out_dtype int8 to support user defined train_mask, val_mask and test_mask

### DIFF
--- a/python/graphstorm/gconstruct/transform.py
+++ b/python/graphstorm/gconstruct/transform.py
@@ -37,8 +37,10 @@ def _get_output_dtype(dtype_str):
         return np.float16
     elif dtype_str == 'float32':
         return np.float32
+    elif dtype_str == 'int8':
+        return np.int8 # for train, val, test mask
     else:
-        assert False, f"Unknown dtype {dtype_str}, only support float16 and float32"
+        assert False, f"Unknown dtype {dtype_str}, only support int8, float16 and float32"
 
 class FeatTransform:
     """ The base class for feature transformation.

--- a/python/graphstorm/gconstruct/transform.py
+++ b/python/graphstorm/gconstruct/transform.py
@@ -666,8 +666,6 @@ class Noop(FeatTransform):
         assert np.issubdtype(feats.dtype, np.integer) \
                 or np.issubdtype(feats.dtype, np.floating), \
                 f"The feature {self.feat_name} has to be integers or floats."
-        if self.feat_name == "train_mask":
-            print(feats)
         return {self.feat_name: feats}
 
 def parse_feat_ops(confs):

--- a/python/graphstorm/gconstruct/transform.py
+++ b/python/graphstorm/gconstruct/transform.py
@@ -666,6 +666,8 @@ class Noop(FeatTransform):
         assert np.issubdtype(feats.dtype, np.integer) \
                 or np.issubdtype(feats.dtype, np.floating), \
                 f"The feature {self.feat_name} has to be integers or floats."
+        if self.feat_name == "train_mask":
+            print(feats)
         return {self.feat_name: feats}
 
 def parse_feat_ops(confs):

--- a/tests/unit-tests/gconstruct/test_construct_graph.py
+++ b/tests/unit-tests/gconstruct/test_construct_graph.py
@@ -486,7 +486,7 @@ def test_process_features_fp16():
     data = {}
     data["test1"] = np.random.rand(10, 3)
     data["test2"] = np.random.rand(10)
-    data["test3"] = np.random.rand(10)
+    data["test3"] = np.random.rand(10) * 5
     handle, tmpfile = tempfile.mkstemp()
     os.close(handle)
     write_data_hdf5(data, tmpfile)
@@ -518,7 +518,7 @@ def test_process_features_fp16():
     assert rst['test3'].dtype == np.int8
     assert_almost_equal(rst['test1'], data['test1'], decimal=3)
     assert_almost_equal(rst['test2'], data['test2'].reshape(-1, 1), decimal=3)
-    assert_almost_equal(rst['test3'].astype(np.int8), data['test3'].reshape(-1, 1))
+    assert_almost_equal(rst['test3'], data['test3'].reshape(-1, 1).astype(np.int8))
 
     data1 = read_data_hdf5(tmpfile, ['test1', 'test2', 'test3'], in_mem=False)
     rst2 = process_features(data1, ops_rst)
@@ -538,7 +538,7 @@ def test_process_features_fp16():
     assert_almost_equal(rst2['test1'].to_tensor().numpy(), data['test1'], decimal=3)
     assert_almost_equal(rst2['test1'].to_tensor().numpy(), data_slice)
     assert_almost_equal(rst2['test2'], data['test2'].reshape(-1, 1), decimal=3)
-    assert_almost_equal(rst2['test3'].astype(np.int8), data['test3'].reshape(-1, 1))
+    assert_almost_equal(rst2['test3'], data['test3'].reshape(-1, 1).astype(np.int8))
 
 def test_process_features():
     # Just get the features without transformation.

--- a/tests/unit-tests/gconstruct/test_construct_graph.py
+++ b/tests/unit-tests/gconstruct/test_construct_graph.py
@@ -506,7 +506,7 @@ def test_process_features_fp16():
     }]
     (ops_rst, _, _) = parse_feat_ops(feat_op1)
     rst = process_features(data, ops_rst)
-    assert len(rst) == 2
+    assert len(rst) == 3
     assert 'test1' in rst
     assert 'test2' in rst
     assert 'test3' in rst
@@ -523,7 +523,7 @@ def test_process_features_fp16():
     data1 = read_data_hdf5(tmpfile, ['test1', 'test2', 'test3'], in_mem=False)
     rst2 = process_features(data1, ops_rst)
     assert isinstance(rst2["test1"], HDF5Array)
-    assert len(rst2) == 2
+    assert len(rst2) == 3
     assert 'test1' in rst2
     assert 'test2' in rst2
     assert 'test3' in rst

--- a/tests/unit-tests/gconstruct/test_construct_graph.py
+++ b/tests/unit-tests/gconstruct/test_construct_graph.py
@@ -486,6 +486,7 @@ def test_process_features_fp16():
     data = {}
     data["test1"] = np.random.rand(10, 3)
     data["test2"] = np.random.rand(10)
+    data["test3"] = np.random.rand(10)
     handle, tmpfile = tempfile.mkstemp()
     os.close(handle)
     write_data_hdf5(data, tmpfile)
@@ -498,34 +499,46 @@ def test_process_features_fp16():
         "feature_col": "test2",
         "feature_name": "test2",
         "out_dtype": "float16",
+    },{
+        "feature_col": "test3",
+        "feature_name": "test3",
+        "out_dtype": "int8",
     }]
     (ops_rst, _, _) = parse_feat_ops(feat_op1)
     rst = process_features(data, ops_rst)
     assert len(rst) == 2
     assert 'test1' in rst
     assert 'test2' in rst
+    assert 'test3' in rst
     assert (len(rst['test1'].shape)) == 2
     assert (len(rst['test2'].shape)) == 2
+    assert (len(rst['test3'].shape)) == 2
     assert rst['test1'].dtype == np.float16
     assert rst['test2'].dtype == np.float16
+    assert rst['test3'].dtype == np.int8
     assert_almost_equal(rst['test1'], data['test1'], decimal=3)
     assert_almost_equal(rst['test2'], data['test2'].reshape(-1, 1), decimal=3)
+    assert_almost_equal(rst['test3'].astype(np.int8), data['test3'].reshape(-1, 1))
 
-    data1 = read_data_hdf5(tmpfile, ['test1', 'test2'], in_mem=False)
+    data1 = read_data_hdf5(tmpfile, ['test1', 'test2', 'test3'], in_mem=False)
     rst2 = process_features(data1, ops_rst)
     assert isinstance(rst2["test1"], HDF5Array)
     assert len(rst2) == 2
     assert 'test1' in rst2
     assert 'test2' in rst2
+    assert 'test3' in rst
     assert (len(rst2['test1'].to_tensor().shape)) == 2
     assert (len(rst2['test2'].shape)) == 2
+    assert (len(rst['test3'].shape)) == 2
     assert rst2['test1'].to_tensor().dtype == th.float16
     assert rst2['test2'].dtype == np.float16
+    assert rst['test3'].dtype == np.int8
     data_slice = rst2['test1'][np.arange(10)]
     assert data_slice.dtype == np.float16
     assert_almost_equal(rst2['test1'].to_tensor().numpy(), data['test1'], decimal=3)
     assert_almost_equal(rst2['test1'].to_tensor().numpy(), data_slice)
     assert_almost_equal(rst2['test2'], data['test2'].reshape(-1, 1), decimal=3)
+    assert_almost_equal(rst2['test3'].astype(np.int8), data['test3'].reshape(-1, 1))
 
 def test_process_features():
     # Just get the features without transformation.


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
