### PR TITLE
Fix categorical transform

### DIFF
--- a/python/graphstorm/gconstruct/transform.py
+++ b/python/graphstorm/gconstruct/transform.py
@@ -351,6 +351,9 @@ class CategoricalTransform(TwoPhaseFeatTransform):
     def __init__(self, col_name, feat_name, separator=None, transform_conf=None):
         self._val_dict = {}
         if transform_conf is not None and 'mapping' in transform_conf:
+            # We assume the keys of a categorical mapping are strings.
+            # But previously keys can be integers. So we convert them
+            # into strings.
             self._val_dict = \
                 {str(key): val for key, val in transform_conf['mapping'].items()}
             self._conf = transform_conf

--- a/python/graphstorm/gconstruct/transform.py
+++ b/python/graphstorm/gconstruct/transform.py
@@ -351,7 +351,8 @@ class CategoricalTransform(TwoPhaseFeatTransform):
     def __init__(self, col_name, feat_name, separator=None, transform_conf=None):
         self._val_dict = {}
         if transform_conf is not None and 'mapping' in transform_conf:
-            self._val_dict = transform_conf['mapping']
+            self._val_dict = \
+                {str(key): val for key, val in transform_conf['mapping'].items()}
             self._conf = transform_conf
         else:
             self._conf = transform_conf

--- a/python/graphstorm/gconstruct/transform.py
+++ b/python/graphstorm/gconstruct/transform.py
@@ -379,7 +379,7 @@ class CategoricalTransform(TwoPhaseFeatTransform):
 
         feats = feats[feats != None] # pylint: disable=singleton-comparison
         if self._separator is None:
-            return {self.feat_name: np.unique(feats)}
+            return {self.feat_name: np.unique(feats.astype(str))}
         else:
             assert feats.dtype.type is np.str_, \
                     "We can only convert strings to multiple categorical values with separaters."
@@ -424,7 +424,7 @@ class CategoricalTransform(TwoPhaseFeatTransform):
             for i, feat in enumerate(feats):
                 if feat is None:
                     continue
-                encoding[i, self._val_dict[feat]] = 1
+                encoding[i, self._val_dict[str(feat)]] = 1
         else:
             for i, feat in enumerate(feats):
                 if feat is None:

--- a/python/graphstorm/gconstruct/transform.py
+++ b/python/graphstorm/gconstruct/transform.py
@@ -402,7 +402,7 @@ class CategoricalTransform(TwoPhaseFeatTransform):
             assert len(info) == 0
             return
 
-        self._val_dict = {key: i for i, key in enumerate(np.unique(np.concatenate(info)))}
+        self._val_dict = {str(key): i for i, key in enumerate(np.unique(np.concatenate(info)))}
         # We need to save the mapping in the config object.
         if self._conf is not None:
             self._conf['mapping'] = self._val_dict

--- a/tests/unit-tests/gconstruct/test_transform.py
+++ b/tests/unit-tests/gconstruct/test_transform.py
@@ -272,6 +272,38 @@ def test_categorize_transform():
         feat[idx] = 0
         assert np.all(feat == 0)
 
+    # Test the case when the input ids are mixture of int and strings
+    # This may happen when loading csv files.
+    transform_conf = {
+        "name": "to_categorical"
+    }
+    transform = CategoricalTransform("test1", "test", transform_conf=transform_conf)
+    str_ids = [str(i) for i in np.random.randint(0, 10, 1000)]
+    str_ids[0] = None
+    str_ids[-1] = None # allow None data
+    str_ids = str_ids + [i for i in range(10)] # mix strings with ints
+    res = transform.pre_process(np.array(str_ids))
+    assert "test" in res
+    assert len(res["test"]) == 10
+    for i in range(10):
+        assert str(i) in res["test"]
+
+    info = [ np.array([str(i) for i in range(6)]),
+            np.array([str(i) for i in range(4, 10)]) ]
+    transform.update_info(info)
+    feat = np.array([str(i) for i in np.random.randint(0, 10, 100)])
+    feat[0] = int(feat[0])
+    cat_feat = transform(feat)
+    assert "test" in cat_feat
+    for feat, str_i in zip(cat_feat["test"], feat):
+        # make sure one value is 1
+        assert feat[int(str_i)] == 1
+        # after we set the value to 0, the entire vector has 0 values.
+        feat[int(str_i)] = 0
+        assert np.all(feat == 0)
+    assert "mapping" in transform_conf
+    assert len(transform_conf["mapping"]) == 10
+
 @pytest.mark.parametrize("out_dtype", [None, np.float16])
 def test_noop_transform(out_dtype):
     transform = Noop("test", "test", out_dtype=out_dtype)

