### PR TITLE
Updated arguments names

### DIFF
--- a/tools/README.md
+++ b/tools/README.md
@@ -56,7 +56,7 @@ python3 /graphstorm/tools/partition_graph.py --dataset ogbn-arxiv \
                                              --filepath /tmp/ogbn-arxiv-nc/ \
                                              --num-parts 2 \
                                              --output /tmp/ogbn_arxiv_nc_2p
-                                             --bert-name "allenai/scibert_scivocab_uncased"
+                                             --lm-model-name "allenai/scibert_scivocab_uncased"
 ```
 
 Below command can download the OGBN mag data, process it into DGL graph, and finally split it into two partition. The partitioned graph is save at the /tmp/ogbn_mag_lp_2p folder.

--- a/tools/gen_ogb_dataset.py
+++ b/tools/gen_ogb_dataset.py
@@ -25,7 +25,7 @@ if __name__ == '__main__':
     parser.add_argument("--savepath", type=str, default=None)
     parser.add_argument("--edge-pct", type=float, default=1)
     parser.add_argument("--dataset",type=str,default="ogbn-arxiv")
-    parser.add_argument('--bert-model-name',type=str,default="bert-base-uncased")
+    parser.add_argument('--lm-model-name',type=str,default="bert-base-uncased")
     parser.add_argument("--max-sequence-length", type=int, default=512)
     parser.add_argument("--retain-original-features",
                         type=lambda x: (str(x).lower() in ['true', '1']), default=True)
@@ -36,7 +36,7 @@ if __name__ == '__main__':
     dataset = OGBTextFeatDataset(args.filepath,
                                  args.dataset,
                                  edge_pct=args.edge_pct,
-                                 bert_model_name=args.bert_model_name,
+                                 lm_model_name=args.lm_model_name,
                                  max_sequence_length=args.max_sequence_length,
                                  retain_original_features=args.retain_original_features,
                                  is_homo=args.is_homo)


### PR DESCRIPTION
I found that:
- `gen_ogb_dataset.py` uses argument name `bert_model_name` to initialize `OGBTextFeatDataset` object. It was changed to `lm_model_name` in #386.

- `partition_graph.py` takes `--lm-model-name` argument instead of `--bert-name`.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
