### PR TITLE
Update the way of getting length of dataloader

### DIFF
--- a/python/graphstorm/dataloading/dataloading.py
+++ b/python/graphstorm/dataloading/dataloading.py
@@ -1177,6 +1177,13 @@ class GSgnnNodeSemiSupDataLoader(GSgnnNodeDataLoader):
     def __next__(self):
         return self.dataloader.__next__(), self.unlabeled_dataloader.__next__()
 
+    def __len__(self):
+        # Follow
+        # https://github.com/dmlc/dgl/blob/1.0.x/python/dgl/distributed/dist_dataloader.py#L116
+        # DistDataLoader.expected_idxs is the length of the datalaoder
+        return min(self.dataloader.expected_idxs,
+                   self.unlabeled_dataloader.expected_idxs)
+
 ####################### Distillation #############################
 
 class DistillDataManager:

--- a/python/graphstorm/dataloading/dataloading.py
+++ b/python/graphstorm/dataloading/dataloading.py
@@ -288,7 +288,8 @@ class GSgnnEdgeDataLoader(GSgnnEdgeDataLoaderBase):
     def __len__(self):
         # Follow
         # https://github.com/dmlc/dgl/blob/1.0.x/python/dgl/distributed/dist_dataloader.py#L116
-        # DistDataLoader.expected_idxs is the length (number of batches) of the datalaoder
+        # In DGL, DistDataLoader.expected_idxs is the length (number of batches)
+        # of the datalaoder.
         return self.dataloader.expected_idxs
 
     @property
@@ -541,7 +542,8 @@ class GSgnnLinkPredictionDataLoader(GSgnnLinkPredictionDataLoaderBase):
     def __len__(self):
         # Follow
         # https://github.com/dmlc/dgl/blob/1.0.x/python/dgl/distributed/dist_dataloader.py#L116
-        # DistDataLoader.expected_idxs is the length (number of batches) of the datalaoder
+        # In DGL, DistDataLoader.expected_idxs is the length (number of batches)
+        # of the datalaoder.
         return self.dataloader.expected_idxs
 
 class GSgnnLPJointNegDataLoader(GSgnnLinkPredictionDataLoader):
@@ -866,8 +868,9 @@ class GSgnnAllEtypeLinkPredictionDataLoader(GSgnnLinkPredictionDataLoader):
     def __len__(self):
         # Follow
         # https://github.com/dmlc/dgl/blob/1.0.x/python/dgl/distributed/dist_dataloader.py#L116
-        # DistDataLoader.expected_idxs is the length (number of batches) of the datalaoder
-        # AllEtypeDistEdgeDataLoader is a child class of DistDataLoader
+        # In DGL, DistDataLoader.expected_idxs is the length (number of batches)
+        # of the datalaoder.
+        # AllEtypeDistEdgeDataLoader is a child class of DistDataLoader.
         return self.dataloader.expected_idxs
 
 class GSgnnAllEtypeLPJointNegDataLoader(GSgnnAllEtypeLinkPredictionDataLoader):
@@ -1136,7 +1139,8 @@ class GSgnnNodeDataLoader(GSgnnNodeDataLoaderBase):
     def __len__(self):
         # Follow
         # https://github.com/dmlc/dgl/blob/1.0.x/python/dgl/distributed/dist_dataloader.py#L116
-        # DistDataLoader.expected_idxs is the length (number of batches) of the datalaoder
+        # In DGL, DistDataLoader.expected_idxs is the length (number of batches)
+        # of the datalaoder.
         return self.dataloader.expected_idxs
 
 class GSgnnNodeSemiSupDataLoader(GSgnnNodeDataLoader):
@@ -1180,7 +1184,10 @@ class GSgnnNodeSemiSupDataLoader(GSgnnNodeDataLoader):
     def __len__(self):
         # Follow
         # https://github.com/dmlc/dgl/blob/1.0.x/python/dgl/distributed/dist_dataloader.py#L116
-        # DistDataLoader.expected_idxs is the length (number of batches) of the datalaoder
+        # In DGL, DistDataLoader.expected_idxs is the length (number of batches)
+        # of the datalaoder.
+        # As it uses two dataloader, either one throws
+        # an End of Iter error will stop the dataloader.
         return min(self.dataloader.expected_idxs,
                    self.unlabeled_dataloader.expected_idxs)
 

