### PR TITLE
Update np_trainer.py

### DIFF
--- a/python/graphstorm/trainer/np_trainer.py
+++ b/python/graphstorm/trainer/np_trainer.py
@@ -90,6 +90,7 @@ class GSgnnNodePredictionTrainer(GSgnnTrainer):
         if self.evaluator is not None:
             assert val_loader is not None, \
                     "The evaluator is provided but validation set is not provided."
+            return_proba = True if self.evaluator.metric() == ['precision_recall'] else False
         if not use_mini_batch_infer:
             assert isinstance(self._model, GSgnnModel), \
                     "Only GSgnnModel supports full-graph inference."
@@ -167,9 +168,10 @@ class GSgnnNodePredictionTrainer(GSgnnTrainer):
                 if self.evaluator is not None and \
                     self.evaluator.do_eval(total_steps, epoch_end=False) and \
                     val_loader is not None:
+
                     val_score = self.eval(model.module if is_distributed() else model,
                                           val_loader, test_loader,
-                                          use_mini_batch_infer, total_steps, return_proba=False)
+                                          use_mini_batch_infer, total_steps, return_proba=return_proba)
 
                     if self.evaluator.do_early_stop(val_score):
                         early_stop = True
@@ -204,7 +206,7 @@ class GSgnnNodePredictionTrainer(GSgnnTrainer):
             if self.evaluator is not None and self.evaluator.do_eval(total_steps, epoch_end=True):
                 val_score = self.eval(model.module if is_distributed() else model,
                                       val_loader, test_loader,
-                                      use_mini_batch_infer, total_steps, return_proba=False)
+                                      use_mini_batch_infer, total_steps, return_proba=return_proba)
                 if self.evaluator.do_early_stop(val_score):
                     early_stop = True
 


### PR DESCRIPTION
*Issue #, if available:*

when using precision_recall as evaluation metric, we need to set `return_proba=True` because scikit-learn's precision_recall_curve takes probability as input.

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
