### PR TITLE
Speed up sampling for constructing node features.

### DIFF
--- a/python/graphstorm/dataloading/dataloading.py
+++ b/python/graphstorm/dataloading/dataloading.py
@@ -169,7 +169,21 @@ class GSgnnEdgeDataLoaderBase():
         return self._fanout
 
 class MultiLayerNeighborSamplerForReconstruct(dgl.dataloading.BlockSampler):
-    """
+    """ A wrapper of MultiLayerNeighborSampler
+
+    This is a wrapper on MultiLayerNeighborSampler to sample additional neighbors
+    for feature construction.
+
+    Parameters
+    ----------
+    sampler : MultiLayerNeighborSampler
+        A sampler to sample multi-hop neighbors.
+    dataset: GSgnnData
+        The GraphStorm dataset
+    construct_feat_ntype : list of str
+        The node types that requires to construct node features.
+    construct_feat_fanout : int
+        The fanout required to construct node features.
     """
     def __init__(self, sampler, dataset, construct_feat_ntype, construct_feat_fanout):
         super().__init__()
@@ -178,6 +192,21 @@ class MultiLayerNeighborSamplerForReconstruct(dgl.dataloading.BlockSampler):
                 dataset, construct_feat_ntype, construct_feat_fanout)
 
     def sample_blocks(self, g, seed_nodes, exclude_eids=None):
+        """ Sample blocks for message passing.
+
+        Parameters
+        ----------
+        g : DistGraph
+            The distributed graph.
+        seed_nodes : dict of Tensors
+            The seed nodes
+
+        Returns
+        -------
+        dict of Tensors : the input node IDs.
+        dict of Tensors : the seed node IDs.
+        list of DGLBlock : the blocks for message passing.
+        """
         input_nodes, seed_nodes, blocks = \
                 self._sampler.sample_blocks(g, seed_nodes, exclude_eids)
         if len(blocks) > 0:
@@ -549,7 +578,7 @@ class GSgnnLinkPredictionDataLoader(GSgnnLinkPredictionDataLoaderBase):
         return self
 
     def __next__(self):
-        return = self.dataloader.__next__()
+        return self.dataloader.__next__()
 
     def __len__(self):
         # Follow

--- a/python/graphstorm/dataloading/dataloading.py
+++ b/python/graphstorm/dataloading/dataloading.py
@@ -168,6 +168,23 @@ class GSgnnEdgeDataLoaderBase():
         """
         return self._fanout
 
