### PR TITLE
Fix load embeding

### DIFF
--- a/python/graphstorm/model/lm_embed.py
+++ b/python/graphstorm/model/lm_embed.py
@@ -31,8 +31,8 @@ from .embed import GSNodeInputLayer
 from .embed import GSNodeEncoderInputLayer
 from .lm_model import init_lm_model
 from .lm_model import get_lm_node_feats
-from .utils import (load_pytorch_embedding,
-                    save_pytorch_embedding)
+from .utils import load_pytorch_embedding, save_embeddings
+from ..utils import get_rank, get_world_size, barrier, create_dist_tensor
 from ..utils import get_rank, barrier, create_dist_tensor
 
 class LMModels(nn.Module):
@@ -259,6 +259,7 @@ class LMCache:
         for ntype in self._lm_models.ntypes:
             embed_path = os.path.join(os.path.join(self._embed_path, ntype),
                     self._get_model_name(ntype))
+            embed_path = os.path.join(embed_path, ntype)
             if os.path.exists(embed_path):
                 if get_rank() == 0:
                     logging.info("load LM embedding from %s for node type %s",
@@ -272,7 +273,7 @@ class LMCache:
         for ntype in self._lm_models.ntypes:
             embed_path = os.path.join(os.path.join(self._embed_path, ntype),
                     self._get_model_name(ntype))
-            save_pytorch_embedding(embed_path, self._lm_emb_cache[ntype], get_rank())
+            save_embeddings(embed_path, self._lm_emb_cache[ntype], get_rank(), get_world_size())
 
     def __len__(self):
         return len(self._lm_emb_cache)

--- a/python/graphstorm/model/lm_embed.py
+++ b/python/graphstorm/model/lm_embed.py
@@ -262,7 +262,7 @@ class LMCache:
                 if get_rank() == 0:
                     logging.info("load LM embedding from %s for node type %s",
                             embed_path, ntype)
-                self._lm_emb_cache[ntype] = load_pytorch_embedding(embed_path,
+                self._lm_emb_cache[ntype] = load_pytorch_embedding(embed_path, ntype,
                         self._g.get_node_partition_policy(ntype), "bert_emb")
 
     def _save_embeddings(self):
@@ -372,11 +372,11 @@ class GSPureLMNodeInputLayer(GSNodeInputLayer):
         Number of trainable texts. Default: 0
     lm_infer_batch_size: int
         Batch size used for computing text embeddings for static lm model. Default: 16
-    use_fp16 : bool 
+    use_fp16 : bool
         Use float16 to store LM embeddings. Default: True
     cached_embed_path : str
         The path where the LM embeddings are cached.
-    
+
     Examples:
     ----------
 
@@ -564,10 +564,10 @@ class GSLMNodeEncoderInputLayer(GSNodeEncoderInputLayer):
         lm_train_nodes=10
 
         encoder = GSLMNodeEncoderInputLayer(
-            g=np_data.g, 
+            g=np_data.g,
             node_lm_configs=node_lm_configs,
-            feat_size=feat_size, 
-            embed_size=128, 
+            feat_size=feat_size,
+            embed_size=128,
             num_train=lm_train_nodes
         )
         model.set_node_input_encoder(encoder)

--- a/python/graphstorm/model/lm_embed.py
+++ b/python/graphstorm/model/lm_embed.py
@@ -258,7 +258,6 @@ class LMCache:
         for ntype in self._lm_models.ntypes:
             embed_path = os.path.join(os.path.join(self._embed_path, ntype),
                     self._get_model_name(ntype))
-            embed_path = os.path.join(embed_path, ntype)
             if os.path.exists(embed_path):
                 if get_rank() == 0:
                     logging.info("load LM embedding from %s for node type %s",

--- a/python/graphstorm/model/lm_embed.py
+++ b/python/graphstorm/model/lm_embed.py
@@ -262,7 +262,7 @@ class LMCache:
                 if get_rank() == 0:
                     logging.info("load LM embedding from %s for node type %s",
                             embed_path, ntype)
-                self._lm_emb_cache[ntype] = load_pytorch_embedding(embed_path, ntype,
+                self._lm_emb_cache[ntype] = load_pytorch_embedding(embed_path,
                         self._g.get_node_partition_policy(ntype), "bert_emb")
 
     def _save_embeddings(self):

--- a/python/graphstorm/model/lm_embed.py
+++ b/python/graphstorm/model/lm_embed.py
@@ -31,8 +31,9 @@ from .embed import GSNodeInputLayer
 from .embed import GSNodeEncoderInputLayer
 from .lm_model import init_lm_model
 from .lm_model import get_lm_node_feats
-from .utils import load_pytorch_embedding, save_embeddings
-from ..utils import get_rank, get_world_size, barrier, create_dist_tensor
+from .utils import (load_pytorch_embedding,
+                    save_pytorch_embedding)
+from ..utils import get_rank, barrier, create_dist_tensor
 
 class LMModels(nn.Module):
     """ LM model collection
@@ -271,7 +272,8 @@ class LMCache:
         for ntype in self._lm_models.ntypes:
             embed_path = os.path.join(os.path.join(self._embed_path, ntype),
                     self._get_model_name(ntype))
-            save_embeddings(embed_path, self._lm_emb_cache[ntype], get_rank(), get_world_size())
+
+            save_pytorch_embedding(embed_path, self._lm_emb_cache[ntype], get_rank())
 
     def __len__(self):
         return len(self._lm_emb_cache)

--- a/python/graphstorm/model/lm_embed.py
+++ b/python/graphstorm/model/lm_embed.py
@@ -31,7 +31,7 @@ from .embed import GSNodeInputLayer
 from .embed import GSNodeEncoderInputLayer
 from .lm_model import init_lm_model
 from .lm_model import get_lm_node_feats
-from .utils import load_pytorch_embedding, save_embeddings
+from .utils import load_pytorch_embedding, save_pytorch_embedding
 from ..utils import get_rank, get_world_size, barrier, create_dist_tensor
 
 class LMModels(nn.Module):
@@ -272,7 +272,10 @@ class LMCache:
         for ntype in self._lm_models.ntypes:
             embed_path = os.path.join(os.path.join(self._embed_path, ntype),
                     self._get_model_name(ntype))
-            save_embeddings(embed_path, self._lm_emb_cache[ntype], get_rank(), get_world_size())
+            save_pytorch_embedding(embed_path,
+                                   self._lm_emb_cache[ntype],
+                                   get_rank(),
+                                   get_world_size())
 
     def __len__(self):
         return len(self._lm_emb_cache)

--- a/python/graphstorm/model/lm_embed.py
+++ b/python/graphstorm/model/lm_embed.py
@@ -272,7 +272,6 @@ class LMCache:
         for ntype in self._lm_models.ntypes:
             embed_path = os.path.join(os.path.join(self._embed_path, ntype),
                     self._get_model_name(ntype))
-
             save_pytorch_embedding(embed_path, self._lm_emb_cache[ntype], get_rank())
 
     def __len__(self):

--- a/python/graphstorm/model/lm_embed.py
+++ b/python/graphstorm/model/lm_embed.py
@@ -33,7 +33,6 @@ from .lm_model import init_lm_model
 from .lm_model import get_lm_node_feats
 from .utils import load_pytorch_embedding, save_embeddings
 from ..utils import get_rank, get_world_size, barrier, create_dist_tensor
-from ..utils import get_rank, barrier, create_dist_tensor
 
 class LMModels(nn.Module):
     """ LM model collection

--- a/python/graphstorm/model/utils.py
+++ b/python/graphstorm/model/utils.py
@@ -488,6 +488,7 @@ def save_pytorch_embedding(emb_path, embedding, rank, world_size):
         world_size : int
             World size in a distributed env.
     """
+    os.makedirs(emb_path, exist_ok=True)
     # [04/16]: Only rank 0 can chmod to let all other ranks to write files.
     if rank == 0:
         # mode 767 means rwx-rw-rwx:

--- a/python/graphstorm/model/utils.py
+++ b/python/graphstorm/model/utils.py
@@ -500,6 +500,21 @@ def load_pytorch_embedding(emb_path, part_policy, name):
     barrier()
     return dist_emb
 
+def save_pytorch_embedding(emb_path, embedding, rank):
+    """ Save pytorch embedding
+
+        Parameters
+        ----------
+        emb_path : str
+            The path of the folder where the embeddings are saved.
+        embedding : DistTensor
+            Embedding to save
+        rank : int
+            Rank of the current process in a distributed environment.
+    """
+    th.save(embedding,
+            os.path.join(emb_path, f'emb.part{pad_file_index(rank)}.bin'))
+
 def save_pytorch_embeddings(emb_path, embeddings, rank, world_size,
     device=th.device('cpu'), node_id_mapping_file=None):
     """ Save embeddings through pytorch a distributed way
@@ -602,15 +617,13 @@ def save_pytorch_embeddings(emb_path, embeddings, rank, world_size,
         # embedding per node type
         for name, emb in embeddings.items():
             os.makedirs(os.path.join(emb_path, name), exist_ok=True)
-            th.save(emb, os.path.join(os.path.join(emb_path, name),
-                                      f'emb.part{pad_file_index(rank)}.bin'))
+            save_pytorch_embedding(os.path.join(emb_path, name), emb, rank)
             emb_info["emb_name"].append(name)
     else:
         os.makedirs(os.path.join(emb_path, NTYPE), exist_ok=True)
         # There is no ntype for the embedding
         # use NTYPE
-        th.save(embeddings, os.path.join(os.path.join(emb_path, NTYPE),
-                                         f'emb.part{pad_file_index(rank)}.bin'))
+        save_pytorch_embedding(os.path.join(emb_path, NTYPE), embeddings, rank)
         emb_info["emb_name"] = NTYPE
 
     if rank == 0:

--- a/python/graphstorm/model/utils.py
+++ b/python/graphstorm/model/utils.py
@@ -474,15 +474,13 @@ def remap_embeddings(embeddings, rank, world_size,
 
     return embeddings
 
-def load_pytorch_embedding(emb_path, ntype, part_policy, name):
+def load_pytorch_embedding(emb_path, part_policy, name):
     """ Load embedding tensor in Pytorch format.
 
     Parameters
     ----------
     emb_path : str
         The path of the save embedding files.
-    ntype: str
-        Node type.
     part_policy : dgl.distributed.PartitionPolicy
         The partitioning policy
     name : str
@@ -494,10 +492,7 @@ def load_pytorch_embedding(emb_path, ntype, part_policy, name):
     """
     rank = get_rank()
     world_size = get_world_size()
-    if ntype is None: # homogeneous graph
-        ntype = NTYPE
-    emb = th.load(os.path.join(os.path.join(emb_path, ntype),
-                               f'emb.part{pad_file_index(rank)}.bin'))
+    emb = th.load(os.path.join(emb_path, f'emb.part{pad_file_index(rank)}.bin'))
     dist_emb = create_dist_tensor((part_policy.get_size(), emb.shape[1]), emb.dtype,
             name=name, part_policy=part_policy)
     start, end = _get_data_range(rank, world_size, len(dist_emb))

--- a/python/graphstorm/model/utils.py
+++ b/python/graphstorm/model/utils.py
@@ -512,6 +512,7 @@ def save_pytorch_embedding(emb_path, embedding, rank):
         rank : int
             Rank of the current process in a distributed environment.
     """
+    os.makedirs(emb_path, exist_ok=True)
     # [04/16]: Only rank 0 can chmod to let all other ranks to write files.
     if rank == 0:
         # mode 767 means rwx-rw-rwx:
@@ -523,7 +524,6 @@ def save_pytorch_embedding(emb_path, embedding, rank):
     # make sure the emb_path permission is changed before other process start to save
     barrier()
 
-    os.makedirs(emb_path, exist_ok=True)
     th.save(embedding,
             os.path.join(emb_path, f'emb.part{pad_file_index(rank)}.bin'))
 

--- a/python/graphstorm/model/utils.py
+++ b/python/graphstorm/model/utils.py
@@ -474,6 +474,40 @@ def remap_embeddings(embeddings, rank, world_size,
 
     return embeddings
 
+def save_pytorch_embedding(emb_path, embedding, rank, world_size):
+    """ Save Dist embedding tensor in Pytorch format.
+
+        Parameters
+        ----------
+        emb_path : str
+            The path of the save embedding files.
+        embedding : DistTensor
+            The Dist tensor to save.
+        rank : int
+            Rank of the current process in a distributed environment.
+        world_size : int
+            World size in a distributed env.
+    """
+    # [04/16]: Only rank 0 can chmod to let all other ranks to write files.
+    if rank == 0:
+        # mode 767 means rwx-rw-rwx:
+        #     - owner of the folder can read, write, and execute;
+        #     - owner' group can read, write;
+        #     - others can read, write, and execute.
+        os.chmod(emb_path, 0o767)
+
+    # make sure the emb_path permission is changed before other process start to save
+    barrier()
+
+    assert rank < world_size
+
+    assert isinstance(embedding, (dgl.distributed.DistTensor, LazyDistTensor)), \
+        "Input embedding must be a dgl.distributed.DistTensor or a LazyDistTensor"
+
+    start, end = _get_data_range(rank, world_size, len(embedding))
+    embedding = embedding[start:end]
+    th.save(embedding, os.path.join(emb_path, f'emb.part{pad_file_index(rank)}.bin'))
+
 def load_pytorch_embedding(emb_path, part_policy, name):
     """ Load embedding tensor in Pytorch format.
 

--- a/python/graphstorm/model/utils.py
+++ b/python/graphstorm/model/utils.py
@@ -604,6 +604,7 @@ def save_pytorch_embeddings(emb_path, embeddings, rank, world_size,
             os.makedirs(os.path.join(emb_path, name), exist_ok=True)
             th.save(emb, os.path.join(os.path.join(emb_path, name),
                                       f'emb.part{pad_file_index(rank)}.bin'))
+            emb_info["emb_name"].append(name)
     else:
         os.makedirs(os.path.join(emb_path, NTYPE), exist_ok=True)
         # There is no ntype for the embedding

--- a/python/graphstorm/model/utils.py
+++ b/python/graphstorm/model/utils.py
@@ -512,6 +512,7 @@ def save_pytorch_embedding(emb_path, embedding, rank):
         rank : int
             Rank of the current process in a distributed environment.
     """
+    os.makedirs(emb_path, exist_ok=True)
     th.save(embedding,
             os.path.join(emb_path, f'emb.part{pad_file_index(rank)}.bin'))
 
@@ -616,11 +617,9 @@ def save_pytorch_embeddings(emb_path, embeddings, rank, world_size,
     if isinstance(embeddings, dict):
         # embedding per node type
         for name, emb in embeddings.items():
-            os.makedirs(os.path.join(emb_path, name), exist_ok=True)
             save_pytorch_embedding(os.path.join(emb_path, name), emb, rank)
             emb_info["emb_name"].append(name)
     else:
-        os.makedirs(os.path.join(emb_path, NTYPE), exist_ok=True)
         # There is no ntype for the embedding
         # use NTYPE
         save_pytorch_embedding(os.path.join(emb_path, NTYPE), embeddings, rank)

--- a/python/graphstorm/model/utils.py
+++ b/python/graphstorm/model/utils.py
@@ -494,6 +494,8 @@ def load_pytorch_embedding(emb_path, ntype, part_policy, name):
     """
     rank = get_rank()
     world_size = get_world_size()
+    if ntype is None: # homogeneous graph
+        ntype = NTYPE
     emb = th.load(os.path.join(os.path.join(emb_path, ntype),
                                f'emb.part{pad_file_index(rank)}.bin'))
     dist_emb = create_dist_tensor((part_policy.get_size(), emb.shape[1]), emb.dtype,

--- a/python/graphstorm/model/utils.py
+++ b/python/graphstorm/model/utils.py
@@ -474,13 +474,15 @@ def remap_embeddings(embeddings, rank, world_size,
 
     return embeddings
 
-def load_pytorch_embedding(emb_path, part_policy, name):
+def load_pytorch_embedding(emb_path, ntype, part_policy, name):
     """ Load embedding tensor in Pytorch format.
 
     Parameters
     ----------
     emb_path : str
         The path of the save embedding files.
+    ntype: str
+        Node type.
     part_policy : dgl.distributed.PartitionPolicy
         The partitioning policy
     name : str
@@ -492,7 +494,8 @@ def load_pytorch_embedding(emb_path, part_policy, name):
     """
     rank = get_rank()
     world_size = get_world_size()
-    emb = th.load(os.path.join(emb_path, f'emb.part{pad_file_index(rank)}.bin'))
+    emb = th.load(os.path.join(os.path.join(emb_path, ntype),
+                               f'emb.part{pad_file_index(rank)}.bin'))
     dist_emb = create_dist_tensor((part_policy.get_size(), emb.shape[1]), emb.dtype,
             name=name, part_policy=part_policy)
     start, end = _get_data_range(rank, world_size, len(dist_emb))

--- a/python/graphstorm/utils.py
+++ b/python/graphstorm/utils.py
@@ -31,7 +31,7 @@ TORCH_MAJOR_VER = int(th.__version__.split('.', maxsplit=1)[0])
 
 def setup_device(local_rank):
     r"""Setup computation device.
-    
+
     Parameters
     -----------
     local_rank: int

--- a/tests/unit-tests/test_embed.py
+++ b/tests/unit-tests/test_embed.py
@@ -13,9 +13,10 @@
     See the License for the specific language governing permissions and
     limitations under the License.
 """
-
+import os
 import multiprocessing as mp
 import pytest
+from unittest.mock import patch
 import torch as th
 from torch import nn
 import torch.nn.functional as F
@@ -33,6 +34,9 @@ from graphstorm.model.embed import compute_node_input_embeddings
 from graphstorm.dataloading.dataset import prepare_batch_input
 from graphstorm.model.lm_model import TOKEN_IDX, ATT_MASK_IDX, VALID_LEN
 from graphstorm.model.lm_embed import LMModels, LMCache
+from graphstorm.model.utils import (LazyDistTensor,
+                                    load_pytorch_embedding,
+                                    save_pytorch_embedding)
 
 from data_utils import generate_dummy_dist_graph
 from data_utils import create_lm_graph, create_lm_graph2, load_lm_graph
@@ -221,6 +225,7 @@ def test_lm_cache():
         assert len(lm_cache.ntypes) == 1
         assert lm_cache.ntypes[0] == 'n0'
 
+        lm_models._lm_models["n0"].lm_model.init_weights()
         # Create the second cache. It should loads the embeddings from
         # the first cache.
         lm_cache2 = LMCache(g, lm_models, tmpdirname)
@@ -503,8 +508,35 @@ def test_lm_embed_warmup(dev):
     th.distributed.destroy_process_group()
     dgl.distributed.kvstore.close_kvstore()
 
+def test_pytroch_emb_load_save(num_embs):
+    with tempfile.TemporaryDirectory() as tmpdirname:
+        emb = th.rand(num_embs, 10)
+        # gen tensor
+        lazy_emb = LazyDistTensor(emb, th.arange(num_embs))
+        path = os.path.join(tmpdirname, "test")
+        os.makedirs(path)
+        save_pytorch_embedding(path, lazy_emb, 0, 2)
+        save_pytorch_embedding(path, lazy_emb, 1, 2)
+        out_emb = th.empty(emb.shape)
+
+        class DummpyPolicy:
+            def get_size(self):
+                return 0
+
+        @patch("graphstorm.model.utils.create_dist_tensor", side_effect = [out_emb, out_emb])
+        @patch("graphstorm.model.utils.get_rank", side_effect = [0, 1])
+        @patch("graphstorm.model.utils.get_world_size", side_effect = [2, 2])
+        def load_tensor(mode_get_world_size,
+                        mock_get_rank,
+                        mock_create_dist_tensor):
+            load_pytorch_embedding(path, DummpyPolicy(), "dummy")
+            load_pytorch_embedding(path, DummpyPolicy(), "dummy")
+
+        load_tensor()
+        assert_almost_equal(emb.numpy(), out_emb.numpy())
 
 if __name__ == '__main__':
+    test_pytroch_emb_load_save(11)
     test_lm_cache()
     test_mp_lm_cache()
     test_input_layer1(None)

--- a/tests/unit-tests/test_embed.py
+++ b/tests/unit-tests/test_embed.py
@@ -508,6 +508,7 @@ def test_lm_embed_warmup(dev):
     th.distributed.destroy_process_group()
     dgl.distributed.kvstore.close_kvstore()
 
+@pytest.mark.parametrize("num_embs", [100, 99])
 def test_pytroch_emb_load_save(num_embs):
     with tempfile.TemporaryDirectory() as tmpdirname:
         emb = th.rand(num_embs, 10)


### PR DESCRIPTION
Now the embeddings saved by save_pytorch_embeddings are saved as per node type.

This PR fixes the path issue of load cached LM embeddings.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
