### PR TITLE
[Fix] Fix node id mapping back logic

### DIFF
--- a/python/graphstorm/model/utils.py
+++ b/python/graphstorm/model/utils.py
@@ -367,7 +367,9 @@ def save_embeddings(model_path, embeddings, local_rank, world_size,
                 if local_rank == 0:
                     assert name in node_id_mappings, \
                         f"node id mapping for ntype {name} should exists"
-                    node_id_mapping = node_id_mappings[name]
+                    # new mapping back index
+                    ori_node_id_mapping = node_id_mappings[name]
+                    _, node_id_mapping = th.sort(ori_node_id_mapping)
                 else:
                     node_id_mapping = None
 
@@ -434,10 +436,16 @@ def shuffle_predict(predictions, id_mapping_file, pred_type,
         device : torch device
             Device used to do data shuffling.
     """
-    id_mapping = th.load(id_mapping_file) if local_rank == 0 else None
     # In most of cases, id_mapping is a dict for heterogeneous graph.
     # For homogeneous graph, it is just a tensor.
-    id_mapping = id_mapping[pred_type] if isinstance(id_mapping, dict) else id_mapping
+    if local_rank == 0:
+        id_mappings = th.load(id_mapping_file)
+        ori_id_mapping = id_mappings[pred_type] if isinstance(id_mappings, dict) else id_mappings
+        # new mapping back index
+        _, id_mapping = th.sort(ori_id_mapping)
+    else:
+        id_mapping = None
+        
     local_id_mapping = _exchange_node_id_mapping(
                 local_rank, world_size, device, id_mapping,
                 len(predictions)).cpu() # predictions are stored in CPU

--- a/python/graphstorm/model/utils.py
+++ b/python/graphstorm/model/utils.py
@@ -352,8 +352,11 @@ def save_embeddings(model_path, embeddings, local_rank, world_size,
     if node_id_mapping_file is not None:
         if isinstance(embeddings, (dgl.distributed.DistTensor, LazyDistTensor)):
             # only host 0 will load node id mapping from disk
-            node_id_mapping = th.load(node_id_mapping_file) \
-                if local_rank == 0 else None
+            if local_rank == 0:
+                ori_node_id_mapping = th.load(node_id_mapping_file)
+                _, node_id_mapping = th.sort(ori_node_id_mapping)
+            else:
+                None
 
             nid_mapping = _exchange_node_id_mapping(
                 local_rank, world_size, device, node_id_mapping, len(embeddings))

--- a/python/graphstorm/model/utils.py
+++ b/python/graphstorm/model/utils.py
@@ -356,7 +356,7 @@ def save_embeddings(model_path, embeddings, local_rank, world_size,
                 ori_node_id_mapping = th.load(node_id_mapping_file)
                 _, node_id_mapping = th.sort(ori_node_id_mapping)
             else:
-                None
+                node_id_mapping = None
 
             nid_mapping = _exchange_node_id_mapping(
                 local_rank, world_size, device, node_id_mapping, len(embeddings))

--- a/python/graphstorm/model/utils.py
+++ b/python/graphstorm/model/utils.py
@@ -445,7 +445,7 @@ def shuffle_predict(predictions, id_mapping_file, pred_type,
         _, id_mapping = th.sort(ori_id_mapping)
     else:
         id_mapping = None
-        
+
     local_id_mapping = _exchange_node_id_mapping(
                 local_rank, world_size, device, id_mapping,
                 len(predictions)).cpu() # predictions are stored in CPU

--- a/tests/unit-tests/test_utils.py
+++ b/tests/unit-tests/test_utils.py
@@ -36,7 +36,6 @@ def gen_embedding_with_nid_mapping(num_embs):
     emb = th.rand((num_embs, 12))
     ori_nid_mapping = th.randperm(num_embs)
     _, nid_mapping = th.sort(ori_nid_mapping)
-
     emb = LazyDistTensor(emb, th.arange(num_embs))
     return emb, ori_nid_mapping, nid_mapping
 

--- a/tests/unit-tests/test_utils.py
+++ b/tests/unit-tests/test_utils.py
@@ -41,7 +41,8 @@ def gen_embedding_with_nid_mapping(num_embs):
 def gen_predict_with_nid_mapping(num_embs):
     pred = th.rand((num_embs, 12)) * 10
     pred = pred.long()
-    nid_mapping = th.randperm(num_embs)
+    ori_nid_mapping = th.randperm(num_embs)
+    _, nid_mapping = th.sort(ori_nid_mapping)
     return pred, nid_mapping
 
 def helper_save_embedding(tmpdirname):

--- a/tests/unit-tests/test_utils.py
+++ b/tests/unit-tests/test_utils.py
@@ -43,7 +43,7 @@ def gen_predict_with_nid_mapping(num_embs):
     pred = pred.long()
     ori_nid_mapping = th.randperm(num_embs)
     _, nid_mapping = th.sort(ori_nid_mapping)
-    return pred, nid_mapping
+    return pred[nid_mapping], ori_nid_mapping
 
 def helper_save_embedding(tmpdirname):
     random_emb = th.rand((103, 12))

--- a/tests/unit-tests/test_utils.py
+++ b/tests/unit-tests/test_utils.py
@@ -231,6 +231,7 @@ def test_shuffle_predict(num_embs, backend):
      # node mapping is a dict
     with tempfile.TemporaryDirectory() as tmpdirname:
         pred, ori_nid_mapping, nid_mapping = gen_predict_with_nid_mapping(num_embs)
+        nid_mapping = {"node": nid_mapping}
         ori_nid_mapping = {"node": ori_nid_mapping}
         save_maps(tmpdirname, "node_mapping", ori_nid_mapping)
         nid_mapping_file = os.path.join(tmpdirname, "node_mapping.pt")

--- a/tests/unit-tests/test_utils.py
+++ b/tests/unit-tests/test_utils.py
@@ -43,7 +43,7 @@ def gen_predict_with_nid_mapping(num_embs):
     pred = pred.long()
     ori_nid_mapping = th.randperm(num_embs)
     _, nid_mapping = th.sort(ori_nid_mapping)
-    return pred[nid_mapping], ori_nid_mapping
+    return pred, ori_nid_mapping, nid_mapping
 
 def helper_save_embedding(tmpdirname):
     random_emb = th.rand((103, 12))
@@ -198,8 +198,8 @@ def test_shuffle_predict(num_embs, backend):
 
     # node_mapping is tensor
     with tempfile.TemporaryDirectory() as tmpdirname:
-        pred, nid_mapping = gen_predict_with_nid_mapping(num_embs)
-        save_maps(tmpdirname, "node_mapping", nid_mapping)
+        pred, ori_nid_mapping, nid_mapping = gen_predict_with_nid_mapping(num_embs)
+        save_maps(tmpdirname, "node_mapping", ori_nid_mapping)
         nid_mapping_file = os.path.join(tmpdirname, "node_mapping.pt")
         ctx = mp.get_context('spawn')
         conn1, conn2 = mp.Pipe()
@@ -230,9 +230,9 @@ def test_shuffle_predict(num_embs, backend):
 
      # node mapping is a dict
     with tempfile.TemporaryDirectory() as tmpdirname:
-        pred, nid_mapping = gen_predict_with_nid_mapping(num_embs)
-        nid_mapping = {"node": nid_mapping}
-        save_maps(tmpdirname, "node_mapping", nid_mapping)
+        pred, ori_nid_mapping, nid_mapping = gen_predict_with_nid_mapping(num_embs)
+        ori_nid_mapping = {"node": ori_nid_mapping}
+        save_maps(tmpdirname, "node_mapping", ori_nid_mapping)
         nid_mapping_file = os.path.join(tmpdirname, "node_mapping.pt")
         ctx = mp.get_context('spawn')
         conn1, conn2 = mp.Pipe()


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This PR fixes the previous node ID mapping logic. Not use the node_mapping.pt node IDs to map back, but use the index of node IDs to map back.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