--- a/python/graphstorm/dataloading/dataloading.py
+++ b/python/graphstorm/dataloading/dataloading.py
@@ -131,6 +131,13 @@ class GSgnnEdgeDataLoaderBase():
         list of DGLGraph : the subgraph blocks for message passing.
         """
 
+    def __len__(self):
+        """ Return the length of the data loader
+
+        Returns
+        int: length
+        """
+
     @property
     def data(self):
         """ The dataset of this dataloader.
@@ -164,7 +171,7 @@ class GSgnnEdgeDataLoaderBase():
 class GSgnnEdgeDataLoader(GSgnnEdgeDataLoaderBase):
     """ The minibatch dataloader for edge prediction
 
-    GSgnnEdgeDataLoader samples GraphStorm edge dataset into an iterable over mini-batches 
+    GSgnnEdgeDataLoader samples GraphStorm edge dataset into an iterable over mini-batches
     of samples. Both source and destination nodes are included in the batch_graph, which
     will be used by GraphStorm Trainers and Inferrers.
 
@@ -192,12 +199,12 @@ class GSgnnEdgeDataLoader(GSgnnEdgeDataLoaderBase):
         The node types that requires to construct node features.
     construct_feat_fanout : int
         The fanout required to construct node features.
-        
+
     Examples
     ------------
-    To train a 2-layer GNN for edge prediction on a set of edges ``target_idx`` on 
+    To train a 2-layer GNN for edge prediction on a set of edges ``target_idx`` on
     a graph where each nodes takes messages from 15 neighbors on the first layer
-    and 10 neighbors on the second. 
+    and 10 neighbors on the second.
 
     .. code:: python
 
@@ -278,6 +285,12 @@ class GSgnnEdgeDataLoader(GSgnnEdgeDataLoaderBase):
 
         return (input_nodes, batch_graph, blocks)
 
+    def __len__(self):
+        # Follow
+        # https://github.com/dmlc/dgl/blob/1.0.x/python/dgl/distributed/dist_dataloader.py#L116
+        # DistDataLoader.expected_idxs is the length of the datalaoder
+        return self.dataloader.expected_idxs
+
     @property
     def data(self):
         """ The dataset of this dataloader.
@@ -351,6 +364,13 @@ class GSgnnLinkPredictionDataLoaderBase():
         list of DGLGraph : subgraph blocks for message passing.
         """
 
+    def __len__(self):
+        """ Return the length of the data loader
+
+        Returns
+        int: length
+        """
+
     @property
     def data(self):
         """ The dataset of this dataloader.
@@ -384,10 +404,10 @@ class GSgnnLinkPredictionDataLoaderBase():
 class GSgnnLinkPredictionDataLoader(GSgnnLinkPredictionDataLoaderBase):
     """ Link prediction minibatch dataloader
 
-    GSgnnLinkPredictionDataLoader samples GraphStorm edge dataset into an iterable over mini-batches 
-    of samples. In each batch, pos_graph and neg_graph are sampled subgraph for positive and 
-    negative edges, which will be used by GraphStorm Trainers and Inferrers. Given a positive edge, 
-    a negative edge is composed of the source node and a random negative destination nodes 
+    GSgnnLinkPredictionDataLoader samples GraphStorm edge dataset into an iterable over mini-batches
+    of samples. In each batch, pos_graph and neg_graph are sampled subgraph for positive and
+    negative edges, which will be used by GraphStorm Trainers and Inferrers. Given a positive edge,
+    a negative edge is composed of the source node and a random negative destination nodes
     according to a uniform distribution.
 
     Argument
@@ -418,10 +438,10 @@ class GSgnnLinkPredictionDataLoader(GSgnnLinkPredictionDataLoaderBase):
         The node types that requires to construct node features.
     construct_feat_fanout : int
         The fanout required to construct node features.
-    
+
     Examples
     ------------
-    To train a 2-layer GNN for link prediction on a set of positive edges ``target_idx`` on 
+    To train a 2-layer GNN for link prediction on a set of positive edges ``target_idx`` on
     a graph where each nodes takes messages from 15 neighbors on the first layer
     and 10 neighbors on the second. We use 10 negative edges per positive in this example.
 
@@ -432,7 +452,7 @@ class GSgnnLinkPredictionDataLoader(GSgnnLinkPredictionDataLoaderBase):
         from graphstorm.trainer import GSgnnLinkPredictionTrainer
 
         lp_data = GSgnnEdgeTrainData(...)
-        lp_dataloader = GSgnnLinkPredictionDataLoader(lp_data, target_idx, fanout=[15, 10], 
+        lp_dataloader = GSgnnLinkPredictionDataLoader(lp_data, target_idx, fanout=[15, 10],
                                                     num_negative_edges=10, batch_size=128)
         lp_trainer = GSgnnLinkPredictionTrainer(...)
         lp_trainer.fit(lp_dataloader, num_epochs=10)
@@ -517,6 +537,12 @@ class GSgnnLinkPredictionDataLoader(GSgnnLinkPredictionDataLoaderBase):
             blocks.insert(0, block)
 
         return (input_nodes, pos_graph, neg_graph, blocks)
+
+    def __len__(self):
+        # Follow
+        # https://github.com/dmlc/dgl/blob/1.0.x/python/dgl/distributed/dist_dataloader.py#L116
+        # DistDataLoader.expected_idxs is the length of the datalaoder
+        return self.dataloader.expected_idxs
 
 class GSgnnLPJointNegDataLoader(GSgnnLinkPredictionDataLoader):
     """ Link prediction dataloader with joint negative sampler
