### PR TITLE
[SageMaker][Docker] Clone more recent DGL code, remove cache files, use Buildkit.

### DIFF
--- a/docker/build_docker_sagemaker.sh
+++ b/docker/build_docker_sagemaker.sh
@@ -44,7 +44,9 @@ DOCKER_FULLNAME="${IMAGE_NAME}:${TAG}"
 echo "Build a sagemaker docker image ${DOCKER_FULLNAME}"
 
 if [ $IMAGE_TYPE = "gpu" ] || [ $IMAGE_TYPE = "cpu" ]; then
-    docker build --build-arg DEVICE=$IMAGE_TYPE -f $GSF_HOME"docker/sagemaker/Dockerfile.sm" . -t $DOCKER_FULLNAME
+    # User Buildkit to avoid pulling both CPU and GPU images
+    DOCKER_BUILDKIT=1 docker build --build-arg DEVICE=$IMAGE_TYPE \
+        -f $GSF_HOME"docker/sagemaker/Dockerfile.sm" . -t $DOCKER_FULLNAME
 else
     echo "Image type can only be \"gpu\" or \"cpu\", but get \""$IMAGE_TYPE"\""
     # remove the temporary code folder

--- a/docker/sagemaker/Dockerfile.sm
+++ b/docker/sagemaker/Dockerfile.sm
@@ -6,25 +6,25 @@ ARG DEVICE=gpu
 FROM 763104351884.dkr.ecr.us-east-1.amazonaws.com/pytorch-training:1.13.1-gpu-py39-cu117-ubuntu20.04-sagemaker as branch-gpu
 ENV dev_type=GPU
 # Install DGL GPU version
-RUN pip3 install dgl==1.0.4+cu117 -f https://data.dgl.ai/wheels/cu117/repo.html
+RUN pip3 install dgl==1.0.4+cu117 -f https://data.dgl.ai/wheels/cu117/repo.html && rm -rf /root/.cache
 
 FROM 763104351884.dkr.ecr.us-east-1.amazonaws.com/pytorch-training:1.13.1-cpu-py39-ubuntu20.04-sagemaker as branch-cpu
 ENV dev_type=CPU
 # Install DGL CPU version
-RUN pip3 install dgl==1.0.4 -f https://data.dgl.ai/wheels-internal/repo.html
+RUN pip3 install dgl==1.0.4 -f https://data.dgl.ai/wheels-internal/repo.html && rm -rf /root/.cache
 
 FROM branch-${DEVICE} AS final
-RUN echo "Build image for ${dev_type}"
 
 LABEL maintainer="Amazon AI Graph ML team"
 
 # Install related Python packages
-RUN pip3 install ogb==1.3.6 scipy pyarrow boto3 scikit-learn transformers==4.28.1
+RUN pip3 install ogb==1.3.6 scipy pyarrow boto3 scikit-learn transformers==4.28.1 \
+    && rm -rf /root/.cache
 
 # Install MPI etc needed by DistDGL
 RUN apt-get update; apt-get install -y --no-install-recommends libopenmpi-dev \
     build-essential software-properties-common; add-apt-repository ppa:ubuntu-toolchain-r/test; \
-    apt-get update; apt-get upgrade libstdc++6 -y
+    apt-get update; apt-get upgrade libstdc++6 -y && rm -rf /var/lib/apt/lists/*
 
 # Copy workaround script for incorrect hostname
 COPY build_artifacts/changehostname.c /opt/ml/code/
@@ -38,7 +38,7 @@ ENV PYTHONPATH="/opt/ml/code/graphstorm/python/:${PYTHONPATH}"
 RUN cp /opt/ml/code/graphstorm/sagemaker/run/* /opt/ml/code/
 
 # Download DGL source code
-RUN cd /root; git clone https://github.com/dmlc/dgl.git; cd dgl; git checkout -b 1.0.2 1.0.2
+RUN cd /root; git clone https://github.com/dmlc/dgl.git; cd dgl; git checkout -b 1.1.0 1.1.0
 # Un-comment if we prefer a local DGL distribution
 # COPY dgl /root/dgl
 ENV PYTHONPATH="/root/dgl/tools/:${PYTHONPATH}"


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

* We clone a more recent version of DGL on to the image, that includes changes needed to run partitioning on SageMaker.
* We clean up temporary cache files after pip/apt installations, as listed in [Dockerfile best practices](https://docs.docker.com/develop/develop-images/dockerfile_best-practices/#apt-get). This reduces image size by ~300MB.
* Enable [buildkit](https://docs.docker.com/build/buildkit/) if available for builds. This will avoid pulling both CPU and GPU images among other optimizations.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
