### PR TITLE
argument num_classess > 0 instead of > 1

### DIFF
--- a/python/graphstorm/config/argument.py
+++ b/python/graphstorm/config/argument.py
@@ -1249,9 +1249,9 @@ class GSConfig:
             "Must provide the number possible labels through num_classes"
         if isinstance(self._num_classes, dict):
             for num_classes in self._num_classes.values():
-                assert num_classes > 1
+                assert num_classes > 0
         else:
-            assert self._num_classes > 1
+            assert self._num_classes > 0
         return self._num_classes
 
     @property

--- a/python/graphstorm/config/argument.py
+++ b/python/graphstorm/config/argument.py
@@ -1791,10 +1791,10 @@ class GSConfig:
             BUILTIN_TASK_EDGE_CLASSIFICATION]:
             if isinstance(self.num_classes, dict):
                 for num_classes in self.num_classes.values():
-                    assert num_classes > 1, \
+                    assert num_classes > 0, \
                         "For node classification, num_classes must be provided"
             else:
-                assert self.num_classes > 1, \
+                assert self.num_classes > 0, \
                     "For node classification, num_classes must be provided"
 
             # check evaluation metrics

--- a/python/graphstorm/config/argument.py
+++ b/python/graphstorm/config/argument.py
@@ -1254,7 +1254,9 @@ class GSConfig:
             # We need assert num_classes>0 so that we can use num_classes=1 for binary classification
             # We prefer num_classes=1 and binary-cross-entropy because sometime we need precision-recall
             # as evaluation metric, where precision-recall is computed on the positive score.
-            # If we switch to num_classes=2 and cross-entropy, we also need changes in the evaluation part.
+            # If we switch to num_classes=2 and cross-entropy, we also need changes in the evaluation part,
+            # and make the new evaluation code to first recognize whether it is binary classification
+            # then only select the positive score column.
             assert self._num_classes > 0
 
         return self._num_classes

--- a/python/graphstorm/config/argument.py
+++ b/python/graphstorm/config/argument.py
@@ -1257,7 +1257,6 @@ class GSConfig:
             # (1) evaluation code need to first recognize whether it is binary classification
             # (2) then evaluation code select the positive score column from the 2-d prediction.
             assert self._num_classes > 0
-
         return self._num_classes
 
     @property

--- a/python/graphstorm/config/argument.py
+++ b/python/graphstorm/config/argument.py
@@ -1251,12 +1251,11 @@ class GSConfig:
             for num_classes in self._num_classes.values():
                 assert num_classes > 0
         else:
-            # We need assert num_classes>0 so that we can use num_classes=1 for binary classification
-            # We prefer num_classes=1 and binary-cross-entropy because sometime we need precision-recall
-            # as evaluation metric, where precision-recall is computed on the positive score.
-            # If we switch to num_classes=2 and cross-entropy, we also need changes in the evaluation part,
-            # and make the new evaluation code to first recognize whether it is binary classification
-            # then only select the positive score column.
+            # We need num_classes=1 for binary classification because when we use precision-recall
+            # as evaluation metric, this precision-recall is computed on the positive score.
+            # If we switch to num_classes=2, we also need changes in the evaluation part:
+            # (1) evaluation code need to first recognize whether it is binary classification
+            # (2) then evaluation code select the positive score column from the 2-d prediction.
             assert self._num_classes > 0
 
         return self._num_classes

--- a/python/graphstorm/config/argument.py
+++ b/python/graphstorm/config/argument.py
@@ -1251,7 +1251,12 @@ class GSConfig:
             for num_classes in self._num_classes.values():
                 assert num_classes > 0
         else:
+            # We need assert num_classes>0 so that we can use num_classes=1 for binary classification
+            # We prefer num_classes=1 and binary-cross-entropy because sometime we need precision-recall
+            # as evaluation metric, where precision-recall is computed on the positive score.
+            # If we switch to num_classes=2 and cross-entropy, we also need changes in the evaluation part.
             assert self._num_classes > 0
+
         return self._num_classes
 
     @property

--- a/tests/unit-tests/test_config.py
+++ b/tests/unit-tests/test_config.py
@@ -821,7 +821,7 @@ def create_edge_class_config(tmp_path, file_name):
         "target_etype": "query,match,asin",
         "reverse_edge_types_map": "query,match,rev-match,asin",
         "multilabel": "error",
-        "num_classes": 1,
+        "num_classes": 0,
         "num_decoder_basis": 1,
         "remove_target_edge_type": "error",
         "decoder_edge_feat": ["query,no-match,asin:feat0,feat1"]


### PR DESCRIPTION
*Issue #, if available:*

If our task is binary classification and evaluate by precision-recall, we might need to set `num_classes = 1` and `multilabel=true`.

We may not want to set `num_classes = 2` and `multilabel=false` for this case because precision-recall is computed on the positive class.

*Description of changes:*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