@@ -837,6 +863,13 @@ class GSgnnAllEtypeLinkPredictionDataLoader(GSgnnLinkPredictionDataLoader):
 
         return (input_nodes, pos_graph, neg_graph, blocks)
 
+    def __len__(self):
+        # Follow
+        # https://github.com/dmlc/dgl/blob/1.0.x/python/dgl/distributed/dist_dataloader.py#L116
+        # DistDataLoader.expected_idxs is the length of the datalaoder
+        # AllEtypeDistEdgeDataLoader is a child class of DistDataLoader
+        return self.dataloader.expected_idxs
+
 class GSgnnAllEtypeLPJointNegDataLoader(GSgnnAllEtypeLinkPredictionDataLoader):
     """ Link prediction dataloader with joint negative sampler.
         In each minibatch, at least one edge is sampled from each etype.
@@ -978,6 +1011,13 @@ class GSgnnNodeDataLoaderBase():
         list of DGLGraph : the subgraph blocks for message passing.
         """
 
+    def __len__(self):
+        """ Return the length of the data loader
+
+        Returns
+        int: length
+        """
+
     @property
     def data(self):
         """ The dataset of this dataloader.
@@ -1010,10 +1050,10 @@ class GSgnnNodeDataLoaderBase():
 
 class GSgnnNodeDataLoader(GSgnnNodeDataLoaderBase):
     """ Minibatch dataloader for node tasks
-    
+
     GSgnnNodeDataLoader samples GraphStorm node dataset into an iterable over mini-batches of
     samples including target nodes and sampled neighbor nodes, which will be used by GraphStorm
-    Trainers and Inferrers. 
+    Trainers and Inferrers.
 
     Parameters
     ----------
@@ -1033,15 +1073,15 @@ class GSgnnNodeDataLoader(GSgnnNodeDataLoaderBase):
         The node types that requires to construct node features.
     construct_feat_fanout : int
         The fanout required to construct node features.
-    
+
     Examples
     ----------
-    To train a 2-layer GNN for node classification on a set of nodes ``target_idx`` on 
+    To train a 2-layer GNN for node classification on a set of nodes ``target_idx`` on
     a graph where each nodes takes messages from 15 neighbors on the first layer
-    and 10 neighbors on the second. 
+    and 10 neighbors on the second.
 
     .. code:: python
-    
+
         from graphstorm.dataloading import GSgnnNodeTrainData
         from graphstorm.dataloading import GSgnnNodeDataLoader
         from graphstorm.trainer import GSgnnNodePredictionTrainer
@@ -1093,6 +1133,12 @@ class GSgnnNodeDataLoader(GSgnnNodeDataLoaderBase):
             blocks.insert(0, block)
         return input_nodes, seeds, blocks
 