--- a/tests/unit-tests/gconstruct/test_transform.py
+++ b/tests/unit-tests/gconstruct/test_transform.py
@@ -304,7 +304,7 @@ def test_categorize_transform():
     assert "mapping" in transform_conf
     assert len(transform_conf["mapping"]) == 10
 
-    # check backward compatible
+    # check update_info
     transform_conf = {
         "name": "to_categorical"
     }
@@ -321,6 +321,23 @@ def test_categorize_transform():
         feat[int(str_i)] = 0
         assert np.all(feat == 0)
     assert len(transform_conf["mapping"]) == 10
+
+    # check backward compatible
+     # check update_info
+    transform_conf = {
+        "name": "to_categorical",
+        "mapping": {i: i for i in range(10)}
+    }
+    transform = CategoricalTransform("test1", "test", transform_conf=transform_conf)
+    assert len(transform_conf["mapping"]) == 10
+    cat_feat = transform(feat)
+    assert "test" in cat_feat
+    for feat, str_i in zip(cat_feat["test"], feat):
+        # make sure one value is 1
+        assert feat[int(str_i)] == 1
+        # after we set the value to 0, the entire vector has 0 values.
+        feat[int(str_i)] = 0
+        assert np.all(feat == 0)
 
 @pytest.mark.parametrize("out_dtype", [None, np.float16])
 def test_noop_transform(out_dtype):

--- a/tests/unit-tests/gconstruct/test_transform.py
+++ b/tests/unit-tests/gconstruct/test_transform.py
@@ -305,6 +305,10 @@ def test_categorize_transform():
     assert len(transform_conf["mapping"]) == 10
 
     # check backward compatible
+    transform_conf = {
+        "name": "to_categorical"
+    }
+    transform = CategoricalTransform("test1", "test", transform_conf=transform_conf)
     info = [np.array([i for i in range(6)]),
             np.array([i for i in range(4, 10)])]
     transform.update_info(info)

--- a/tests/unit-tests/gconstruct/test_transform.py
+++ b/tests/unit-tests/gconstruct/test_transform.py
@@ -288,8 +288,8 @@ def test_categorize_transform():
     for i in range(10):
         assert str(i) in res["test"]
 
-    info = [ np.array([str(i) for i in range(6)]),
-            np.array([str(i) for i in range(4, 10)]) ]
+    info = [np.array([str(i) for i in range(6)]),
+            np.array([str(i) for i in range(4, 10)])]
     transform.update_info(info)
     feat = np.array([str(i) for i in np.random.randint(0, 10, 100)])
     feat[0] = int(feat[0])
@@ -302,6 +302,20 @@ def test_categorize_transform():
         feat[int(str_i)] = 0
         assert np.all(feat == 0)
     assert "mapping" in transform_conf
+    assert len(transform_conf["mapping"]) == 10
+
+    # check backward compatible
+    info = [np.array([i for i in range(6)]),
+            np.array([i for i in range(4, 10)])]
+    transform.update_info(info)
+    cat_feat = transform(feat)
+    assert "test" in cat_feat
+    for feat, str_i in zip(cat_feat["test"], feat):
+        # make sure one value is 1
+        assert feat[int(str_i)] == 1
+        # after we set the value to 0, the entire vector has 0 values.
+        feat[int(str_i)] = 0
+        assert np.all(feat == 0)
     assert len(transform_conf["mapping"]) == 10
 
 @pytest.mark.parametrize("out_dtype", [None, np.float16])


### PR DESCRIPTION
*Issue #, if available:*
An error happens when the loaded categorical features include both integers and strings. This may happen when loading features from CSV files.

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