+class MultiLayerNeighborSamplerForReconstruct(dgl.dataloading.BlockSampler):
+    """
+    """
+    def __init__(self, sampler, dataset, construct_feat_ntype, construct_feat_fanout):
+        super().__init__()
+        self._sampler = sampler
+        self._construct_feat_sampler = _ReconstructedNeighborSampler(
+                dataset, construct_feat_ntype, construct_feat_fanout)
+
+    def sample_blocks(self, g, seed_nodes, exclude_eids=None):
+        input_nodes, seed_nodes, blocks = \
+                self._sampler.sample_blocks(g, seed_nodes, exclude_eids)
+        if len(blocks) > 0:
+            block, input_nodes = self._construct_feat_sampler.sample(input_nodes)
+            blocks.insert(0, block)
+        return input_nodes, seed_nodes, blocks
+
 class GSgnnEdgeDataLoader(GSgnnEdgeDataLoaderBase):
     """ The minibatch dataloader for edge prediction
 
@@ -244,21 +261,24 @@ class GSgnnEdgeDataLoader(GSgnnEdgeDataLoaderBase):
                     "edge type {} does not exist in the graph".format(etype)
         if construct_feat_ntype is None:
             construct_feat_ntype = []
-        self._construct_feat_sampler = \
-                _ReconstructedNeighborSampler(dataset, construct_feat_ntype,
-                        construct_feat_fanout) if len(construct_feat_ntype) > 0 else None
-        self.dataloader = self._prepare_dataloader(dataset.g,
+        self.dataloader = self._prepare_dataloader(dataset,
                                                    target_idx,
                                                    edge_fanout_lis,
                                                    batch_size,
                                                    exclude_training_targets,
                                                    reverse_edge_types_map,
-                                                   train_task=train_task)
+                                                   train_task=train_task,
+                                                   construct_feat_ntype=construct_feat_ntype,
+                                                   construct_feat_fanout=construct_feat_fanout)
 
-    def _prepare_dataloader(self, g, target_idxs, fanout, batch_size,
+    def _prepare_dataloader(self, dataset, target_idxs, fanout, batch_size,
                             exclude_training_targets=False, reverse_edge_types_map=None,
-                            train_task=True):
+                            train_task=True, construct_feat_ntype=[], construct_feat_fanout=5):
+        g = dataset.g
         sampler = dgl.dataloading.MultiLayerNeighborSampler(fanout)
+        if len(construct_feat_ntype) > 0:
+            sampler = MultiLayerNeighborSamplerForReconstruct(sampler,
+                    dataset, construct_feat_ntype, construct_feat_fanout)
         # edge loader
         exclude_val = 'reverse_types' if exclude_training_targets else None
         loader = dgl.dataloading.DistEdgeDataLoader(g,
@@ -267,7 +287,6 @@ class GSgnnEdgeDataLoader(GSgnnEdgeDataLoaderBase):
                                                     batch_size=batch_size,
                                                     shuffle=train_task,
                                                     drop_last=False,
-                                                    num_workers=0,
                                                     exclude=exclude_val,
                                                     reverse_etypes=reverse_edge_types_map
                                                     if exclude_training_targets else None)
@@ -278,12 +297,7 @@ class GSgnnEdgeDataLoader(GSgnnEdgeDataLoaderBase):
         return self
 
     def __next__(self):
-        input_nodes, batch_graph, blocks = self.dataloader.__next__()
-        if self._construct_feat_sampler is not None and len(blocks) > 0:
-            block, input_nodes = self._construct_feat_sampler.sample(input_nodes)
-            blocks.insert(0, block)
-
-        return (input_nodes, batch_graph, blocks)
+        return self.dataloader.__next__()
 
     def __len__(self):
         # Follow
@@ -470,25 +484,26 @@ class GSgnnLinkPredictionDataLoader(GSgnnLinkPredictionDataLoaderBase):
 
         if construct_feat_ntype is None:
             construct_feat_ntype = []
-        self._construct_feat_sampler = \
-                _ReconstructedNeighborSampler(dataset, construct_feat_ntype,
-                        construct_feat_fanout) if len(construct_feat_ntype) > 0 else None
-        self.dataloader = self._prepare_dataloader(dataset.g, target_idx, fanout,
+        self.dataloader = self._prepare_dataloader(dataset, target_idx, fanout,
                 num_negative_edges, batch_size, device,
                 train_task=train_task,
                 exclude_training_targets=exclude_training_targets,
                 reverse_edge_types_map=reverse_edge_types_map,
-                edge_mask_for_gnn_embeddings=edge_mask_for_gnn_embeddings)
+                edge_mask_for_gnn_embeddings=edge_mask_for_gnn_embeddings,
+                construct_feat_ntype=construct_feat_ntype,
+                construct_feat_fanout=construct_feat_fanout)
 
     def _prepare_negative_sampler(self, num_negative_edges):
         # the default negative sampler is uniform sampler
         negative_sampler = dgl.dataloading.negative_sampler.Uniform(num_negative_edges)
         return negative_sampler
 
-    def _prepare_dataloader(self, g, target_idxs, fanout,
+    def _prepare_dataloader(self, dataset, target_idxs, fanout,
                             num_negative_edges, batch_size, device, train_task=True,
                             exclude_training_targets=False, reverse_edge_types_map=None,
-                            edge_mask_for_gnn_embeddings=None):
+                            edge_mask_for_gnn_embeddings=None, construct_feat_ntype=[],
+                            construct_feat_fanout=5):
+        g = dataset.g
         # The dataloader can only sample neighbors from the training graph.
         # This can avoid information leak during the link prediction training.
         # This avoids two types of information leak: it avoids sampling neighbors
@@ -502,6 +517,9 @@ class GSgnnLinkPredictionDataLoader(GSgnnLinkPredictionDataLoaderBase):
                                                                 mask=edge_mask_for_gnn_embeddings)
         else:
             sampler = dgl.dataloading.MultiLayerNeighborSampler(fanout)
+        if len(construct_feat_ntype) > 0:
+            sampler = MultiLayerNeighborSamplerForReconstruct(sampler,
+                    dataset, construct_feat_ntype, construct_feat_fanout)
         negative_sampler = self._prepare_negative_sampler(num_negative_edges)
 
         # edge loader
@@ -522,7 +540,6 @@ class GSgnnLinkPredictionDataLoader(GSgnnLinkPredictionDataLoaderBase):
                                                     negative_sampler=negative_sampler,
                                                     shuffle=train_task,
                                                     drop_last=False,
-                                                    num_workers=0,
                                                     exclude=exclude,
                                                     reverse_etypes=reverse_etypes)
         return loader
@@ -532,12 +549,7 @@ class GSgnnLinkPredictionDataLoader(GSgnnLinkPredictionDataLoaderBase):
         return self
 
     def __next__(self):
-        input_nodes, pos_graph, neg_graph, blocks = self.dataloader.__next__()
-        if self._construct_feat_sampler is not None and len(blocks) > 0:
-            block, input_nodes = self._construct_feat_sampler.sample(input_nodes)
-            blocks.insert(0, block)
-
-        return (input_nodes, pos_graph, neg_graph, blocks)
+        return = self.dataloader.__next__()
 
     def __len__(self):
         # Follow
@@ -581,10 +593,12 @@ class FastGSgnnLinkPredictionDataLoader(GSgnnLinkPredictionDataLoader):
         DGL sampler but use the train_mask to trim the sampled graph.
     """
 