+    def __len__(self):
+        # Follow
+        # https://github.com/dmlc/dgl/blob/1.0.x/python/dgl/distributed/dist_dataloader.py#L116
+        # DistDataLoader.expected_idxs is the length of the datalaoder
+        return self.dataloader.expected_idxs
+
 class GSgnnNodeSemiSupDataLoader(GSgnnNodeDataLoader):
     """ Semisupervised Minibatch dataloader for node tasks
 
@@ -1139,10 +1185,10 @@ class DistillDataManager:
 
     Parameters:
     ----------
-    dataloader_generator : DataloaderGenerator: 
+    dataloader_generator : DataloaderGenerator:
         A dataloader generator
         Generates dataloader based on given a file path.
-    dataset_path str : 
+    dataset_path str :
         Path to the data files.
     shuffle : bool
         Set to ``True`` to have the files reshuffled at every epoch (default: ``False``).
@@ -1232,7 +1278,7 @@ class DistillDataManager:
 
 class DistillDataloaderGenerator:
     r""" Distill Data Generator that generates pytorch dataloader based on the given file.
-    
+
     Parameters:
     ----------
     tokenizer : transformers.AutoTokenizer
@@ -1263,10 +1309,10 @@ class DistillDataloaderGenerator:
         self.collate_fn = collate_fn
 
     def _data_len_sync(self, data):
-        r""" Drop additional samples to make sure each dataloader 
+        r""" Drop additional samples to make sure each dataloader
         has the same number of batches. This is to avoid the training
         stuck in distributed mode if any trainer has more or less batches.
-        
+
         Parameters:
         ----------
         data : GSDistillData

--- a/python/graphstorm/dataloading/dataloading.py
+++ b/python/graphstorm/dataloading/dataloading.py
@@ -132,7 +132,7 @@ class GSgnnEdgeDataLoaderBase():
         """
 
     def __len__(self):
-        """ Return the length of the data loader
+        """ Return the length (number of mini-batches) of the data loader
 
         Returns
         int: length
@@ -288,7 +288,7 @@ class GSgnnEdgeDataLoader(GSgnnEdgeDataLoaderBase):
     def __len__(self):
         # Follow
         # https://github.com/dmlc/dgl/blob/1.0.x/python/dgl/distributed/dist_dataloader.py#L116
-        # DistDataLoader.expected_idxs is the length of the datalaoder
+        # DistDataLoader.expected_idxs is the length (number of batches) of the datalaoder
         return self.dataloader.expected_idxs
 
     @property
@@ -365,7 +365,7 @@ class GSgnnLinkPredictionDataLoaderBase():
         """
 
     def __len__(self):
-        """ Return the length of the data loader
+        """ Return the length (number of mini-batches) of the data loader
 
         Returns
         int: length
@@ -541,7 +541,7 @@ class GSgnnLinkPredictionDataLoader(GSgnnLinkPredictionDataLoaderBase):
     def __len__(self):
         # Follow
         # https://github.com/dmlc/dgl/blob/1.0.x/python/dgl/distributed/dist_dataloader.py#L116
-        # DistDataLoader.expected_idxs is the length of the datalaoder
+        # DistDataLoader.expected_idxs is the length (number of batches) of the datalaoder
         return self.dataloader.expected_idxs
 
 class GSgnnLPJointNegDataLoader(GSgnnLinkPredictionDataLoader):
@@ -866,7 +866,7 @@ class GSgnnAllEtypeLinkPredictionDataLoader(GSgnnLinkPredictionDataLoader):
     def __len__(self):
         # Follow
         # https://github.com/dmlc/dgl/blob/1.0.x/python/dgl/distributed/dist_dataloader.py#L116
-        # DistDataLoader.expected_idxs is the length of the datalaoder
+        # DistDataLoader.expected_idxs is the length (number of batches) of the datalaoder
         # AllEtypeDistEdgeDataLoader is a child class of DistDataLoader
         return self.dataloader.expected_idxs
 
