### PR TITLE
Increasing IAM role token expiry timeout

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -37,6 +37,7 @@ jobs:
       uses: aws-actions/configure-aws-credentials@v1
       with:
         role-to-assume: arn:aws:iam::698571788627:role/github-oidc-role
+        role-duration-seconds: 14400
         aws-region: us-east-1
     - name: Checkout repository
       uses: actions/checkout@v3


### PR DESCRIPTION
*Description of changes:*
This PR is to increase the timeout assumed by the CI IAM roles.
This increase the timeout of any long tests running in the CI from 1 hour to 4 hours.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