-    def _prepare_dataloader(self, g, target_idxs, fanout,
+    def _prepare_dataloader(self, dataset, target_idxs, fanout,
                             num_negative_edges, batch_size, device, train_task=True,
                             exclude_training_targets=False, reverse_edge_types_map=None,
-                            edge_mask_for_gnn_embeddings=None):
+                            edge_mask_for_gnn_embeddings=None, construct_feat_ntype=[],
+                            construct_feat_fanout=5):
+        g = dataset.g
         # The dataloader can only sample neighbors from the training graph.
         # This can avoid information leak during the link prediction training.
         # This avoids two types of information leak: it avoids sampling neighbors
@@ -598,6 +612,9 @@ class FastGSgnnLinkPredictionDataLoader(GSgnnLinkPredictionDataLoader):
                                                     mask=edge_mask_for_gnn_embeddings)
         else:
             sampler = dgl.dataloading.MultiLayerNeighborSampler(fanout)
+        if len(construct_feat_ntype) > 0:
+            sampler = MultiLayerNeighborSamplerForReconstruct(sampler,
+                    dataset, construct_feat_ntype, construct_feat_fanout)
         negative_sampler = self._prepare_negative_sampler(num_negative_edges)
 
         # edge loader
@@ -618,7 +635,6 @@ class FastGSgnnLinkPredictionDataLoader(GSgnnLinkPredictionDataLoader):
                                                     negative_sampler=negative_sampler,
                                                     shuffle=train_task,
                                                     drop_last=False,
-                                                    num_workers=0,
                                                     exclude=exclude,
                                                     reverse_etypes=reverse_etypes)
         return loader
