### PR TITLE
Fix the bug when there are edges with missing src or dst nodes, the num edge features != num edges

### DIFF
--- a/python/graphstorm/gconstruct/construct_graph.py
+++ b/python/graphstorm/gconstruct/construct_graph.py
@@ -175,8 +175,22 @@ def parse_edge_data(in_file, feat_ops, label_ops, node_id_map, read_file,
     src_ids = data[src_id_col] if src_id_col is not None else None
     dst_ids = data[dst_id_col] if dst_id_col is not None else None
     if src_ids is not None:
-        src_ids, dst_ids = map_node_ids(src_ids, dst_ids, edge_type, node_id_map,
+        src_ids, dst_ids, src_exist_locs, dst_exist_locs = \
+            map_node_ids(src_ids, dst_ids, edge_type, node_id_map,
                                         skip_nonexist_edges)
+        if src_exist_locs is not None:
+            feat_data = {key: feat[src_exist_locs] \
+                         for key, feat in feat_data.items()}
+        if dst_exist_locs is not None:
+            feat_data = {key: feat[dst_exist_locs] \
+                         for key, feat in feat_data.items()}
+        # do some check
+        if src_exist_locs is not None or dst_exist_locs is not None:
+            for key, feat in feat_data.items():
+                assert len(src_ids) == len(feat), \
+                    f"Expecting the edge feature {key} has the same length" \
+                    f"as num existing edges {len(src_ids)}, but get {len(feat)}"
+
     return (src_ids, dst_ids, feat_data)
 
 def _process_data(user_pre_parser, user_parser,

--- a/python/graphstorm/gconstruct/id_map.py
+++ b/python/graphstorm/gconstruct/id_map.py
@@ -224,6 +224,6 @@ def map_node_ids(src_ids, dst_ids, edge_type, node_id_map, skip_nonexist_edges):
             raise ValueError(f"dest nodes of {dst_type} do not exist: {dst_ids[bool_mask]}")
         # We need to remove the source nodes as well.
         src_ids = src_ids[orig_locs] if len(orig_locs) > 0 else np.array([], dtype=src_ids.dtype)
-        dst_exist_locs = bool_mask
+        dst_exist_locs = orig_locs
     dst_ids = new_dst_ids
     return src_ids, dst_ids, src_exist_locs, dst_exist_locs

--- a/python/graphstorm/gconstruct/id_map.py
+++ b/python/graphstorm/gconstruct/id_map.py
@@ -180,10 +180,23 @@ def map_node_ids(src_ids, dst_ids, edge_type, node_id_map, skip_nonexist_edges):
 
     Returns
     -------
-    tuple of tensors : the remapped source and destination node IDs.
+    tuple of tensors :
+        src_ids: The remapped source node IDs.
+        dst_ids: The remapped destination node IDs.
+        src_exist_locs: The locations of source node IDs that
+                        have existing edges. Only valid when
+                        skip_nonexist_edges is True.
+        dst_exist_locs: The location of destination node IDs that
+                        have existing edges. Only valid when
+                        skip_nonexist_edges is True.
+
+        How to use src_exist_locs and dst_exist_locs:
+        feat_data = feat_data[src_exist_locs][dst_exist_locs]
     """
     src_type, _, dst_type = edge_type
     new_src_ids, orig_locs = node_id_map[src_type].map_id(src_ids)
+    src_exist_locs = None
+    dst_exist_locs = None
     # If some of the source nodes don't exist in the node set.
     if len(orig_locs) != len(src_ids):
         bool_mask = np.ones(len(src_ids), dtype=bool)
@@ -195,6 +208,7 @@ def map_node_ids(src_ids, dst_ids, edge_type, node_id_map, skip_nonexist_edges):
         else:
             raise ValueError(f"source nodes of {src_type} do not exist: {src_ids[bool_mask]}")
         dst_ids = dst_ids[orig_locs] if len(orig_locs) > 0 else np.array([], dtype=dst_ids.dtype)
+        src_exist_locs = orig_locs
     src_ids = new_src_ids
 
     new_dst_ids, orig_locs = node_id_map[dst_type].map_id(dst_ids)
@@ -210,5 +224,6 @@ def map_node_ids(src_ids, dst_ids, edge_type, node_id_map, skip_nonexist_edges):
             raise ValueError(f"dest nodes of {dst_type} do not exist: {dst_ids[bool_mask]}")
         # We need to remove the source nodes as well.
         src_ids = src_ids[orig_locs] if len(orig_locs) > 0 else np.array([], dtype=src_ids.dtype)
+        dst_exist_locs = bool_mask
     dst_ids = new_dst_ids
-    return src_ids, dst_ids
+    return src_ids, dst_ids, src_exist_locs, dst_exist_locs


### PR DESCRIPTION
The logic of skipping edges with missing src or dst nodes in ID mapping will fail when there are edge features.

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
