### PR TITLE
[Doc] Add return_proba argument explanation

### DIFF
--- a/docs/source/configuration/configuration-run.rst
+++ b/docs/source/configuration/configuration-run.rst
@@ -275,7 +275,7 @@ General Configurations
     - Yaml: ``task_type: node_classification``
     - Argument: ``--task-type node_classification``
     - Default value: This parameter must be provided by user.
-- **eval_metric**: Evaluation metric used during evaluation. The input can be a string specifying the evaluation metric to report or a list of strings specifying a list of evaluation metrics to report. The first evaluation metric is treated as the major metric and is used to choose the best trained model. The supported evaluation metrics of classification tasks include ``accuracy``, ``precision_recall``, ``roc_auc``, ``f1_score``, ``per_class_f1_score``. The supported evaluation metrics of regression tasks include ``rmse``, ``mse`` and ``mae``. The supported evaluation metrics of link prediction tasks include ``mrr``.
+- **eval_metric**: Evaluation metric used during evaluation. The input can be a string specifying the evaluation metric to report or a list of strings specifying a list of evaluation metrics to report. The first evaluation metric is treated as the major metric and is used to choose the best trained model. The supported evaluation metrics of classification tasks include ``accuracy``, ``precision_recall``, ``roc_auc``, ``f1_score``, ``per_class_f1_score``. The supported evaluation metrics of regression tasks include ``rmse``, ``mse`` and ``mae``. The supported evaluation metrics of link prediction tasks include ``mrr``. 
     - Yaml: ``eval_metric:``
         | ``- accuracy``
         | ``- precision_recall``
@@ -284,6 +284,10 @@ General Configurations
             - For classification tasks, the default value is ``accuracy``.
             - For regression tasks, the default value is ``rmse``.
             - For link prediction tasks, the default value is ``mrr``.
+
+.. note::
+
+    To use ``precision_recall`` and ``roc_auc``, please set the **return_proba** to be `false`.
 
 Classification and Regression Task
 ......................................

--- a/docs/source/configuration/configuration-run.rst
+++ b/docs/source/configuration/configuration-run.rst
@@ -285,10 +285,6 @@ General Configurations
             - For regression tasks, the default value is ``rmse``.
             - For link prediction tasks, the default value is ``mrr``.
 
-.. note::
-
-    To use ``precision_recall`` and ``roc_auc``, please set the **return_proba** to be `false`.
-
 Classification and Regression Task
 ......................................
 - **label_field**: (**Required**) The field name of labelled data in the graph data. For node classification tasks, GraphStorm use ``graph.nodes[target_ntype].data[label_field]`` to access node labels. For edge classification tasks, GraphStorm use ``graph.edges[target_etype].data[label_field]`` to access edge labels.
@@ -311,7 +307,7 @@ Classification and Regression Task
     - Yaml: ``imbalance_class_weights: 0.1,0.2,0.3``
     - Argument: ``--imbalance-class-weights 0.1,0.2,0.3``
     - Default value: ``None``
-- **return_proba**: For classification task, this configuraiton determines whether to return prediction probability or the argmax prediction. Set `true`` to return predictions probability and `false` to return the argmax prediction.
+- **return_proba**: For classification task, this configuraiton determines whether to return probability estimates for each class or the maximum probable class. Set `true`` to return probability estimates and `false` to return the maximum probable class.
     - Yaml: ``return_proba: true``
     - Argument: ``--return_proba true``
     - Default value: ``true``

--- a/docs/source/configuration/configuration-run.rst
+++ b/docs/source/configuration/configuration-run.rst
@@ -307,6 +307,10 @@ Classification and Regression Task
     - Yaml: ``imbalance_class_weights: 0.1,0.2,0.3``
     - Argument: ``--imbalance-class-weights 0.1,0.2,0.3``
     - Default value: ``None``
+- **return_proba**: For classification task, this configuraiton determines whether to return prediction probability or the argmax prediction. Set `true`` to return predictions probability and `false` to return the argmax prediction.
+    - Yaml: ``return_proba: true``
+    - Argument: ``--return_proba true``
+    - Default value: ``true``
 - **save_prediction_path**: Path to save prediction results. This is used in node/edge classification/regression inference.
     - Yaml: ``save_prediction_path: /data/infer-output/predictions/``
     - Argument: ``--save-prediction-path /data/infer-output/predictions/``

--- a/docs/source/configuration/configuration-run.rst
+++ b/docs/source/configuration/configuration-run.rst
@@ -26,7 +26,7 @@ GraphStorm's `graphstorm.run.launch <https://github.com/awslabs/graphstorm/blob/
     - NCCL_DEBUG=INFO
 - **lm-encoder-only**: Indicate that the model is using language model + decoder only. model. No GNN is involved, only graph structure.
 
-..  note:: Below configurations can be set either in a YAML configuraiton file or be added as arguments of launch command.
+..  note:: Below configurations can be set either in a YAML configuration file or be added as arguments of launch command.
 
 Environment Configurations
 -------------------------------------
@@ -307,7 +307,7 @@ Classification and Regression Task
     - Yaml: ``imbalance_class_weights: 0.1,0.2,0.3``
     - Argument: ``--imbalance-class-weights 0.1,0.2,0.3``
     - Default value: ``None``
-- **return_proba**: For classification task, this configuraiton determines whether to return probability estimates for each class or the maximum probable class. Set `true`` to return probability estimates and `false` to return the maximum probable class.
+- **return_proba**: For classification task, this configuration determines whether to return probability estimates for each class or the maximum probable class. Set `true`` to return probability estimates and `false` to return the maximum probable class.
     - Yaml: ``return_proba: true``
     - Argument: ``--return_proba true``
     - Default value: ``true``


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This PR fix the documentation of `return_proba`:
- Add the return_proba argument;
- Add a note on eval_metric.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