@@ -815,11 +831,14 @@ class GSgnnAllEtypeLinkPredictionDataLoader(GSgnnLinkPredictionDataLoader):
 
     """
 
-    def _prepare_dataloader(self, g, target_idxs, fanout, num_negative_edges,
+    def _prepare_dataloader(self, dataset, target_idxs, fanout, num_negative_edges,
                             batch_size, device, train_task=True,
                             exclude_training_targets=False,
                             reverse_edge_types_map=None,
-                            edge_mask_for_gnn_embeddings=None):
+                            edge_mask_for_gnn_embeddings=None,
+                            construct_feat_ntype=[],
+                            construct_feat_fanout=5):
+        g = dataset.g
         # See the comment in GSgnnLinkPredictionDataLoader
         if edge_mask_for_gnn_embeddings is not None and \
                 any(edge_mask_for_gnn_embeddings in g.edges[etype].data
@@ -828,6 +847,9 @@ class GSgnnAllEtypeLinkPredictionDataLoader(GSgnnLinkPredictionDataLoader):
                                                                 mask=edge_mask_for_gnn_embeddings)
         else:
             sampler = dgl.dataloading.MultiLayerNeighborSampler(fanout)
+        if len(construct_feat_ntype) > 0:
+            sampler = MultiLayerNeighborSamplerForReconstruct(sampler,
+                    dataset, construct_feat_ntype, construct_feat_fanout)
         negative_sampler = self._prepare_negative_sampler(num_negative_edges)
 
         # edge loader
@@ -847,7 +869,6 @@ class GSgnnAllEtypeLinkPredictionDataLoader(GSgnnLinkPredictionDataLoader):
                                             negative_sampler=negative_sampler,
                                             shuffle=train_task,
                                             drop_last=False,
-                                            num_workers=0,
                                             exclude=exclude_val,
                                             reverse_etypes=reverse_edge_types_map \
                                                 if exclude_training_targets else None)
@@ -858,12 +879,7 @@ class GSgnnAllEtypeLinkPredictionDataLoader(GSgnnLinkPredictionDataLoader):
         return self
 
     def __next__(self):
-        input_nodes, pos_graph, neg_graph, blocks = self.dataloader.__next__()
-        if self._construct_feat_sampler is not None and len(blocks) > 0:
-            block, input_nodes = self._construct_feat_sampler.sample(input_nodes)
-            blocks.insert(0, block)
-
-        return (input_nodes, pos_graph, neg_graph, blocks)
+        return self.dataloader.__next__()
 
     def __len__(self):
         # Follow
@@ -1099,29 +1115,33 @@ class GSgnnNodeDataLoader(GSgnnNodeDataLoaderBase):
         super().__init__(dataset, target_idx, fanout)
         if construct_feat_ntype is None:
             construct_feat_ntype = []
-        self._construct_feat_sampler = \
-                _ReconstructedNeighborSampler(dataset, construct_feat_ntype,
-                        construct_feat_fanout) if len(construct_feat_ntype) > 0 else None
         assert isinstance(target_idx, dict)
         for ntype in target_idx:
             assert ntype in dataset.g.ntypes, \
                     "node type {} does not exist in the graph".format(ntype)
-        self.dataloader = self._prepare_dataloader(dataset.g,
+        self.dataloader = self._prepare_dataloader(dataset,
                                                    target_idx,
                                                    fanout,
                                                    batch_size,
                                                    train_task,
-                                                   device)
+                                                   device,
+                                                   construct_feat_ntype=construct_feat_ntype,
+                                                   construct_feat_fanout=construct_feat_fanout)
 
-    def _prepare_dataloader(self, g, target_idx, fanout, batch_size, train_task, device):
+    def _prepare_dataloader(self, dataset, target_idx, fanout, batch_size,
+            train_task, device, construct_feat_ntype=[], construct_feat_fanout=5):
+        g = dataset.g
         if train_task:
             for ntype in target_idx:
                 target_idx[ntype] = trim_data(target_idx[ntype], device)
         # for validation and test, there is no need to trim data
 
         sampler = dgl.dataloading.MultiLayerNeighborSampler(fanout)
+        if len(construct_feat_ntype) > 0:
+            sampler = MultiLayerNeighborSamplerForReconstruct(sampler,
+                    dataset, construct_feat_ntype, construct_feat_fanout)
         loader = dgl.dataloading.DistNodeDataLoader(g, target_idx, sampler,
-            batch_size=batch_size, shuffle=train_task, num_workers=0)
+            batch_size=batch_size, shuffle=train_task)
 
         return loader
 
@@ -1130,11 +1150,7 @@ class GSgnnNodeDataLoader(GSgnnNodeDataLoaderBase):
         return self
 
     def __next__(self):
-        input_nodes, seeds, blocks = self.dataloader.__next__()
-        if self._construct_feat_sampler is not None and len(blocks) > 0:
-            block, input_nodes = self._construct_feat_sampler.sample(input_nodes)
-            blocks.insert(0, block)
-        return input_nodes, seeds, blocks
+        return self.dataloader.__next__()
 
     def __len__(self):
         # Follow

--- a/python/graphstorm/dataloading/dataloading.py
+++ b/python/graphstorm/dataloading/dataloading.py
@@ -1217,7 +1217,7 @@ class GSgnnNodeSemiSupDataLoader(GSgnnNodeDataLoader):
         super().__init__(dataset, target_idx, fanout, batch_size // 2, device,
                          train_task=train_task)
         # loader for unlabeled nodes:
-        self.unlabeled_dataloader = self._prepare_dataloader(dataset.g,
+        self.unlabeled_dataloader = self._prepare_dataloader(dataset,
                                                    unlabeled_idx,
                                                    fanout,
                                                    batch_size // 2,

--- a/python/graphstorm/dataloading/dataloading.py
+++ b/python/graphstorm/dataloading/dataloading.py
@@ -288,8 +288,6 @@ class GSgnnEdgeDataLoader(GSgnnEdgeDataLoaderBase):
         for etype in target_idx:
             assert etype in dataset.g.canonical_etypes, \
                     "edge type {} does not exist in the graph".format(etype)
-        if construct_feat_ntype is None:
-            construct_feat_ntype = []
         self.dataloader = self._prepare_dataloader(dataset,
                                                    target_idx,
                                                    edge_fanout_lis,
@@ -302,8 +300,10 @@ class GSgnnEdgeDataLoader(GSgnnEdgeDataLoaderBase):
 
     def _prepare_dataloader(self, dataset, target_idxs, fanout, batch_size,
                             exclude_training_targets=False, reverse_edge_types_map=None,
-                            train_task=True, construct_feat_ntype=[], construct_feat_fanout=5):
+                            train_task=True, construct_feat_ntype=None, construct_feat_fanout=5):
         g = dataset.g
+        if construct_feat_ntype is None:
+            construct_feat_ntype = []
         sampler = dgl.dataloading.MultiLayerNeighborSampler(fanout)
         if len(construct_feat_ntype) > 0:
             sampler = MultiLayerNeighborSamplerForReconstruct(sampler,
@@ -511,8 +511,6 @@ class GSgnnLinkPredictionDataLoader(GSgnnLinkPredictionDataLoaderBase):
             assert etype in dataset.g.canonical_etypes, \
                     "edge type {} does not exist in the graph".format(etype)
 
-        if construct_feat_ntype is None:
-            construct_feat_ntype = []
         self.dataloader = self._prepare_dataloader(dataset, target_idx, fanout,
                 num_negative_edges, batch_size, device,
                 train_task=train_task,
@@ -530,9 +528,11 @@ class GSgnnLinkPredictionDataLoader(GSgnnLinkPredictionDataLoaderBase):
     def _prepare_dataloader(self, dataset, target_idxs, fanout,
                             num_negative_edges, batch_size, device, train_task=True,
                             exclude_training_targets=False, reverse_edge_types_map=None,
-                            edge_mask_for_gnn_embeddings=None, construct_feat_ntype=[],
+                            edge_mask_for_gnn_embeddings=None, construct_feat_ntype=None,
                             construct_feat_fanout=5):
         g = dataset.g
+        if construct_feat_ntype is None:
+            construct_feat_ntype = []
         # The dataloader can only sample neighbors from the training graph.
         # This can avoid information leak during the link prediction training.
         # This avoids two types of information leak: it avoids sampling neighbors
@@ -625,9 +625,11 @@ class FastGSgnnLinkPredictionDataLoader(GSgnnLinkPredictionDataLoader):
     def _prepare_dataloader(self, dataset, target_idxs, fanout,
                             num_negative_edges, batch_size, device, train_task=True,
                             exclude_training_targets=False, reverse_edge_types_map=None,
-                            edge_mask_for_gnn_embeddings=None, construct_feat_ntype=[],
+                            edge_mask_for_gnn_embeddings=None, construct_feat_ntype=None,
                             construct_feat_fanout=5):
         g = dataset.g
+        if construct_feat_ntype is None:
+            construct_feat_ntype = []
         # The dataloader can only sample neighbors from the training graph.
         # This can avoid information leak during the link prediction training.
         # This avoids two types of information leak: it avoids sampling neighbors
@@ -865,9 +867,11 @@ class GSgnnAllEtypeLinkPredictionDataLoader(GSgnnLinkPredictionDataLoader):
                             exclude_training_targets=False,
                             reverse_edge_types_map=None,
                             edge_mask_for_gnn_embeddings=None,
-                            construct_feat_ntype=[],
+                            construct_feat_ntype=None,
                             construct_feat_fanout=5):
         g = dataset.g
+        if construct_feat_ntype is None:
+            construct_feat_ntype = []
         # See the comment in GSgnnLinkPredictionDataLoader
         if edge_mask_for_gnn_embeddings is not None and \
                 any(edge_mask_for_gnn_embeddings in g.edges[etype].data
@@ -1142,8 +1146,6 @@ class GSgnnNodeDataLoader(GSgnnNodeDataLoaderBase):
     def __init__(self, dataset, target_idx, fanout, batch_size, device, train_task=True,
                  construct_feat_ntype=None, construct_feat_fanout=5):
         super().__init__(dataset, target_idx, fanout)
-        if construct_feat_ntype is None:
-            construct_feat_ntype = []
         assert isinstance(target_idx, dict)
         for ntype in target_idx:
             assert ntype in dataset.g.ntypes, \
@@ -1158,8 +1160,10 @@ class GSgnnNodeDataLoader(GSgnnNodeDataLoaderBase):
                                                    construct_feat_fanout=construct_feat_fanout)
 
     def _prepare_dataloader(self, dataset, target_idx, fanout, batch_size,
-            train_task, device, construct_feat_ntype=[], construct_feat_fanout=5):
+            train_task, device, construct_feat_ntype=None, construct_feat_fanout=5):
         g = dataset.g
+        if construct_feat_ntype is None:
+            construct_feat_ntype = []
         if train_task:
             for ntype in target_idx:
                 target_idx[ntype] = trim_data(target_idx[ntype], device)


### PR DESCRIPTION
*Description of changes:*
When sampling more neighbors to construct node features, we should run this in the sampling process instead of in the trainer process.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
