### PR TITLE
Fix CI end2end test

### DIFF
--- a/tests/end2end-tests/graphstorm-ec/mgpu_test.sh
+++ b/tests/end2end-tests/graphstorm-ec/mgpu_test.sh
@@ -26,7 +26,7 @@ error_and_exit () {
 echo "**************dataset: Generated multilabel MovieLens EC, RGCN layer: 1, node feat: generated feature, inference: full graph, exclude-training-targets: True"
 python3 -m graphstorm.run.gs_edge_classification --workspace $GS_HOME/training_scripts/gsgnn_ep/ --num-trainers $NUM_TRAINERS --num-servers 1 --num-samplers 0 --part-config /data/movielen_100k_multi_label_ec/movie-lens-100k.json --ip-config ip_list.txt --ssh-port 2222 --cf ml_ec.yaml --exclude-training-targets True --multilabel true --num-classes 6 --node-feat-name movie:title user:feat --use-mini-batch-infer false --topk-model-to-save 1  --save-embed-path /data/gsgnn_ec/emb/ --save-model-path /data/gsgnn_ec/ --save-model-frequency 1000 --logging-file /tmp/train_log.txt --logging-level debug
 
-error_and_exit ${PIPESTATUS[0]}
+error_and_exit $?
 
 # check prints
 cnt=$(grep "save_embed_path: /data/gsgnn_ec/emb/" /tmp/train_log.txt | wc -l)
@@ -79,7 +79,7 @@ rm /tmp/train_log.txt
 echo "**************dataset: Generated multilabel MovieLens EC, load only embed layer and GNN layer of the saved model to retrain"
 python3 -m graphstorm.run.gs_edge_classification --workspace $GS_HOME/training_scripts/gsgnn_ep/ --num-trainers $NUM_TRAINERS --num-servers 1 --num-samplers 0 --part-config /data/movielen_100k_multi_label_ec/movie-lens-100k.json --ip-config ip_list.txt --ssh-port 2222 --cf ml_ec.yaml --exclude-training-targets True --multilabel true --num-classes 6 --node-feat-name movie:title user:feat --use-mini-batch-infer false --topk-model-to-save 1  --restore-model-path /data/gsgnn_ec/epoch-$best_epoch/ --restore-model-layers embed,gnn --save-model-path /data/gsgnn_ec_retrain/ --save-model-frequency 1000
 
-error_and_exit ${PIPESTATUS[0]}
+error_and_exit $?
 
 cnt=$(ls -l /data/gsgnn_ec_retrain/ | grep epoch | wc -l)
 if test $cnt != 1
@@ -91,7 +91,7 @@ fi
 echo "**************dataset: Generated multilabel MovieLens EC, do inference on saved model"
 python3 -m graphstorm.run.gs_edge_classification --inference --workspace $GS_HOME/inference_scripts/ep_infer --num-trainers $NUM_INFO_TRAINERS --num-servers 1 --num-samplers 0 --part-config /data/movielen_100k_multi_label_ec/movie-lens-100k.json --ip-config ip_list.txt --ssh-port 2222 --cf ml_ec_infer.yaml  --multilabel true --num-classes 6 --node-feat-name movie:title user:feat --use-mini-batch-infer false --save-embed-path /data/gsgnn_ec/infer-emb/ --restore-model-path /data/gsgnn_ec/epoch-$best_epoch/ --save-prediction-path /data/gsgnn_ec/prediction/ --logging-file /tmp/log.txt  --logging-level debug
 
-error_and_exit ${PIPESTATUS[0]}
+error_and_exit $?
 
 cnt=$(grep "| Test accuracy" /tmp/log.txt | wc -l)
 if test $cnt -ne 1
@@ -145,7 +145,7 @@ rm -fr /data/gsgnn_ec/*
 echo "**************dataset: Generated MovieLens EC, language model only, node feat: text feature, inference: full graph, train_nodes 10"
 python3 -m graphstorm.run.gs_edge_classification --lm-encoder-only --workspace $GS_HOME/training_scripts/gsgnn_ep/ --num-trainers $NUM_TRAINERS --num-servers 1 --num-samplers 0 --part-config /data/movielen_100k_lm_encoder_train_val_1p_4t/movie-lens-100k-text.json --ip-config ip_list.txt --ssh-port 2222 --cf ml_lm_ec.yaml --num-classes 6 --use-mini-batch-infer false --topk-model-to-save 1  --save-embed-path /data/gsgnn_ec_lm/emb/ --save-model-path /data/gsgnn_ec_lm/ --save-model-frequency 1000 --logging-file /tmp/train_log.txt
 
-error_and_exit ${PIPESTATUS[0]}
+error_and_exit $?
 
 best_epoch=$(grep "successfully save the model to" /tmp/train_log.txt | tail -1 | tr -d '\n' | tail -c 1)
 echo "The best model is saved in epoch $best_epoch"
@@ -155,7 +155,7 @@ rm /tmp/train_log.txt
 echo "**************dataset: Generated MovieLens EC, node feat: text feature, do inference on saved model"
 python3 -m graphstorm.run.gs_edge_classification --lm-encoder-only --inference --workspace $GS_HOME/inference_scripts/ep_infer --num-trainers $NUM_INFO_TRAINERS --num-servers 1 --num-samplers 0 --part-config /data/movielen_100k_lm_encoder_train_val_1p_4t/movie-lens-100k-text.json --ip-config ip_list.txt --ssh-port 2222 --cf ml_lm_ec_infer.yaml   --num-classes 6 --use-mini-batch-infer false --save-embed-path /data/gsgnn_ec_lm/infer-emb/ --restore-model-path /data/gsgnn_ec_lm/epoch-$best_epoch/
 
-error_and_exit ${PIPESTATUS[0]}
+error_and_exit $?
 
 cd $GS_HOME/tests/end2end-tests/
 python3 check_infer.py --train_embout /data/gsgnn_ec_lm/emb/ --infer_embout /data/gsgnn_ec_lm/infer-emb/

--- a/tests/end2end-tests/graphstorm-ec/test.sh
+++ b/tests/end2end-tests/graphstorm-ec/test.sh
@@ -40,7 +40,7 @@ error_and_exit $?
 echo "**************dataset: Test edge classification, RGCN layer: 1, node feat: fixed HF BERT, BERT nodes: movie, inference: mini-batch, no test"
 python3 -m graphstorm.run.gs_edge_classification --workspace $GS_HOME/training_scripts/gsgnn_ep/ --num-trainers $NUM_TRAINERS --num-servers 1 --num-samplers 0 --part-config /data/movielen_100k_ec_no_test_1p_4t/movie-lens-100k.json --ip-config ip_list.txt --ssh-port 2222 --cf ml_ec.yaml --num-epochs 1 --logging-file /tmp/train_log.txt
 
-error_and_exit ${PIPESTATUS[0]}
+error_and_exit $?
 
 bst_cnt=$(grep "Best Test accuracy: N/A" /tmp/train_log.txt | wc -l)
 if test $bst_cnt -lt 1
@@ -113,7 +113,7 @@ error_and_exit $?
 echo "**************dataset: Test edge classification, RGCN layer: 1, node feat: fixed HF BERT, BERT nodes: movie, inference: mini-batch early stop"
 python3 -m graphstorm.run.gs_edge_classification --workspace $GS_HOME/training_scripts/gsgnn_ep/ --num-trainers $NUM_TRAINERS --num-servers 1 --num-samplers 0 --part-config /data/movielen_100k_ec_1p_4t/movie-lens-100k.json --ip-config ip_list.txt --ssh-port 2222  --cf ml_ec.yaml --part-config /data/movielen_100k_ec_1p_4t/movie-lens-100k.json --use-early-stop True --early-stop-burnin-rounds 2 -e 30 --early-stop-rounds 3 --eval-frequency 100 --lr 0.01 --logging-file /tmp/exec.log
 
-error_and_exit ${PIPESTATUS[0]}
+error_and_exit $?
 
 # check early stop
 cnt=$(cat /tmp/exec.log | grep "Evaluation step" | wc -l)

--- a/tests/end2end-tests/graphstorm-er/test.sh
+++ b/tests/end2end-tests/graphstorm-er/test.sh
@@ -35,7 +35,7 @@ error_and_exit $?
 echo "**************dataset: Test edge regression, RGCN layer: 1, node feat: fixed HF BERT, BERT nodes: movie, inference: mini-batch, no test"
 python3 -m graphstorm.run.gs_edge_regression --workspace $GS_HOME/training_scripts/gsgnn_ep/ --num-trainers $NUM_TRAINERS --num-servers 1 --num-samplers 0 --part-config /data/movielen_100k_er_no_test_1p_4t/movie-lens-100k.json --ip-config ip_list.txt --ssh-port 2222 --cf ml_er.yaml  --num-epochs 1 --logging-file /tmp/train_log.txt
 
-error_and_exit ${PIPESTATUS[0]}
+error_and_exit $?
 
 bst_cnt=$(grep "Best Test rmse: N/A" /tmp/train_log.txt | wc -l)
 if test $bst_cnt -lt 1

--- a/tests/end2end-tests/graphstorm-lp/mgpu_test.sh
+++ b/tests/end2end-tests/graphstorm-lp/mgpu_test.sh
@@ -29,7 +29,7 @@ df /dev/shm -h
 echo "**************dataset: Movielens, RGCN layer 2, node feat: fixed HF BERT & sparse embed, BERT nodes: movie, inference: full-graph, negative_sampler: joint, exclude_training_targets: true, save model"
 python3 -m graphstorm.run.gs_link_prediction --workspace $GS_HOME/training_scripts/gsgnn_lp --num-trainers $NUM_TRAINERS --num-servers 1 --num-samplers 0 --part-config /data/movielen_100k_lp_train_val_1p_4t/movie-lens-100k.json --ip-config ip_list.txt --ssh-port 2222 --cf ml_lp.yaml --fanout '10,15' --num-layers 2 --use-mini-batch-infer false  --use-node-embeddings true --eval-batch-size 1024 --exclude-training-targets True --reverse-edge-types-map user,rating,rating-rev,movie  --save-model-path /data/gsgnn_lp_ml_dot/ --topk-model-to-save 1 --save-model-frequency 1000 --save-embed-path /data/gsgnn_lp_ml_dot/emb/ --logging-file /tmp/train_log.txt --logging-level debug
 
-error_and_exit ${PIPESTATUS[0]}
+error_and_exit $?
 
 # check prints
 cnt=$(grep "save_embed_path: /data/gsgnn_lp_ml_dot/emb/" /tmp/train_log.txt | wc -l)
@@ -110,7 +110,7 @@ fi
 echo "**************dataset: Movielens, RGCN layer 2, node feat: fixed HF BERT & sparse embed, BERT nodes: movie, inference: full-graph, negative_sampler: joint, decoder: DistMult, exclude_training_targets: true, save model"
 python3 -m graphstorm.run.gs_link_prediction --workspace $GS_HOME/training_scripts/gsgnn_lp --num-trainers $NUM_TRAINERS --num-servers 1 --num-samplers 0 --part-config /data/movielen_100k_lp_train_val_1p_4t/movie-lens-100k.json --ip-config ip_list.txt --ssh-port 2222 --cf ml_lp.yaml --fanout '10,15' --num-layers 2 --use-mini-batch-infer false  --use-node-embeddings true  --eval-batch-size 1024 --save-model-path /data/gsgnn_lp_ml_distmult/ --topk-model-to-save 1 --save-model-frequency 1000 --save-embed-path /data/gsgnn_lp_ml_distmult/emb/ --lp-decoder-type distmult --train-etype user,rating,movie movie,rating-rev,user --logging-file /tmp/train_log.txt
 
-error_and_exit ${PIPESTATUS[0]}
+error_and_exit $?
 
 cnt=$(ls -l /data/gsgnn_lp_ml_distmult/ | grep epoch | wc -l)
 if test $cnt != 1
@@ -141,7 +141,7 @@ fi
 echo "**************dataset: Movielens, do inference on saved model, decoder: dot"
 python3 -m graphstorm.run.gs_link_prediction --inference --workspace $GS_HOME/inference_scripts/lp_infer --num-trainers $NUM_INFO_TRAINERS --num-servers 1 --num-samplers 0 --part-config /data/movielen_100k_lp_train_val_1p_4t/movie-lens-100k.json --ip-config ip_list.txt --ssh-port 2222 --cf ml_lp_infer.yaml --fanout '10,15' --num-layers 2 --use-mini-batch-infer false --use-node-embeddings true --eval-batch-size 1024 --save-embed-path /data/gsgnn_lp_ml_dot/infer-emb/ --restore-model-path /data/gsgnn_lp_ml_dot/epoch-$best_epoch_dot/ --logging-file /tmp/log.txt
 
-error_and_exit ${PIPESTATUS[0]}
+error_and_exit $?
 
 cnt=$(grep "| Test mrr" /tmp/log.txt | wc -l)
 if test $cnt -ne 1
@@ -183,7 +183,7 @@ rm /tmp/log.txt
 echo "**************dataset: Movielens, do inference on saved model, decoder: DistMult"
 python3 -m graphstorm.run.gs_link_prediction --inference --workspace $GS_HOME/inference_scripts/lp_infer --num-trainers $NUM_INFO_TRAINERS --num-servers 1 --num-samplers 0 --part-config /data/movielen_100k_lp_train_val_1p_4t/movie-lens-100k.json --ip-config ip_list.txt --ssh-port 2222 --cf ml_lp_infer.yaml --fanout '10,15' --num-layers 2 --use-mini-batch-infer false --use-node-embeddings true --eval-batch-size 1024 --save-embed-path /data/gsgnn_lp_ml_distmult/infer-emb/ --restore-model-path /data/gsgnn_lp_ml_distmult/epoch-$best_epoch_distmult/ --lp-decoder-type distmult --no-validation False --train-etype user,rating,movie movie,rating-rev,user
 
-error_and_exit ${PIPESTATUS[0]}
+error_and_exit $?
 
 cd $GS_HOME/tests/end2end-tests/graphstorm-lp/
 python3 $GS_HOME/tests/end2end-tests/check_infer.py --train_embout /data/gsgnn_lp_ml_dot/emb/ --infer_embout /data/gsgnn_lp_ml_dot/infer-emb/ --link_prediction
@@ -218,7 +218,7 @@ fi
 echo "**************dataset: Movielens, RGCN layer 2, node feat: fixed HF BERT & sparse embed, BERT nodes: movie, inference: full-graph, negative_sampler: joint, exclude_training_targets: true, save model, early stop"
 python3 -m graphstorm.run.launch --workspace $GS_HOME/training_scripts/gsgnn_lp --num-trainers $NUM_TRAINERS --num-servers 1 --num-samplers 0 --part-config /data/movielen_100k_lp_train_val_1p_4t/movie-lens-100k.json --ip-config ip_list.txt --ssh-port 2222 $GS_HOME/python/graphstorm/run/gsgnn_lp/gsgnn_lp.py --cf ml_lp.yaml --fanout '10,15' --num-layers 2 --use-mini-batch-infer false  --use-node-embeddings true --exclude-training-targets True --reverse-edge-types-map user,rating,rating-rev,movie --save-model-path /data/gsgnn_lp_ml_dot/ --topk-model-to-save 3 --save-model-frequency 1000 --save-embed-path /data/gsgnn_lp_ml_dot/emb/ --use-early-stop True --early-stop-burnin-rounds 3 -e 30 --early-stop-rounds 2 --early-stop-strategy consecutive_increase --logging-file /tmp/exec.log
 
-error_and_exit ${PIPESTATUS[0]}
+error_and_exit $?
 
 # check early stop
 cnt=$(cat /tmp/exec.log | grep "Evaluation step" | wc -l)
@@ -241,7 +241,7 @@ rm -fr /data/gsgnn_lp_ml_dot/*
 echo "**************dataset: Movielens, RGCN layer 1, BERT nodes: movie, user , inference: full-graph, negative_sampler: joint, decoder: Dot Product, exclude_training_targets: true, save model"
 python3 -m graphstorm.run.launch --workspace $GS_HOME/training_scripts/gsgnn_lp --num-trainers $NUM_TRAINERS --num-servers 1 --num-samplers 0 --part-config /data/movielen_100k_lm_encoder_lp_train_val_1p_4t/movie-lens-100k-text.json --ip-config ip_list.txt --ssh-port 2222 $GS_HOME/python/graphstorm/run/gsgnn_lp/gsgnn_lp.py --cf ml_lp_text.yaml --fanout '4' --num-layers 1 --use-mini-batch-infer false  --use-node-embeddings true --save-model-path /data/gsgnn_lp_ml_dotprod_text/ --topk-model-to-save 1 --save-model-frequency 1000 --save-embed-path /data/gsgnn_lp_ml_dotprod_text/emb/ --lp-decoder-type dot_product --train-etype user,rating,movie --logging-file /tmp/train_log.txt
 
-error_and_exit ${PIPESTATUS[0]}
+error_and_exit $?
 
 best_epoch_dotprod=$(grep "successfully save the model to" /tmp/train_log.txt | tail -1 | tr -d '\n' | tail -c 1)
 echo "The best model is saved in epoch $best_epoch_dotprod"
@@ -251,7 +251,7 @@ rm /tmp/train_log.txt
 echo "**************dataset: Movielens text, do inference on saved model, decoder: Dot Product"
 python3 -m graphstorm.run.launch --workspace $GS_HOME/inference_scripts/lp_infer --num-trainers $NUM_INFO_TRAINERS --num-servers 1 --num-samplers 0 --part-config /data/movielen_100k_lm_encoder_lp_train_val_1p_4t/movie-lens-100k-text.json --ip-config ip_list.txt --ssh-port 2222 $GS_HOME/python/graphstorm/run/gsgnn_lp/lp_infer_gnn.py --cf ml_lp_text_infer.yaml --fanout '4' --num-layers 1 --use-mini-batch-infer false --use-node-embeddings true   --save-embed-path /data/gsgnn_lp_ml_dotprod_text/infer-emb/ --restore-model-path /data/gsgnn_lp_ml_dotprod_text/epoch-$best_epoch_dotprod/ --lp-decoder-type dot_product --no-validation False --train-etype user,rating,movie
 
-error_and_exit ${PIPESTATUS[0]}
+error_and_exit $?
 
 python3 $GS_HOME/tests/end2end-tests/check_infer.py --train_embout /data/gsgnn_lp_ml_dotprod_text/emb/ --infer_embout /data/gsgnn_lp_ml_dotprod_text/infer-emb/ --link_prediction
 
@@ -292,7 +292,7 @@ error_and_exit $?
 echo "**************dataset: Movielens, RGCN layer 1, node feat: fixed HF BERT & sparse embed, BERT nodes: movie, inference: full-graph, negative_sampler: joint, decoder: DistMult, exclude_training_targets: true, save model, train_etype: None"
 python3 -m graphstorm.run.gs_link_prediction --workspace $GS_HOME/training_scripts/gsgnn_lp --num-trainers $NUM_TRAINERS --num-servers 1 --num-samplers 0 --part-config /data/movielen_100k_lp_train_val_1p_4t/movie-lens-100k.json --ip-config ip_list.txt --ssh-port 2222 --cf ml_lp_none_train_etype.yaml --fanout '5' --num-layers 1 --use-mini-batch-infer false  --use-node-embeddings true --save-model-path /data/gsgnn_lp_ml_distmult_all_etype/ --topk-model-to-save 1 --save-model-frequency 1000 --save-embed-path /data/gsgnn_lp_ml_distmult_all_etype/emb/ --lp-decoder-type distmult --logging-file /tmp/train_log.txt
 
-error_and_exit ${PIPESTATUS[0]}
+error_and_exit $?
 
 cnt=$(ls -l /data/gsgnn_lp_ml_distmult_all_etype/ | grep epoch | wc -l)
 if test $cnt != 1
@@ -309,7 +309,7 @@ rm /tmp/train_log.txt
 echo "**************dataset: Movielens, do inference on saved model, decoder: DistMult, eval_etype: None"
 python3 -m graphstorm.run.gs_link_prediction --inference --workspace $GS_HOME/inference_scripts/lp_infer --num-trainers $NUM_INFO_TRAINERS --num-servers 1 --num-samplers 0 --part-config /data/movielen_100k_lp_train_val_1p_4t/movie-lens-100k.json --ip-config ip_list.txt --ssh-port 2222 --cf ml_lp_none_train_etype_infer.yaml --fanout '5' --num-layers 1 --use-mini-batch-infer false  --use-node-embeddings true  --save-embed-path /data/gsgnn_lp_ml_distmult_all_etype/infer-emb/ --restore-model-path /data/gsgnn_lp_ml_distmult_all_etype/epoch-$best_epoch_distmult/ --lp-decoder-type distmult --no-validation False
 
-error_and_exit ${PIPESTATUS[0]}
+error_and_exit $?
 
 python3 $GS_HOME/tests/end2end-tests/check_infer.py --train_embout /data/gsgnn_lp_ml_distmult_all_etype/emb/ --infer_embout /data/gsgnn_lp_ml_distmult_all_etype/infer-emb/ --link_prediction
 
@@ -320,7 +320,7 @@ rm -fr /data/gsgnn_lp_ml_distmult_all_etype/*
 echo "**************dataset: Movielens, Bert only, inference: full-graph, negative_sampler: joint, decoder: Dot, save model"
 python3 -m graphstorm.run.gs_link_prediction --lm-encoder-only --workspace $GS_HOME/training_scripts/gsgnn_lp --num-trainers $NUM_TRAINERS --num-servers 1 --num-samplers 0 --part-config /data/movielen_100k_lm_encoder_lp_train_val_1p_4t/movie-lens-100k-text.json --ip-config ip_list.txt --ssh-port 2222 --cf ml_lm_lp.yaml --save-model-path /data/gsgnn_lp_ml_lm_dot_all_etype/ --topk-model-to-save 1 --save-model-frequency 1000 --save-embed-path /data/gsgnn_lp_ml_lm_dot_all_etype/emb/ --lp-decoder-type dot_product --logging-file /tmp/train_log.txt
 
-error_and_exit ${PIPESTATUS[0]}
+error_and_exit $?
 
 cnt=$(ls -l /data/gsgnn_lp_ml_lm_dot_all_etype/ | grep epoch | wc -l)
 if test $cnt != 1
@@ -349,7 +349,7 @@ rm -fr /data/gsgnn_lp_ml_lm_dot_all_etype/*
 echo "**************dataset: Movielens, input encoder with Bert, inference: full-graph, negative_sampler: joint, decoder: Dot, save model"
 python3 -m graphstorm.run.launch --workspace $GS_HOME/training_scripts/gsgnn_lp --num-trainers $NUM_TRAINERS --num-servers 1 --num-samplers 0 --part-config /data/movielen_100k_lm_encoder_lp_train_val_1p_4t/movie-lens-100k-text.json --ip-config ip_list.txt --ssh-port 2222 $GS_HOME/python/graphstorm/run/gsgnn_lp/gsgnn_lm_lp.py --cf ml_lm_lp.yaml  --save-model-path /data/gsgnn_lp_ml_lmmlp_dot_all_etype/ --topk-model-to-save 1 --save-model-frequency 1000 --save-embed-path /data/gsgnn_lp_ml_lmmlp_dot_all_etype/emb/ --lp-decoder-type dot_product --model-encoder-type mlp --logging-file /tmp/train_log.txt
 
-error_and_exit ${PIPESTATUS[0]}
+error_and_exit $?
 
 cnt=$(ls -l /data/gsgnn_lp_ml_lmmlp_dot_all_etype/ | grep epoch | wc -l)
 if test $cnt != 1

--- a/tests/end2end-tests/graphstorm-lp/test.sh
+++ b/tests/end2end-tests/graphstorm-lp/test.sh
@@ -40,7 +40,7 @@ error_and_exit $?
 echo "**************dataset: Movielens, RGCN layer 1, node feat: fixed HF BERT, BERT nodes: movie, inference: mini-batch, negative_sampler: joint, exclude_training_targets: false, no test"
 python3 -m graphstorm.run.gs_link_prediction --workspace $GS_HOME/training_scripts/gsgnn_lp --num-trainers $NUM_TRAINERS --num-servers 1 --num-samplers 0 --part-config /data/movielen_100k_lp_train_no_test_1p_4t/movie-lens-100k.json --ip-config ip_list.txt --ssh-port 2222 --cf ml_lp.yaml --num-epochs 1 --eval-frequency 300 --logging-file /tmp/train_log.txt
 
-error_and_exit ${PIPESTATUS[0]}
+error_and_exit $?
 
 bst_cnt=$(grep "Best Test mrr: N/A" /tmp/train_log.txt | wc -l)
 if test $bst_cnt -lt 1

--- a/tests/end2end-tests/graphstorm-nc/mgpu_test.sh
+++ b/tests/end2end-tests/graphstorm-nc/mgpu_test.sh
@@ -27,7 +27,7 @@ error_and_exit () {
 echo "**************dataset: MovieLens classification, RGCN layer: 1, node feat: fixed HF BERT, BERT nodes: movie, inference: mini-batch save model save emb node"
 python3 -m graphstorm.run.gs_node_classification --workspace $GS_HOME/training_scripts/gsgnn_np/ --num-trainers $NUM_TRAINERS --num-servers 1 --num-samplers 0 --part-config /data/movielen_100k_train_val_1p_4t/movie-lens-100k.json --ip-config ip_list.txt --ssh-port 2222 --cf ml_nc.yaml --save-model-path /data/gsgnn_nc_ml/ --topk-model-to-save 1 --save-embed-path /data/gsgnn_nc_ml/emb/ --num-epochs 3 --logging-file /tmp/train_log.txt --logging-level debug
 
-error_and_exit ${PIPESTATUS[0]}
+error_and_exit $?
 
 # check prints
 cnt=$(grep "save_embed_path: /data/gsgnn_nc_ml/emb/" /tmp/train_log.txt | wc -l)
@@ -94,7 +94,7 @@ rm /tmp/train_log.txt
 echo "**************dataset: Movielens, do inference on saved model"
 python3 -m graphstorm.run.gs_node_classification --inference --workspace $GS_HOME/inference_scripts/np_infer/ --num-trainers $NUM_INFERs --num-servers 1 --num-samplers 0 --part-config /data/movielen_100k_train_val_1p_4t/movie-lens-100k.json --ip-config ip_list.txt --ssh-port 2222 --cf ml_nc_infer.yaml --use-mini-batch-infer false  --save-embed-path /data/gsgnn_nc_ml/infer-emb/ --restore-model-path /data/gsgnn_nc_ml/epoch-$best_epoch/ --save-prediction-path /data/gsgnn_nc_ml/prediction/ --logging-file /tmp/log.txt
 
-error_and_exit ${PIPESTATUS[0]}
+error_and_exit $?
 
 cnt=$(grep "| Test accuracy" /tmp/log.txt | wc -l)
 if test $cnt -ne 1
@@ -149,7 +149,7 @@ error_and_exit $?
 echo "**************dataset: MovieLens classification, RGCN layer: 1, node feat: fixed HF BERT, BERT nodes: movie, inference: mini-batch save model save emb node, early stop"
 python3 -m graphstorm.run.gs_node_classification --workspace $GS_HOME/training_scripts/gsgnn_np/ --num-trainers $NUM_TRAINERS --num-servers 1 --num-samplers 0 --part-config /data/movielen_100k_train_val_1p_4t/movie-lens-100k.json --ip-config ip_list.txt --ssh-port 2222 --cf ml_nc.yaml --save-model-path /data/gsgnn_nc_ml/ --topk-model-to-save 3 --save-embed-path /data/gsgnn_nc_ml/emb/ --use-early-stop True --early-stop-burnin-rounds 2 -e 20 --early-stop-rounds 3 --early-stop-strategy consecutive_increase --logging-file /tmp/exec.log --logging-level debug
 
-error_and_exit ${PIPESTATUS[0]}
+error_and_exit $?
 
 # check early stop
 cnt=$(cat /tmp/exec.log | grep "Evaluation step" | wc -l)
@@ -179,7 +179,7 @@ rm -fr /data/gsgnn_nc_ml/*
 echo "**************dataset: MovieLens classification, RGCN layer: 1, node feat: BERT nodes: movie, user inference: mini-batch save model save emb node"
 python3 -m graphstorm.run.gs_node_classification --workspace $GS_HOME/training_scripts/gsgnn_np/ --num-trainers $NUM_TRAINERS --num-servers 1 --num-samplers 0 --part-config /data/movielen_100k_lm_encoder_train_val_1p_4t/movie-lens-100k-text.json --ip-config ip_list.txt --ssh-port 2222 --cf ml_nc_utext.yaml  --save-model-path /data/gsgnn_nc_ml_text/ --topk-model-to-save 1 --save-embed-path /data/gsgnn_nc_ml_text/emb/ --num-epochs 3 --logging-file /tmp/train_log.txt
 
-error_and_exit ${PIPESTATUS[0]}
+error_and_exit $?
 
 cnt=$(ls -l /data/gsgnn_nc_ml_text/ | grep epoch | wc -l)
 if test $cnt != 1
@@ -196,7 +196,7 @@ rm /tmp/train_log.txt
 echo "**************dataset: Movielens, do inference on saved model, decoder: dot"
 python3 -m graphstorm.run.gs_node_classification --inference --workspace $GS_HOME/inference_scripts/np_infer/ --num-trainers $NUM_INFERs --num-servers 1 --num-samplers 0 --part-config /data/movielen_100k_lm_encoder_train_val_1p_4t/movie-lens-100k-text.json --ip-config ip_list.txt --ssh-port 2222 --cf ml_nc_text_infer.yaml --use-mini-batch-infer false   --save-embed-path /data/gsgnn_nc_ml_text/infer-emb/ --restore-model-path /data/gsgnn_nc_ml_text/epoch-$best_epoch/ --save-prediction-path /data/gsgnn_nc_ml_text/prediction/ --logging-file /tmp/log.txt --logging-level debug
 
-error_and_exit ${PIPESTATUS[0]}
+error_and_exit $?
 
 cnt=$(grep "| Test accuracy" /tmp/log.txt | wc -l)
 if test $cnt -ne 1
@@ -232,7 +232,7 @@ rm /tmp/train_log.txt
 echo "**************dataset: Movielens, do inference on saved model, decoder: dot"
 python3 -m graphstorm.run.gs_node_classification --inference --workspace $GS_HOME/inference_scripts/np_infer/ --num-trainers $NUM_INFERs --num-servers 1 --num-samplers 0 --part-config /data/movielen_100k_lm_encoder_train_val_1p_4t/movie-lens-100k-text.json --ip-config ip_list.txt --ssh-port 2222 --cf ml_nc_text_infer.yaml --use-mini-batch-infer false --save-embed-path /data/gsgnn_nc_ml_text/infer-emb/ --restore-model-path /data/gsgnn_nc_ml_text/epoch-$best_epoch/ --save-prediction-path /data/gsgnn_nc_ml_text/prediction/ --logging-file /tmp/log.txt --logging-level debug
 
-error_and_exit ${PIPESTATUS[0]}
+error_and_exit $?
 
 cnt=$(grep "| Test accuracy" /tmp/log.txt | wc -l)
 if test $cnt -ne 1
@@ -251,19 +251,19 @@ rm -fr /data/gsgnn_nc_ml_text/*
 echo "**************dataset: MovieLens classification, RGCN layer: 1, node feat: BERT nodes: movie, user inference: mini-batch save model save emb node, train_nodes 0"
 python3 -m graphstorm.run.gs_node_classification --workspace $GS_HOME/training_scripts/gsgnn_np/ --num-trainers $NUM_TRAINERS --num-servers 1 --num-samplers 0 --part-config /data/movielen_100k_lm_encoder_train_val_1p_4t/movie-lens-100k-text.json --ip-config ip_list.txt --ssh-port 2222 --cf ml_nc_utext.yaml  --save-model-path /data/gsgnn_nc_ml_text/ --topk-model-to-save 1 --save-embed-path /data/gsgnn_nc_ml_text/emb/ --num-epochs 3 --lm-train-nodes 0
 
-error_and_exit ${PIPESTATUS[0]}
+error_and_exit $?
 rm -fr /data/gsgnn_nc_ml_text/*
 
 echo "**************dataset: MovieLens classification, RGCN layer: 1, node feat: RoBERTa nodes: movie, user inference: mini-batch save model save emb node, train_nodes 0"
 python3 -m graphstorm.run.gs_node_classification --workspace $GS_HOME/training_scripts/gsgnn_np/ --num-trainers $NUM_TRAINERS --num-servers 1 --num-samplers 0 --part-config /data/movielen_100k_roberta_encoder_train_val_1p_4t/movie-lens-100k-text.json --ip-config ip_list.txt --ssh-port 2222 --cf ml_nc_utext_roberta.yaml  --save-model-path /data/gsgnn_nc_ml_text/ --topk-model-to-save 1 --save-embed-path /data/gsgnn_nc_ml_text/emb/ --num-epochs 3 --lm-train-nodes 0
 
-error_and_exit ${PIPESTATUS[0]}
+error_and_exit $?
 rm -fr /data/gsgnn_nc_ml_text/*
 
 echo "**************dataset: MovieLens classification, GLEM co-training, RGCN layer: 1, node feat: BERT nodes: movie, user inference: mini-batch save model save emb node"
 python3 -m graphstorm.run.gs_node_classification --workspace $GS_HOME/training_scripts/gsgnn_np/ --num-trainers $NUM_TRAINERS --num-servers 1 --num-samplers 0 --part-config /data/movielen_100k_lm_encoder_train_val_1p_4t/movie-lens-100k-text.json --ip-config ip_list.txt --ssh-port 2222 --cf ml_nc_utext_glem.yml  --save-model-path /data/gsgnn_nc_ml_text/ --topk-model-to-save 1 --num-epochs 3
 
-error_and_exit ${PIPESTATUS[0]}
+error_and_exit $?
 
 cnt=$(ls -l /data/gsgnn_nc_ml_text/ | grep epoch | wc -l)
 if test $cnt != 1
@@ -277,7 +277,7 @@ rm -fr /data/gsgnn_nc_ml_text/*
 echo "**************dataset: MovieLens semi-supervised classification, GLEM co-training, RGCN layer: 1, node feat: BERT nodes: movie, user inference: mini-batch save model"
 python3 -m graphstorm.run.gs_node_classification --workspace $GS_HOME/training_scripts/gsgnn_np/ --num-trainers $NUM_TRAINERS --num-servers 1 --num-samplers 0 --part-config /data/movielen_100k_lm_encoder_train_val_1p_4t/movie-lens-100k-text.json --ip-config ip_list.txt --ssh-port 2222 --cf ml_nc_utext_glem.yml  --save-model-path /data/gsgnn_nc_ml_text/ --topk-model-to-save 1 --num-epochs 2 --use-pseudolabel true
 
-error_and_exit ${PIPESTATUS[0]}
+error_and_exit $?
 
 cnt=$(ls -l /data/gsgnn_nc_ml_text/ | grep epoch | wc -l)
 if test $cnt != 1

--- a/tests/end2end-tests/graphstorm-nc/test.sh
+++ b/tests/end2end-tests/graphstorm-nc/test.sh
@@ -45,7 +45,7 @@ error_and_exit $?
 echo "**************dataset: MovieLens, RGCN layer: 1, node feat: fixed HF BERT, BERT nodes: movie, inference: mini-batch, no test_set"
 python3 -m graphstorm.run.gs_node_classification --workspace $GS_HOME/training_scripts/gsgnn_np/ --num-trainers $NUM_TRAINERS --num-servers 1 --num-samplers 0 --part-config /data/movielen_100k_train_notest_1p_4t/movie-lens-100k.json --ip-config ip_list.txt --ssh-port 2222 --cf ml_nc.yaml --logging-file /tmp/train_log.txt
 
-error_and_exit ${PIPESTATUS[0]}
+error_and_exit $?
 
 bst_cnt=$(grep "Best Test accuracy: N/A" /tmp/train_log.txt | wc -l)
 if test $bst_cnt -lt 1


### PR DESCRIPTION
*Issue #, if available:*
Using `error_and_exit ${PIPESTATUS[0]}` to capture the error status of testing scripts that do not redirect outputs using pipe is not correct.

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
