### PR TITLE
[Doc] Improving instruction for a distributed setting

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -6,3 +6,4 @@
 * [Prateek M Desai](https://github.com/prateekdesai04) from AWS
 * [Israt Nisa](https://github.com/isratnisa) from AWS
 * [Vasileios Ioannidis](https://github.com/bioannidis) from AWS
+* [Dominika Jedynak](https://github.com/DominikaJedynak) from Intel

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 ## GraphStorm
-|[Document and Tutorial Site](https://github.com/awslabs/graphstorm/wiki) |
+|[Document and Tutorial Site](https://graphstorm.readthedocs.io/en/latest/) |
 
 GraphStorm is a graph machine learning (GML) framework for enterprise use cases.
 It simplifies the development, training and deployment of GML models for industry-scale graphs
@@ -18,11 +18,11 @@ provide their own model implementations and use GraphStorm training pipeline to 
 ### Installation
 GraphStorm is compatible to Python 3.7+. It requires PyTorch 1.13+, DGL 1.0 and transformers 4.3.0+.
 
-To install GraphStorm in your environment, you can clone the repository and run `python3 setup.py install` to install it. However, running GraphStorm in a distributed environment is non-trivial. Users need to install dependencies and configure distributed Pytorch running environments. For this reason, we highly recommend users to using [Docker](https://docs.docker.com/get-started/overview/) container to run GraphStorm. A guideline to build GraphStorm docker image and run it on Amazon EC2 can be found at [here](https://github.com/awslabs/graphstorm/tree/main/docker).
+To install GraphStorm in your environment, you can clone the repository and run `python3 setup.py install` to install it. However, running GraphStorm in a distributed environment is non-trivial. Users need to install dependencies and configure distributed Pytorch running environments. For this reason, we highly recommend users to using [Docker](https://docs.docker.com/get-started/overview/) container to run GraphStorm. A guideline to build GraphStorm docker image and run it on Amazon EC2 can be found at [here](https://graphstorm.readthedocs.io/en/latest/install/env-setup.html#setup-graphstorm-docker-environment) and a full instruction on how to setup distributed training can be found [here](https://graphstorm.readthedocs.io/en/latest/scale/distributed.html).
 
 ### Run GraphStorm with OGB datasets
 
-**Note**: we assume users have setup their Docker container following the [Build a Docker image from source](https://github.com/awslabs/graphstorm/tree/main/docker#build-a-docker-image-from-source) instructions. All following commands run within a Docker container.
+**Note**: we assume users have setup their Docker container following the [Build a Docker image from source](https://graphstorm.readthedocs.io/en/latest/install/env-setup.html#build-a-graphstorm-docker-image-from-source-code) instructions. All following commands run within a Docker container.
 
 **Start the GraphStorm docker container**
 First, start your docker container by running the following command:

--- a/docker/README.md
+++ b/docker/README.md
@@ -23,7 +23,7 @@ sudo apt install Docker.io
 ## Build a Docker image from source
 ---------------
 
-Please use the following command to build a Docker image from source:
+Once you have the GraphStorm repository cloned, please use the following command to build a Docker image from source:
 ```shell
 cd /path-to-graphstorm/docker/
 
@@ -33,11 +33,13 @@ bash /path-to-graphstorm/docker/build_docker_oss4local.sh /path-to-graphstorm/ d
 There are three arguments of the `build_docker_oss4local.sh`:
 
 1. **path-to-graphstorm**(required), is the absolute path of the "graphstorm" folder, where you
-clone the GraphStorm source code. For example, the path could be "/code/graphstorm".
+cloned the GraphStorm source code. For example, the path could be "/code/graphstorm".
 2. **docker-name**(optional), is the assigned name of the to be built Docker image. Default is
 "graphstorm".
 3. **docker-tag**(optional), is the assigned tag name of the to be built docker image. Default is
 "local".
+
+If Docker requires you to run it as a root user and you don't want to preface all docker commands with sudo, you can check the solution available [here](https://docs.docker.com/engine/install/linux-postinstall/#manage-docker-as-a-non-root-user).
 
 You can use the below command to check if the new image exists.
 ```shell

--- a/docs/source/install/env-setup.rst
+++ b/docs/source/install/env-setup.rst
@@ -3,7 +3,7 @@
 Environment Setup
 ======================
 GraphStorm supports two environment setup methods:
-    - Install GraphStorm using as a pip packcage. This method works well for development and test on a signle machine.
+    - Install GraphStorm as a pip package. This method works well for development and test on a single machine.
     - Setup a GraphStorm Docker image. This method is good for using GraphStorm in distributed environments that commonly used in production.
 
 .. _setup_pip:
@@ -125,6 +125,8 @@ There are three arguments of the ``build_docker_oss4local.sh``:
 2. **docker-name** (optional), is the assigned name of the to be built Docker image. Default is ``graphstorm``.
 3. **docker-tag** (optional), is the assigned tag name of the to be built docker image. Default is ``local``.
 
+If Docker requires you to run it as a root user and you don't want to preface all docker commands with sudo, you can check the solution available `here <https://docs.docker.com/engine/install/linux-postinstall/#manage-docker-as-a-non-root-user>`_.
+
 You can use the below command to check if the new Docker image is created successfully.
 
 .. code:: bash
@@ -137,6 +139,10 @@ Create a GraphStorm Container
 ..............................
 
 First, you need to create a GraphStorm container based on the Docker image built in the previous step.
+
+.. note::
+
+    If you are preparing the environment to run GraphStorm in a distributed setting, specific instruction for running a Docker image with the NFS folder is given in :ref:`this section<distributed-cluster>`.
 
 Run the following command:
 

--- a/docs/source/scale/distributed.rst
+++ b/docs/source/scale/distributed.rst
@@ -70,7 +70,7 @@ In the container environment, users can check the connectivity with the command 
 
 .. code-block:: bash
 
-    ssh 172.38.12.143 -p 2222
+    ssh 172.38.12.143 -o StrictHostKeyChecking=no -p 2222
 
 If succeeds, you should login to the container in the ``<ip-in-the-cluster>`` instance. 
 

--- a/docs/source/scale/distributed.rst
+++ b/docs/source/scale/distributed.rst
@@ -16,7 +16,7 @@ Create a GraphStorm Cluster
 
 Setup the instance of a cluster
 .......................................
-A cluster contains several GPU installed instances each of which can run GraphStorm Docker container. For each instance, please follow the :ref:`Environment Setup <setup>` description to setup GraphStorm Docker container environment. This tutorial uses three EC2 instances in the cluster.
+A cluster contains several GPU installed instances each of which can run GraphStorm Docker container. For each instance, please follow the :ref:`Environment Setup <setup_docker>` description to setup GraphStorm Docker container environment. This tutorial uses three EC2 instances in the cluster.
 
 Setup of a shared file system for the cluster
 ...............................................
@@ -66,7 +66,7 @@ Pick one instance and run the following command to connect to the GraphStorm Doc
 
     docker container exec -it test /bin/bash
 
-In the container environment, users can check the connectivity with the command ``ssh <ip-in-the-cluster> -p 2222``. Please replacing the ``<ip-in-the-cluster>`` with the real IP address in the ``ip_list.txt`` file above, e.g., 
+In the container environment, users can check the connectivity with the command ``ssh <ip-in-the-cluster> -o StrictHostKeyChecking=no -p 2222``. Please replace the ``<ip-in-the-cluster>`` with the real IP address from the ``ip_list.txt`` file above, e.g.,
 
 .. code-block:: bash
 
@@ -75,6 +75,7 @@ In the container environment, users can check the connectivity with the command 
 If succeeds, you should login to the container in the ``<ip-in-the-cluster>`` instance. 
 
 If not, please make sure there is no limitation of port 2222. 
+You may also have to exchange the keys from inside the GraphStorm Docker containers to allow their communication. For that, copy the keys from the ``/root/.ssh/id_rsa.pub`` from this container to ``/root/.ssh/authorized_keys`` in containers on every machine in your cluster.
 
 For distributed training, users also need to make sure ports under 65536 is open for DistDGL to use.
 
@@ -85,7 +86,7 @@ Partition a Graph
 
 .. note::
 
-    All commands below should be run in a GraphStorm Docker container. Please refer to the :ref:`GraphStorm Docker environment setup<setup>` to prepare your environment.
+    All commands below should be run in a GraphStorm Docker container. Please refer to the :ref:`GraphStorm Docker environment setup<setup_docker>` to prepare your environment.
 
 Now we can download and process the OGBN-MAG data with the command below.
 


### PR DESCRIPTION
This PR fixes some small issues in the instructions on how to setup a (distributed) environment for GraphStorm. It: 

- changes some links so that they point to GraphStorm's docs instead of to deprecated wiki,
- changes/adds some links so that they point to more accurate parts of the instruction,
- adds the tip how to avoid having to preface all Docker commands with _sudo_ (which is the case by default on some AWS instances),
- adds _-o StrictHostKeyChecking=no_ flag for checking the connectivity between containers (which is also used for connecting in _python/graphstorm/run/launch.py_ file and without which it seems impossible to connect following the current instruction),
- adds a step of exchanging the ssh keys between Docker containers

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
