### PR TITLE
Refactor the code of BERT computation to fix a potential bug.

### DIFF
--- a/python/graphstorm/model/lm_embed.py
+++ b/python/graphstorm/model/lm_embed.py
@@ -119,7 +119,9 @@ class LMModels(nn.Module):
                 assert ntype not in self._lm_node_feats, \
                         f"More than one BERT model runs on Node {ntype}."
                 self._lm_node_feats[ntype] = feats
-            key = str(lm_ntypes)
+            # We should sort the node type list before converting it to the key.
+            lm_ntypes.sort()
+            key = ','.join(lm_ntypes)
             self._lm_models[key] = lm_model
             for ntype in lm_ntypes:
                 self._lm_map[ntype] = key

--- a/python/graphstorm/model/lm_embed.py
+++ b/python/graphstorm/model/lm_embed.py
@@ -20,6 +20,7 @@
 import logging
 
 import torch as th
+from torch import nn
 import dgl
 
 from .embed import GSNodeInputLayer
@@ -28,109 +29,200 @@ from .lm_model import init_lm_model
 from .lm_model import get_lm_node_feats
 from ..utils import get_rank, barrier
 
-def update_bert_cache(g, lm_models_info, lm_models, lm_emb_cache, lm_infer_batch_size):
+def update_bert_cache(g, lm_models, lm_emb_cache, lm_infer_batch_size):
     """ Update the lm_emb_cache using lanaguage models.
 
     Parameters
     ----------
-    lm_models_info: dict
-        Language model information
-    lm_models: dict
-        Language models
+    lm_models: LMModels
+        A collection of LM models and related information.
     lm_emb_cache: dict
         Language model embedding cache
     lm_infer_batch_size: int
         Language model inference batch size
     """
-    for (lm_ntypes, lm_node_feats), lm_model \
-        in zip(lm_models_info, lm_models):
+    for ntype in lm_models.ntypes:
+        lm_model = lm_models.get_lm_model(ntype)
+        lm_node_feat = lm_models.get_lm_node_feat(ntype)
         lm_model.eval()
-        for ntype in lm_ntypes:
-            if get_rank() == 0:
-                logging.info('Compute bert embedding on node %s.', ntype)
-            hidden_size = lm_model.feat_size
-            if 'bert_emb' not in g.nodes[ntype].data:
-                g.nodes[ntype].data['bert_emb'] = \
+        if get_rank() == 0:
+            logging.info('Compute bert embedding on node %s.', ntype)
+        hidden_size = lm_model.feat_size
+        # TODO we should not save the BERT embeddings on the graph data in the future.
+        if 'bert_emb' not in g.nodes[ntype].data:
+            g.nodes[ntype].data['bert_emb'] = \
                     dgl.distributed.DistTensor(
                         (g.number_of_nodes(ntype), hidden_size),
                         name="bert_emb",
                         dtype=th.float32,
                         part_policy=g.get_node_partition_policy(ntype),
                         persistent=True)
