### PR TITLE
Fix lint does not work with astroid==3.0 error.

### DIFF
--- a/.github/workflow_scripts/lint_check.sh
+++ b/.github/workflow_scripts/lint_check.sh
@@ -4,6 +4,8 @@ cd ../../
 set -ex
 
 python3 -m pip install --upgrade prospector pip
+pip3 uninstall -y astroid
+yes | pip3 install astroid==2.15.7
 FORCE_CUDA=1 python3 -m pip install -e '.[test]'  --no-build-isolation
 pylint --rcfile=./tests/lint/pylintrc ./python/graphstorm/data/*.py
 pylint --rcfile=./tests/lint/pylintrc ./python/graphstorm/dataloading/


### PR DESCRIPTION
`python3 -m pip install --upgrade prospector pip` has a change to install astroid==3.0 (do not know why) which is not compatible with lint.

Fix astroid version to 2.15.7 in this PR.



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
