### PR TITLE
[Bug fix]Fix hgt_encoder no edge error

### DIFF
--- a/python/graphstorm/model/hgt_encoder.py
+++ b/python/graphstorm/model/hgt_encoder.py
@@ -189,6 +189,7 @@ class HGTLayer(nn.Module):
         """
         # pylint: disable=no-member
         with g.local_scope():
+            edge_fn = {}
             for srctype, etype, dsttype in g.canonical_etypes:
                 c_etype_str = '_'.join((srctype, etype, dsttype))
                 # extract each relation as a sub graph
@@ -227,9 +228,6 @@ class HGTLayer(nn.Module):
                 attn_score = edge_softmax(sub_graph, attn_score, norm_by='dst')
                 sub_graph.edata[f't_{c_etype_str}'] = attn_score.unsqueeze(-1)
 
-            edge_fn = {}
-            for srctype, etype, dsttype in g.canonical_etypes:
-                c_etype_str = '_'.join((srctype, etype, dsttype))
                 edge_fn[srctype, etype, dsttype] = (fn.u_mul_e(f'v_{c_etype_str}',
                                                                f't_{c_etype_str}', 'm'),
                                                     fn.sum('m', 't'))


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This PR fixed the error when no edge exists in a block, but the relation type still exist.

The previous code assign `edge_fn` to all relation types in a mini-batch. But some mini-batchs could have the case where there is no edge for a specific relation type. In such case, the that relation type has an `edge_fn`, but no nodes and edges. When call `multi_update_all()` function, that relation type will fail due to no node or edge data.

The new implementation will filter up such no-edge relation type, and only assign `edge_fn` to relation types having edges. Therefore fix this issue.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
