### PR TITLE
Fix the case when some categories do not exist in transform_conf

### DIFF
--- a/python/graphstorm/gconstruct/transform.py
+++ b/python/graphstorm/gconstruct/transform.py
@@ -435,7 +435,8 @@ class CategoricalTransform(TwoPhaseFeatTransform):
             for i, feat in enumerate(feats):
                 if feat is None:
                     continue
-                idx = [self._val_dict[val] for val in feat.split(self._separator) if val in self._val_dict]
+                idx = [self._val_dict[val] for val in feat.split(self._separator) \
+                       if val in self._val_dict]
                 encoding[i, idx] = 1
         return {self.feat_name: encoding}
 

--- a/python/graphstorm/gconstruct/transform.py
+++ b/python/graphstorm/gconstruct/transform.py
@@ -428,12 +428,14 @@ class CategoricalTransform(TwoPhaseFeatTransform):
             for i, feat in enumerate(feats):
                 if feat is None:
                     continue
-                encoding[i, self._val_dict[str(feat)]] = 1
+                if str(feat) in self._val_dict:
+                    encoding[i, self._val_dict[str(feat)]] = 1
+                # if key does not exist, keep the feature as all zeros.
         else:
             for i, feat in enumerate(feats):
                 if feat is None:
                     continue
-                idx = [self._val_dict[val] for val in feat.split(self._separator)]
+                idx = [self._val_dict[val] for val in feat.split(self._separator) if val in self._val_dict]
                 encoding[i, idx] = 1
         return {self.feat_name: encoding}
 

--- a/tests/unit-tests/gconstruct/test_transform.py
+++ b/tests/unit-tests/gconstruct/test_transform.py
@@ -219,6 +219,22 @@ def test_categorize_transform():
     assert np.all(cat_feat["test"][0] == 0)
     assert np.all(cat_feat["test"][1] == 0)
 
+    feat = [str(i) for i in np.random.randint(0, 10, 100)]
+    feat_with_unknown = feat[:]
+    feat_with_unknown[0] = "10"
+    feat = np.array(feat)
+    feat_with_unknown = np.array(feat_with_unknown)
+    cat_feat = transform(feat)
+    assert "test" in cat_feat
+    for i, (feat, str_i) in enumerate(zip(cat_feat["test"], feat)):
+        if i == 0:
+            continue
+        # make sure one value is 1
+        assert feat[int(str_i)] == 1
+        # after we set the value to 0, the entire vector has 0 values.
+        feat[int(str_i)] = 0
+        assert np.all(feat == 0)
+
     # Test categorical values with empty strings.
     transform = CategoricalTransform("test1", "test", separator=',')
     str_ids = [f"{i},{i+1}" for i in np.random.randint(0, 9, 1000)] + [",0"]
@@ -242,6 +258,24 @@ def test_categorize_transform():
     transform.update_info(info)
     feat = np.array([f"{i},{i+1}" for i in np.random.randint(0, 9, 100)])
     cat_feat = transform(feat)
+    assert "test" in cat_feat
+    for feat, str_feat in zip(cat_feat["test"], feat):
+        # make sure two elements are 1
+        i = str_feat.split(",")
+        assert feat[int(i[0])] == 1
+        assert feat[int(i[1])] == 1
+        # after removing the elements, the vector has only 0 values.
+        feat[int(i[0])] = 0
+        feat[int(i[1])] = 0
+        assert np.all(feat == 0)
+
+    # feat contains unknown keys
+    feat = [f"{i},{i+1}" for i in np.random.randint(0, 9, 100)]
+    feat_with_unknown = feat[:]
+    feat_with_unknown[0] = feat[0]+",10"
+    feat = np.array(feat)
+    feat_with_unknown = np.array(feat_with_unknown)
+    cat_feat = transform(feat_with_unknown)
     assert "test" in cat_feat
     for feat, str_feat in zip(cat_feat["test"], feat):
         # make sure two elements are 1


### PR DESCRIPTION
For CategoricalTransform, when it is doing transformation given a pre-defined mapping table, it is possible that, the new graph data have some unknown categories. This PR will ignore these unknown categories and set the corresponding feature as all zeros. 



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
