### PR TITLE
fix fanout parser

### DIFF
--- a/python/graphstorm/config/argument.py
+++ b/python/graphstorm/config/argument.py
@@ -628,7 +628,7 @@ class GSConfig:
                 # Each etype should be a canonical etype in format of
                 # srcntype/relation/dstntype
 
-                fanout = [{tuple(k.split(":")[0].split('/')): int(k.split(":")[1]) \
+                fanout = [{k.split(":")[0]: int(k.split(":")[1]) \
                     for k in val.split("@")} for val in fanout]
         except Exception: # pylint: disable=broad-except
             assert False, f"{fot_name} Fanout should either in format 20,10 " \


### PR DESCRIPTION
*Issue #, if available:
Tested in DGL 1.0.3, there's a bug of fanout parser for heterogeneous graph. To be specific, there's a if check for canonical_etype by checking wether it's tuple format at ```"/usr/local/lib/python3.8/dist-packages/dgl/distributed/graph_partition_book.py", line 933, in to_canonical_etype
    raise DGLError('Edge type "{}" does not exist.'.format(etype))```, but the current fanout parser for graphstorm parse the fanout into the format like ```('etype',): 20```. The correct parser should be convert the fanout into ```('ntype', 'etype', 'ntype'): 20```

*Description of changes:*
fix the bug by updating the fanout parser.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