@@ -1012,7 +1012,7 @@ class GSgnnNodeDataLoaderBase():
         """
 
     def __len__(self):
-        """ Return the length of the data loader
+        """ Return the length (number of mini-batches) of the data loader
 
         Returns
         int: length
@@ -1136,7 +1136,7 @@ class GSgnnNodeDataLoader(GSgnnNodeDataLoaderBase):
     def __len__(self):
         # Follow
         # https://github.com/dmlc/dgl/blob/1.0.x/python/dgl/distributed/dist_dataloader.py#L116
-        # DistDataLoader.expected_idxs is the length of the datalaoder
+        # DistDataLoader.expected_idxs is the length (number of batches) of the datalaoder
         return self.dataloader.expected_idxs
 
 class GSgnnNodeSemiSupDataLoader(GSgnnNodeDataLoader):
@@ -1180,7 +1180,7 @@ class GSgnnNodeSemiSupDataLoader(GSgnnNodeDataLoader):
     def __len__(self):
         # Follow
         # https://github.com/dmlc/dgl/blob/1.0.x/python/dgl/distributed/dist_dataloader.py#L116
-        # DistDataLoader.expected_idxs is the length of the datalaoder
+        # DistDataLoader.expected_idxs is the length (number of batches) of the datalaoder
         return min(self.dataloader.expected_idxs,
                    self.unlabeled_dataloader.expected_idxs)
 

--- a/python/graphstorm/model/edge_gnn.py
+++ b/python/graphstorm/model/edge_gnn.py
@@ -185,7 +185,7 @@ def edge_mini_batch_gnn_predict(model, loader, return_proba=True, return_label=F
     labels = {}
     model.eval()
 
-    len_dataloader = max_num_batch = len(list(loader))
+    len_dataloader = max_num_batch = len(loader)
     tensor = th.tensor([len_dataloader], device=device)
     if is_distributed():
         th.distributed.all_reduce(tensor, op=th.distributed.ReduceOp.MAX)

--- a/python/graphstorm/model/gnn_encoder_base.py
+++ b/python/graphstorm/model/gnn_encoder_base.py
@@ -18,7 +18,6 @@
 
 from functools import partial
 import logging
-import time
 
 import dgl
 import torch as th

--- a/python/graphstorm/model/gnn_encoder_base.py
+++ b/python/graphstorm/model/gnn_encoder_base.py
@@ -18,6 +18,7 @@
 
 from functools import partial
 import logging
+import time
 
 import dgl
 import torch as th
@@ -158,7 +159,11 @@ def dist_minibatch_inference(g, gnn_encoder, get_input_embeds, batch_size, fanou
                                                             shuffle=False,
                                                             drop_last=False)
 
-        len_dataloader = max_num_batch = len(list(dataloader))
+        # Follow
+        # https://github.com/dmlc/dgl/blob/1.0.x/python/dgl/distributed/dist_dataloader.py#L116
+        # DistDataLoader.expected_idxs is the length of the datalaoder
+        len_dataloader = max_num_batch = dataloader.expected_idxs
+
         tensor = th.tensor([len_dataloader], device=device)
         if is_distributed():
             th.distributed.all_reduce(tensor, op=th.distributed.ReduceOp.MAX)
@@ -232,7 +237,10 @@ def dist_inference_one_layer(layer_id, g, dataloader, target_ntypes, layer, get_
     -------
         dict of Tensors : the inferenced tensors.
     """
-    len_dataloader = max_num_batch = len(list(dataloader))
+    # Follow
+    # https://github.com/dmlc/dgl/blob/1.0.x/python/dgl/distributed/dist_dataloader.py#L116
+    # DistDataLoader.expected_idxs is the length of the datalaoder
+    len_dataloader = max_num_batch = dataloader.expected_idxs
     tensor = th.tensor([len_dataloader], device=device)
     if is_distributed():
         th.distributed.all_reduce(tensor, op=th.distributed.ReduceOp.MAX)

--- a/python/graphstorm/model/node_gnn.py
+++ b/python/graphstorm/model/node_gnn.py
@@ -209,7 +209,7 @@ def node_mini_batch_gnn_predict(model, loader, return_proba=True, return_label=F
     labels = {}
     model.eval()
 
-    len_dataloader = max_num_batch = len(list(loader))
+    len_dataloader = max_num_batch = len(loader)
     tensor = th.tensor([len_dataloader], device=device)
     if is_distributed():
         th.distributed.all_reduce(tensor, op=th.distributed.ReduceOp.MAX)


### PR DESCRIPTION
Previously in dist_inference_one_layer, node_mini_batch_gnn_predict, dist_minibatch_inference, edge_mini_batch_gnn_predict, we use len(list(dataloader)) to get the length of a dataload which is costy. Change the implementation to use len(datalaoder)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
