### PR TITLE
[Bug Fix] Fix RGAT when inputs of rgat.forward have shape (0, x)

### DIFF
--- a/python/graphstorm/model/hgt_encoder.py
+++ b/python/graphstorm/model/hgt_encoder.py
@@ -68,7 +68,7 @@ class HGTLayer(nn.Module):
 
     Note:
     -----
-    * Different from DGL's HGTConv, this implementation is based on heterogeneous graph. Other 
+    * Different from DGL's HGTConv, this implementation is based on heterogeneous graph. Other
       hyperparameters' default values are same as the DGL's HGTConv setting.
 
     * The cross-relation aggregation function of this implementation is `mean`, which was chosen
@@ -76,7 +76,7 @@ class HGTLayer(nn.Module):
 
     Examples:
     ----------
-    
+
     .. code:: python
 
         # suppose graph and input_feature are ready
@@ -85,7 +85,7 @@ class HGTLayer(nn.Module):
         layer = HGTLayer(hid_dim, out_dim, g.ntypes, g.canonical_etypes,
                          num_heads, activation, dropout, norm)
         h = layer(g, input_feature)
-        
+
     Parameters
     ----------
     in_dim : int
@@ -264,7 +264,8 @@ class HGTLayer(nn.Module):
                         trans_out = self.drop(self.a_linears[k](h[k]))
                         trans_out = trans_out * alpha + h[k] * (1-alpha)
                 else:
-                    continue
+                    # handle the case when len(h[k]) is 0
+                    new_h[k] = h[k].new_empty((0, self.out_dim))
 
                 if self.use_norm:
                     new_h[k] = self.norms[k](trans_out)
@@ -382,7 +383,7 @@ class HGTEncoder(GraphConvEncoder):
             Sampled subgraph in DGL MFG
         h: dict[str, torch.Tensor]
             Input node feature for each node type.
-            
+
         Returns
         ----------
         h: dict[str, torch.Tensor]

--- a/python/graphstorm/model/hgt_encoder.py
+++ b/python/graphstorm/model/hgt_encoder.py
@@ -264,8 +264,7 @@ class HGTLayer(nn.Module):
                         trans_out = self.drop(self.a_linears[k](h[k]))
                         trans_out = trans_out * alpha + h[k] * (1-alpha)
                 else:
-                    # handle the case when len(h[k]) is 0
-                    new_h[k] = h[k].new_empty((0, self.out_dim))
+                    continue
 
                 if self.use_norm:
                     new_h[k] = self.norms[k](trans_out)

--- a/python/graphstorm/model/rgat_encoder.py
+++ b/python/graphstorm/model/rgat_encoder.py
@@ -177,6 +177,11 @@ class RelationalAttLayer(nn.Module):
         hs = self.conv(g, inputs_src)
 
         def _apply(ntype, h):
+            # handle the case when len(h) is 0
+            if h.shape[0] == 0:
+                shape = list(inputs[ntype].shape)
+                shape[0] = 0
+                return h.reshape(shape)
             if self.self_loop:
                 h = h + th.matmul(inputs_dst[ntype], self.loop_weight)
             if self.bias:

--- a/python/graphstorm/model/rgat_encoder.py
+++ b/python/graphstorm/model/rgat_encoder.py
@@ -179,9 +179,7 @@ class RelationalAttLayer(nn.Module):
         def _apply(ntype, h):
             # handle the case when len(h) is 0
             if h.shape[0] == 0:
-                shape = list(inputs[ntype].shape)
-                shape[0] = 0
-                return h.reshape(shape)
+                return h.reshape((0, self.out_feat))
             if self.self_loop:
                 h = h + th.matmul(inputs_dst[ntype], self.loop_weight)
             if self.bias:

--- a/tests/unit-tests/test_nn_model.py
+++ b/tests/unit-tests/test_nn_model.py
@@ -65,7 +65,7 @@ def create_dummy_test_graph(dim):
     return block, inputs, list(edges.keys())
 
 @pytest.mark.parametrize("input_dim", [32])
-@pytest.mark.parametrize("output_dim", [32, 64])
+@pytest.mark.parametrize("output_dim", [32])
 def test_rgcn_with_zero_input(input_dim, output_dim):
     block, inputs, etypes = create_dummy_test_graph(input_dim)
 
@@ -108,5 +108,5 @@ def test_rgat_with_zero_input(input_dim, output_dim):
 
 
 if __name__ == '__main__':
-    test_rgcn_with_zero_input(32,64)
+    test_rgcn_with_zero_input(32,32)
     test_rgat_with_zero_input(32,64)