-            input_emb = g.nodes[ntype].data['bert_emb']
-            infer_nodes = dgl.distributed.node_split(
+        input_emb = g.nodes[ntype].data['bert_emb']
+        infer_nodes = dgl.distributed.node_split(
                 th.ones((g.number_of_nodes(ntype),), dtype=th.bool),
                 partition_book=g.get_partition_book(),
                 ntype=ntype, force_even=False)
+        logging.debug("node %s, local infer set: %d, batch size: %d",
+                      ntype, len(infer_nodes), lm_infer_batch_size)
 
-            node_list = th.split(infer_nodes, lm_infer_batch_size)
-            input_ntypes = [ntype]
-            for _, input_nodes in enumerate(node_list):
-                input_lm_feats = {}
-                input_lm_feats[ntype] = {
-                    fname: feat[input_nodes] \
-                        for fname, feat in lm_node_feats[ntype].items()
-                }
-                text_embs = lm_model(input_ntypes, input_lm_feats)
-                input_emb[input_nodes] = text_embs[ntype].to('cpu')
-            barrier()
-            lm_emb_cache[ntype] = input_emb
+        node_list = th.split(infer_nodes, lm_infer_batch_size)
+        input_ntypes = [ntype]
+        for input_nodes in node_list:
+            input_lm_feats = {}
+            input_lm_feats[ntype] = {
+                    fname: feat[input_nodes] for fname, feat in lm_node_feat.items()
+            }
+            text_embs = lm_model(input_ntypes, input_lm_feats)
+            input_emb[input_nodes] = text_embs[ntype].to('cpu')
+        barrier()
+        lm_emb_cache[ntype] = input_emb
         lm_model.train()
 
-def lm_model_forward(input_nodes, lm_emb_cache, lm_models, lm_models_info, use_cache=False):
-    """ Do language model forward pass on input_nodes
+class LMModels(nn.Module):
+    """ LM model collection
+
+    This class maintains the mapping between node type and the LM model
+    as well as the corresponding information of the LM model.
+
+    The class ensures that the connection between the LM model and
+    the node type is fixed. We always get the right LM model for a given node type.
 
     Parameters
     ----------
-    input_nodes: dict
-        Input nodes for different node types
-    lm_emb_cache: dict
-        Language model embedding cache for different node types
-    lm_models: list
-        Language models for different node types.
-        lm_models stores a list of different language models.
-    lm_models_info: list
-        Language model information for different node types.
-        lm_models_info stores a list of (lm_ntypes, lm_node_feats) tuples.
-        There is a one-one correspondence between the language models stored in
-        lm_models and the (lm_ntypes, lm_node_feats) tuples in lm_models_info.
-        The lm_ntypes stores the node types that share the same language model
-        and the lm_node_feats stores the corresponding language model computation
-        related node features (i.e., token ids, attention masks, etc.)
-    use_cache: bool
-        If true, use the embeddings in lm_emb_cache
+    g : DistGraph
+        The distributed graph.
+    node_lm_configs:
+        A list of language model configurations.
+    num_train: int
+        Number of trainable texts
+    lm_infer_batch_size: int
+        Batch size used for computing text embeddings for static lm model
     """
-    lm_feats = {}
-
-    # Get the device from lm_models
-    # The cached BERT embedding should be moved to the same device
-    # as lm_models.
-    dev = next(lm_models[0].parameters()).device
-    if use_cache:
-        # No bert training, Get cached LM embedding
-        # Note: self.lm_emb_cache is initialized by calling warmup
-        for ntype, idx in input_nodes.items():
-            if ntype in lm_emb_cache:
-                lm_feats[ntype] = lm_emb_cache[ntype][idx].to(dev)
-    else:
-        # TODO: Release the bert cache properly
-        #       This may need support from DistDGL
-        # Need bert training
-        for (lm_ntypes, lm_node_feats), lm_model \
-            in zip(lm_models_info, lm_models):
-            input_ntypes = []
-            input_lm_feats = {}
+    def __init__(self, g, node_lm_configs, num_train, lm_infer_batch_size):
+        super(LMModels, self).__init__()
+        # More than one node type may share the same BERT model.
+        # To avoid duplicate BERT models, we save add the BERT model
+        # in the module dict once, whose key is the node types of the BERT model.
+        # We then maintain a mapping from the node type to the key
+        # to help find the right BERT model for a node type.
+        self._lm_map = {}
+        self._lm_models = nn.ModuleDict()
+        self._lm_node_feats = {}
+        for lm_config in node_lm_configs:
+            lm_model = init_lm_model(lm_config,
+                                     num_train=num_train,
+                                     lm_infer_batch_size=lm_infer_batch_size)
+            # A list of node types sharing the same lm model
+            lm_ntypes = lm_config["node_types"]
+            lm_node_feats = get_lm_node_feats(g, lm_model, lm_ntypes)
+            for ntype, feats in lm_node_feats.items():
+                assert ntype not in self._lm_node_feats, \
+                        f"More than one BERT model runs on Node {ntype}."
+                self._lm_node_feats[ntype] = feats
+            key = str(lm_ntypes)
+            self._lm_models[key] = lm_model
             for ntype in lm_ntypes:
-                if ntype in input_nodes:
-                    input_ntypes.append(ntype)
-                    input_lm_feats[ntype] = {
-                        fname: feat[input_nodes[ntype]].to(dev) \
-                            for fname, feat in lm_node_feats[ntype].items()
-                    }
+                self._lm_map[ntype] = key
 
-            if len(input_ntypes) > 0:
-                lm_feats.update(lm_model(input_ntypes, input_lm_feats))
-    return lm_feats
+    def forward(self, input_nodes, lm_emb_cache=None):
+        """ Do language model forward pass on input_nodes
+
+        Parameters
+        ----------
+        input_nodes: dict
+            Input nodes for different node types
+        lm_emb_cache: dict
+            Language model embedding cache for different node types
+        """
+        lm_feats = {}
+
+        # Get the device from lm_models
+        # The cached BERT embedding should be moved to the same device
+        # as lm_models.
+        dev = self.device
+        if lm_emb_cache is not None:
+            # No bert training, Get cached LM embedding
+            # Note: self.lm_emb_cache is initialized by calling warmup
+            for ntype, idx in input_nodes.items():
+                if ntype in lm_emb_cache:
+                    lm_feats[ntype] = lm_emb_cache[ntype][idx].to(dev)
+        else:
+            # TODO: Release the bert cache properly
+            #       This may need support from DistDGL
+            # Need bert training
+            for ntype in self.ntypes:
+                lm_node_feat = self.get_lm_node_feat(ntype)
+                lm_model = self.get_lm_model(ntype)
+                if ntype in input_nodes:
+                    input_lm_feat = {
+                            fname: feat[input_nodes[ntype]].to(dev) \
+                                    for fname, feat in lm_node_feat.items()
+                        }
+                    lm_feats.update(lm_model([ntype], {ntype: input_lm_feat}))
+        return lm_feats
+
+    def get_lm_model(self, ntype):
+        """ Get a LM model for a node type
+
+        Parameters
+        ----------
+        ntype : str
+            The node type
+
+        Returns
+        -------
+        nn.Module : the LM model for the node type.
+        """
+        idx = self._lm_map[ntype]
+        return self._lm_models[idx]
+
+    def get_lm_node_feat(self, ntype):
+        """ Get the LM node features.
+
+        Parameters
+        ----------
+        ntype : str
+            The node type
+
+        Returns
+        -------
+        dict : the node features of the node type.
+        """
+        return self._lm_node_feats[ntype]
+
+    @property
+    def ntypes(self):
+        """ Get all node types with text features.
+
+        Returns
+        -------
+        list of str : the node types with text features.
+        """
+        return list(self._lm_map.keys())
+
+    @property
+    def feat_size(self):
+        """ The feature size of the BERT model.
+        """
+        assert len(self._lm_models) > 0
+        for model in self._lm_models.values():
+            return model.feat_size
+        return -1
+
+    @property
+    def device(self):
+        """ The device where the model is on.
+        """
+        assert len(self._lm_models) > 0
+        for model in self._lm_models.values():
+            return next(model.parameters()).device
+        return None
+
+    @property
+    def lm_models(self):
+        """ The list of LM models.
+        """
+        return list(self._lm_models.values())
 
 class GSPureLMNodeInputLayer(GSNodeInputLayer):
     """The input embedding layer with language model only for all nodes in a
@@ -163,31 +255,17 @@ class GSPureLMNodeInputLayer(GSNodeInputLayer):
         assert node_lm_configs is not None and len(node_lm_configs) > 0, \
             "language model configurations must be provided"
 
-        lm_models = th.nn.ModuleList()
-        lm_models_info = []
-        node_with_lm_feats = set()
-        for lm_config in node_lm_configs:
-            lm_model = init_lm_model(lm_config,
-                                     num_train=num_train,
-                                     lm_infer_batch_size=lm_infer_batch_size)
-            # A list of node types sharing the same lm model
-            lm_ntypes = lm_config["node_types"]
-            lm_node_feats = get_lm_node_feats(g, lm_model, lm_ntypes)
-            lm_models.append(lm_model)
-            lm_models_info.append((lm_ntypes, lm_node_feats))
-            node_with_lm_feats.update(lm_ntypes)
-        assert len(node_with_lm_feats) == len(g.ntypes), \
-            "Every node type in a graph should have text feature"
+        self._lm_models = LMModels(g, node_lm_configs, num_train, lm_infer_batch_size)
+        #assert len(self._lm_models.ntypes) == len(g.ntypes), \
+        #    "Every node type in a graph should have text feature"
 
         self.num_train = num_train
         self.lm_infer_batch_size = lm_infer_batch_size
         self.use_cache = False
         self.lm_emb_cache = {}
 
-        self.lm_models = lm_models
-        self.lm_models_info = lm_models_info
-        self._feat_size = self.lm_models[0].feat_size
-        for lm_model in self.lm_models:
+        self._feat_size = self._lm_models.feat_size
+        for lm_model in self._lm_models.lm_models:
             assert self.out_dims == lm_model.feat_size, \
                 "All Language models should have the same output embedding " \
                 "dimension, otherwise please use GSLMNodeEncoderInputLayer " \
@@ -211,7 +289,7 @@ class GSPureLMNodeInputLayer(GSNodeInputLayer):
         -------
         list of Tensors: the language model parameters.
         """
-        return self.lm_models.parameters()
+        return self._lm_models.parameters()
 
     def prepare(self, g):
         # If there is no trainable nodes, freeze Bert layer.
@@ -232,8 +310,7 @@ class GSPureLMNodeInputLayer(GSNodeInputLayer):
         #
         # 3) if train_nodes > 0, no emb_cache is used unless Case 2.
         update_bert_cache(g,
-                          self.lm_models_info,
-                          self.lm_models,
+                          self._lm_models,
                           self.lm_emb_cache,
                           self.lm_infer_batch_size)
         self.use_cache = True
@@ -265,13 +342,8 @@ class GSPureLMNodeInputLayer(GSNodeInputLayer):
         """
         assert isinstance(input_nodes, dict), 'The input node IDs should be in a dict.'
 
-        lm_feats = lm_model_forward(input_nodes,
-            self.lm_emb_cache,
-            self.lm_models,
-            self.lm_models_info,
-            use_cache=len(self.lm_emb_cache) > 0 and self.use_cache)
-
-        return lm_feats
+        cache = self.lm_emb_cache if len(self.lm_emb_cache) > 0 and self.use_cache else None
+        return self._lm_models(input_nodes, lm_emb_cache=cache)
 
     @property
     def out_dims(self):
@@ -326,22 +398,14 @@ class GSLMNodeEncoderInputLayer(GSNodeEncoderInputLayer):
         assert node_lm_configs is not None and len(node_lm_configs) > 0, \
             "language model configurations must be provided"
 
-        lm_models = th.nn.ModuleList()
-        lm_models_info = []
+        lm_models = LMModels(g, node_lm_configs, num_train, lm_infer_batch_size)
         adjust_feat_size = dict(feat_size)
         for lm_config in node_lm_configs:
-            lm_model = init_lm_model(lm_config,
-                                     num_train=num_train,
-                                     lm_infer_batch_size=lm_infer_batch_size)
             # A list of node types sharing the same lm model
             lm_ntypes = lm_config["node_types"]
-            lm_node_feats = get_lm_node_feats(g, lm_model, lm_ntypes)
-            lm_models.append(lm_model)
-            lm_models_info.append((lm_ntypes, lm_node_feats))
-
             # Update feature size
             for ntype in lm_ntypes:
-                adjust_feat_size[ntype] += lm_model.feat_size
+                adjust_feat_size[ntype] += lm_models.feat_size
                 if get_rank() == 0:
                     logging.debug('Node %s adds lm %s features %d->%d',
                                   ntype, lm_config["lm_type"], feat_size[ntype],
@@ -355,9 +419,7 @@ class GSLMNodeEncoderInputLayer(GSNodeEncoderInputLayer):
         super(GSLMNodeEncoderInputLayer, self).__init__(
             g, adjust_feat_size, embed_size,
             activation, dropout, use_node_embeddings)
-
-        self.lm_models = lm_models
-        self.lm_models_info = lm_models_info
+        self._lm_models = lm_models
 
     def get_general_dense_parameters(self):
         """ Get dense layers' parameters.
@@ -378,7 +440,7 @@ class GSLMNodeEncoderInputLayer(GSNodeEncoderInputLayer):
         -------
         list of Tensors: the language model parameters.
         """
-        return self.lm_models.parameters()
+        return self._lm_models.parameters()
 
     def prepare(self, g):
         # If there is no trainable nodes, freeze Bert layer.
@@ -399,8 +461,7 @@ class GSLMNodeEncoderInputLayer(GSNodeEncoderInputLayer):
         #
         # 3) if train_nodes > 0, no emb_cache is used unless Case 2.
         update_bert_cache(g,
-                          self.lm_models_info,
-                          self.lm_models,
+                          self._lm_models,
                           self.lm_emb_cache,
                           self.lm_infer_batch_size)
         self.use_cache = True
@@ -439,11 +500,8 @@ class GSLMNodeEncoderInputLayer(GSNodeEncoderInputLayer):
         assert isinstance(input_nodes, dict), 'The input node IDs should be in a dict.'
 
         # Compute language model features first
-        lm_feats = lm_model_forward(input_nodes,
-            self.lm_emb_cache,
-            self.lm_models,
-            self.lm_models_info,
-            use_cache=len(self.lm_emb_cache) > 0 and self.use_cache)
+        cache = self.lm_emb_cache if len(self.lm_emb_cache) > 0 and self.use_cache else None
+        lm_feats = self._lm_models(input_nodes, lm_emb_cache=cache)
 
         for ntype, lm_feat in lm_feats.items():
             # move lm_feat to the right device

--- a/python/graphstorm/model/lm_embed.py
+++ b/python/graphstorm/model/lm_embed.py
@@ -256,8 +256,8 @@ class GSPureLMNodeInputLayer(GSNodeInputLayer):
             "language model configurations must be provided"
 
         self._lm_models = LMModels(g, node_lm_configs, num_train, lm_infer_batch_size)
-        #assert len(self._lm_models.ntypes) == len(g.ntypes), \
-        #    "Every node type in a graph should have text feature"
+        assert len(self._lm_models.ntypes) == len(g.ntypes), \
+            "Every node type in a graph should have text feature"
 
         self.num_train = num_train
         self.lm_infer_batch_size = lm_infer_batch_size

--- a/tests/unit-tests/data_utils.py
+++ b/tests/unit-tests/data_utils.py
@@ -450,7 +450,7 @@ def create_lm_graph(tmpdirname):
 
 def create_lm_graph2(tmpdirname):
     """ Create a graph with textual feaures
-        Both n0 and n1 have textual features.
+        Both n0 and n1 have textual features and use the same BERT model.
     """
     bert_model_name = "bert-base-uncased"
     max_seq_length = 8

--- a/tests/unit-tests/test_embed.py
+++ b/tests/unit-tests/test_embed.py
@@ -219,10 +219,11 @@ def test_lm_infer():
     nn.init.eye_(layer.input_projs['n0'])
     embeds_with_lm = compute_node_input_embeddings(g, 10, layer,
                                                    feat_field={'n0' : ['feat']})
-    layer.lm_models[0].lm_model.eval()
-    outputs = layer.lm_models[0].lm_model(input_ids,
-                                      attention_mask=attention_mask)
-    layer.lm_models[0].lm_model.train()
+    ntype = layer._lm_models.ntypes[0]
+    lm_model = layer._lm_models.get_lm_model(ntype).lm_model
+    lm_model.eval()
+    outputs = lm_model(input_ids, attention_mask=attention_mask)
+    lm_model.train()
     out_emb = outputs.pooler_output
     feat_size['n0'] += out_emb.shape[1]
     g.nodes['n0'].data['text'] = out_emb
@@ -258,10 +259,11 @@ def test_lm_embed(num_train):
     nn.init.eye_(layer.input_projs['n0'])
     embeds_with_lm = compute_node_input_embeddings(g, 10, layer,
                                                    feat_field={'n0' : ['feat']})
-    layer.lm_models[0].lm_model.eval()
-    outputs = layer.lm_models[0].lm_model(input_ids,
-                                      attention_mask=attention_mask)
-    layer.lm_models[0].lm_model.train()
+    ntype = layer._lm_models.ntypes[0]
+    lm_model = layer._lm_models.get_lm_model(ntype).lm_model
+    lm_model.eval()
+    outputs = lm_model(input_ids, attention_mask=attention_mask)
+    lm_model.train()
     out_emb = outputs.pooler_output
 
     assert len(embeds_with_lm) == len(g.ntypes)
@@ -302,10 +304,11 @@ def test_lm_embed(num_train):
     embeds_with_lm = compute_node_input_embeddings(g, 10, layer,
                                                    feat_field={'n0' : ['feat']})
 
-    layer.lm_models[0].lm_model.eval()
-    outputs = layer.lm_models[0].lm_model(input_ids,
-                                           attention_mask=attention_mask)
-    layer.lm_models[0].lm_model.train()
+    ntype = layer._lm_models.ntypes[0]
+    lm_model = layer._lm_models.get_lm_model(ntype).lm_model
+    lm_model.eval()
+    outputs = lm_model(input_ids, attention_mask=attention_mask)
+    lm_model.train()
     out_emb = outputs.pooler_output
 
     assert len(embeds_with_lm) == len(g.ntypes)
@@ -347,13 +350,11 @@ def test_pure_lm_embed(num_train):
     embeds_with_lm = compute_node_input_embeddings(g, 10, layer,
                                                    feat_field={'n0' : ['feat']})
 
-    layer.lm_models[0].lm_model.eval()
-    outputs0 = layer.lm_models[0].lm_model(input_ids0,
-                                           attention_mask=attention_mask0)
-
-    outputs1 = layer.lm_models[0].lm_model(input_ids1,
-                                           attention_mask=attention_mask1)
-    layer.lm_models[0].lm_model.train()
+    ntype = layer._lm_models.ntypes[0]
+    lm_model = layer._lm_models.get_lm_model(ntype).lm_model.eval()
+    outputs0 = lm_model(input_ids0, attention_mask=attention_mask0)
+    outputs1 = lm_model(input_ids1, attention_mask=attention_mask1)
+    lm_model.train()
     out_emb0 = outputs0.pooler_output
     out_emb1 = outputs1.pooler_output
 
@@ -414,7 +415,9 @@ def test_lm_embed_warmup(dev):
     def rand_init(m):
         if isinstance(m, th.nn.Embedding):
             th.nn.init.uniform(m.weight.data, b=10.)
-    layer.lm_models[0].lm_model.apply(rand_init)
+    ntype = layer._lm_models.ntypes[0]
+    lm_model = layer._lm_models.get_lm_model(ntype).lm_model
+    lm_model.apply(rand_init)
     # model has been freezed, still use bert cache.
     feat = prepare_batch_input(g, input_nodes, dev=dev, feat_field=feat_field)
     emb_1 = layer(feat, input_nodes)

--- a/tests/unit-tests/test_gnn.py
+++ b/tests/unit-tests/test_gnn.py
@@ -732,10 +732,6 @@ def test_mlp_node_prediction():
     th.distributed.destroy_process_group()
     dgl.distributed.kvstore.close_kvstore()
 
-def rand_init_params(model):
-    for param in model.parameters():
-        param.data.random_()
-
 def test_lm_model_load_save():
     """ Test if we can load and save LM+GNN model correctly.
     """


### PR DESCRIPTION
*Description of changes:*
The original code locates a BERT model based on the index. There is potentially a bug here. If a user fine-tune BERT models on two node types:
```
  node_lm_models:
    -
      lm_type: bert
      model_name: "bert-base-uncased"
      gradient_checkpoint: true
      node_types:
        - paper
    -
      lm_type: bert
      model_name: "bert-base-uncased"
      gradient_checkpoint: true
      node_types:
        - fos
```
If the user trains the GNN model with the following config,
```
  node_lm_models:
    -
      lm_type: bert
      model_name: "bert-base-uncased"
      gradient_checkpoint: true
      node_types:
        - fos
    -
      lm_type: bert
      model_name: "bert-base-uncased"
      gradient_checkpoint: true
      node_types:
        - paper
```
The original code will use the wrong BERT model for the node types.
The fix is to associate the BERT model with node types and the parameter names contain the node types to make sure the parameters are loaded to the right BERT model.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
