### PR TITLE
[Bug Fix] Fix HGT example's infer to inferrer

### DIFF
--- a/examples/customized_models/HGT/hgt_nc.py
+++ b/examples/customized_models/HGT/hgt_nc.py
@@ -11,7 +11,7 @@ import graphstorm as gs
 from graphstorm.config import GSConfig
 from graphstorm import model as gsmodel
 from graphstorm.trainer import GSgnnNodePredictionTrainer
-from graphstorm.inference import GSgnnNodePredictionInfer
+from graphstorm.inference import GSgnnNodePredictionInferrer
 from graphstorm.dataloading import GSgnnNodeTrainData, GSgnnNodeInferData
 from graphstorm.dataloading import GSgnnNodeDataLoader
 from graphstorm.eval import GSgnnAccEvaluator
@@ -357,7 +357,7 @@ def main(args):
                                     label_field=config.label_field)
 
     # Create an inference for a node task.
-    infer = GSgnnNodePredictionInfer(model)
+    infer = GSgnnNodePredictionInferrer(model)
     infer.setup_device(device=device)
     infer.setup_evaluator(evaluator)
     infer.setup_task_tracker(tracker)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This PR fixed the naming error in the HGT example python file, using the new `GSgnnNodePredictionInferrer` class name.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