--- a/tests/unit-tests/test_nn_model.py
+++ b/tests/unit-tests/test_nn_model.py
@@ -1,0 +1,110 @@
+"""
+    Copyright 2023 Contributors
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+    Test basic Nueral Network modules
+"""
+import pytest
+import tempfile
+import torch as th
+import dgl
+
+from graphstorm.model.rgat_encoder import RelationalAttLayer
+from graphstorm.model.rgcn_encoder import RelGraphConvLayer
+
+def create_dummy_test_graph(dim):
+    num_src_nodes = {
+        "n0": 1024,
+        "n1": 0,
+        "n2": 0,
+        "n3": 0,
+        "n4": 0,
+    }
+    num_nodes_dict = {
+        "n0": 1024,
+        "n1": 0,
+        "n2": 0,
+        "n3": 0,
+        "n4": 0,
+    }
+
+    edges = {
+    ("n1", "r0", "n0"): (th.empty((0,), dtype=th.int64),
+                            (th.empty((0,), dtype=th.int64))),
+    ("n2", "r1", "n0"): (th.empty((0,), dtype=th.int64),
+                            (th.empty((0,), dtype=th.int64))),
+    ("n3", "r2", "n1"): (th.empty((0,), dtype=th.int64),
+                            (th.empty((0,), dtype=th.int64))),
+    ("n4", "r3", "n2"): (th.empty((0,), dtype=th.int64),
+                            (th.empty((0,), dtype=th.int64))),
+    ("n0", "r4", "n3"): (th.empty((0,), dtype=th.int64),
+                            (th.empty((0,), dtype=th.int64))),
+    }
+
+    block = dgl.create_block(edges,
+        num_src_nodes=num_src_nodes,
+        num_dst_nodes=num_nodes_dict)
+
+    inputs = {"n0": th.zeros((1024,dim)),
+              "n1": th.empty((0,dim)),
+              "n2": th.empty((0,dim)),
+              "n3": th.empty((0,dim)),
+              "n4": th.empty((0,dim)),}
+
+    return block, inputs, list(edges.keys())
+
+def test_rgcn_with_zero_input():
+    dim = 32
+    block, inputs, etypes = create_dummy_test_graph(32)
+
+    layer = RelGraphConvLayer(
+        dim, dim, etypes,
+        2, activation=th.nn.ReLU(), self_loop=True,
+        dropout=0.1)
+
+    out = layer(block, inputs)
+    assert out["n0"].shape[0] == 1024
+    assert out["n0"].shape[1] == 32
+    assert out["n1"].shape[0] == 0
+    assert out["n1"].shape[1] == 32
+    assert out["n2"].shape[0] == 0
+    assert out["n2"].shape[1] == 32
+    assert out["n3"].shape[0] == 0
+    assert out["n3"].shape[1] == 32
+    assert "n4" not in out
+
+def test_rgat_with_zero_input():
+    dim = 32
+    block, inputs, etypes = create_dummy_test_graph(32)
+
+    layer = RelationalAttLayer(
+        dim, dim, etypes,
+        2, activation=th.nn.ReLU(), self_loop=True,
+        dropout=0.1)
+
+    out = layer(block, inputs)
+    assert out["n0"].shape[0] == 1024
+    assert out["n0"].shape[1] == 32
+    assert out["n1"].shape[0] == 0
+    assert out["n1"].shape[1] == 32
+    assert out["n2"].shape[0] == 0
+    assert out["n2"].shape[1] == 32
+    assert out["n3"].shape[0] == 0
+    assert out["n3"].shape[1] == 32
+    assert "n4" not in out
+
+
+if __name__ == '__main__':
+    test_rgcn_with_zero_input()
+    test_rgat_with_zero_input()

--- a/tests/unit-tests/test_nn_model.py
+++ b/tests/unit-tests/test_nn_model.py
@@ -64,47 +64,49 @@ def create_dummy_test_graph(dim):
 
     return block, inputs, list(edges.keys())
 
-def test_rgcn_with_zero_input():
-    dim = 32
-    block, inputs, etypes = create_dummy_test_graph(32)
+@pytest.mark.parametrize("input_dim", [32])
+@pytest.mark.parametrize("output_dim", [32, 64])
+def test_rgcn_with_zero_input(input_dim, output_dim):
+    block, inputs, etypes = create_dummy_test_graph(input_dim)
 
     layer = RelGraphConvLayer(
-        dim, dim, etypes,
+        input_dim, output_dim, etypes,
         2, activation=th.nn.ReLU(), self_loop=True,
         dropout=0.1)
 
     out = layer(block, inputs)
     assert out["n0"].shape[0] == 1024
-    assert out["n0"].shape[1] == 32
+    assert out["n0"].shape[1] == output_dim
     assert out["n1"].shape[0] == 0
-    assert out["n1"].shape[1] == 32
+    assert out["n1"].shape[1] == output_dim
     assert out["n2"].shape[0] == 0
-    assert out["n2"].shape[1] == 32
+    assert out["n2"].shape[1] == output_dim
     assert out["n3"].shape[0] == 0
-    assert out["n3"].shape[1] == 32
+    assert out["n3"].shape[1] == output_dim
     assert "n4" not in out
 
-def test_rgat_with_zero_input():
-    dim = 32
-    block, inputs, etypes = create_dummy_test_graph(32)
+@pytest.mark.parametrize("input_dim", [32])
+@pytest.mark.parametrize("output_dim", [32,64])
+def test_rgat_with_zero_input(input_dim, output_dim):
+    block, inputs, etypes = create_dummy_test_graph(input_dim)
 
     layer = RelationalAttLayer(
-        dim, dim, etypes,
+        input_dim, output_dim, etypes,
         2, activation=th.nn.ReLU(), self_loop=True,
         dropout=0.1)
 
     out = layer(block, inputs)
     assert out["n0"].shape[0] == 1024
-    assert out["n0"].shape[1] == 32
+    assert out["n0"].shape[1] == output_dim
     assert out["n1"].shape[0] == 0
-    assert out["n1"].shape[1] == 32
+    assert out["n1"].shape[1] == output_dim
     assert out["n2"].shape[0] == 0
-    assert out["n2"].shape[1] == 32
+    assert out["n2"].shape[1] == output_dim
     assert out["n3"].shape[0] == 0
-    assert out["n3"].shape[1] == 32
+    assert out["n3"].shape[1] == output_dim
     assert "n4" not in out
 
 
 if __name__ == '__main__':
-    test_rgcn_with_zero_input()
-    test_rgat_with_zero_input()
+    test_rgcn_with_zero_input(32,64)
+    test_rgat_with_zero_input(32,64)


### PR DESCRIPTION
*Issue #, if available:*
When inputs of RGAT.RelationalAttLayer have some node types with input shape (0, x). The module will crash.

*Description of changes:*
Fix the bug. More details please see tests/unit-tests/test_nn_model.py: test_rgat_with_zero_input


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
