### PR TITLE
Add support in-batch joint negative

### DIFF
--- a/python/graphstorm/dataloading/__init__.py
+++ b/python/graphstorm/dataloading/__init__.py
@@ -16,9 +16,10 @@
     Initial to import dataloading and dataset classes
 """
 from .dataloading import GSgnnLinkPredictionDataLoader
-from .dataloading import GSgnnLPJointNegDataLoader
-from .dataloading import GSgnnLPLocalUniformNegDataLoader
-from .dataloading import GSgnnLPLocalJointNegDataLoader
+from .dataloading import (GSgnnLPJointNegDataLoader,
+                          GSgnnLPLocalUniformNegDataLoader,
+                          GSgnnLPLocalJointNegDataLoader,
+                          GSgnnLPInBatchJointNegDataLoader)
 from .dataloading import GSgnnAllEtypeLPJointNegDataLoader
 from .dataloading import GSgnnAllEtypeLinkPredictionDataLoader
 from .dataloading import GSgnnEdgeDataLoader
@@ -38,10 +39,11 @@ from .dataset import GSgnnEdgeInferData
 from .dataset import GSgnnNodeTrainData
 from .dataset import GSgnnNodeInferData
 
-from .dataloading import BUILTIN_LP_UNIFORM_NEG_SAMPLER
-from .dataloading import BUILTIN_LP_JOINT_NEG_SAMPLER
-from .dataloading import BUILTIN_LP_LOCALUNIFORM_NEG_SAMPLER
-from .dataloading import BUILTIN_LP_LOCALJOINT_NEG_SAMPLER
+from .dataloading import (BUILTIN_LP_UNIFORM_NEG_SAMPLER,
+                          BUILTIN_LP_JOINT_NEG_SAMPLER,
+                          BUILTIN_LP_INBATCH_JOINT_NEG_SAMPLER,
+                          BUILTIN_LP_LOCALUNIFORM_NEG_SAMPLER,
+                          BUILTIN_LP_LOCALJOINT_NEG_SAMPLER)
 from .dataloading import BUILTIN_LP_ALL_ETYPE_UNIFORM_NEG_SAMPLER
 from .dataloading import BUILTIN_LP_ALL_ETYPE_JOINT_NEG_SAMPLER
 from .dataloading import (BUILTIN_FAST_LP_UNIFORM_NEG_SAMPLER,

--- a/python/graphstorm/dataloading/dataloading.py
+++ b/python/graphstorm/dataloading/dataloading.py
@@ -595,17 +595,17 @@ class GSgnnLPJointNegDataLoader(GSgnnLinkPredictionDataLoader):
     """
 
     def _prepare_negative_sampler(self, num_negative_edges):
-        # the default negative sampler is uniform sampler
+        # The negative sampler is the joint uniform negative sampler.
         negative_sampler = JointUniform(num_negative_edges)
         return negative_sampler
 
 class GSgnnLPInBatchJointNegDataLoader(GSgnnLinkPredictionDataLoader):
-    """ Link prediction dataloader with joint negative sampler
+    """ Link prediction dataloader with in-batch and joint negative sampler
 
     """
 
     def _prepare_negative_sampler(self, num_negative_edges):
-        # the default negative sampler is uniform sampler
+        # The negative sampler is the in-batch joint uniform negative sampler.
         negative_sampler = InbatchJointUniform(num_negative_edges)
         return negative_sampler
 

--- a/python/graphstorm/dataloading/dataloading.py
+++ b/python/graphstorm/dataloading/dataloading.py
@@ -31,6 +31,7 @@ from .sampler import (LocalUniform,
                       JointUniform,
                       GlobalUniform,
                       JointLocalUniform,
+                      InbatchJointUniform,
                       FastMultiLayerNeighborSampler,
                       DistributedFileSampler)
 from .utils import trim_data, modify_fanout_for_target_etype
@@ -357,6 +358,7 @@ class GSgnnEdgeDataLoader(GSgnnEdgeDataLoaderBase):
 
 BUILTIN_LP_UNIFORM_NEG_SAMPLER = 'uniform'
 BUILTIN_LP_JOINT_NEG_SAMPLER = 'joint'
+BUILTIN_LP_INBATCH_JOINT_NEG_SAMPLER = 'inbatch_joint'
 BUILTIN_LP_LOCALUNIFORM_NEG_SAMPLER = 'localuniform'
 BUILTIN_LP_LOCALJOINT_NEG_SAMPLER = 'localjoint'
 BUILTIN_LP_ALL_ETYPE_UNIFORM_NEG_SAMPLER = 'all_etype_uniform'
@@ -595,6 +597,16 @@ class GSgnnLPJointNegDataLoader(GSgnnLinkPredictionDataLoader):
     def _prepare_negative_sampler(self, num_negative_edges):
         # the default negative sampler is uniform sampler
         negative_sampler = JointUniform(num_negative_edges)
+        return negative_sampler
+
+class GSgnnLPInBatchJointNegDataLoader(GSgnnLinkPredictionDataLoader):
+    """ Link prediction dataloader with joint negative sampler
+
+    """
+
+    def _prepare_negative_sampler(self, num_negative_edges):
+        # the default negative sampler is uniform sampler
+        negative_sampler = InbatchJointUniform(num_negative_edges)
         return negative_sampler
 
 class GSgnnLPLocalUniformNegDataLoader(GSgnnLinkPredictionDataLoader):

--- a/python/graphstorm/dataloading/sampler.py
+++ b/python/graphstorm/dataloading/sampler.py
@@ -224,7 +224,7 @@ class InbatchJointUniform(JointUniform):
         The number of negative examples per edge.
     '''
     def __init__(self, k):
-        self.k = k
+        super(JointUniform, self).__init__(k)
 
     def _generate(self, g, eids, canonical_etype):
         _, _, vtype = canonical_etype

--- a/python/graphstorm/dataloading/sampler.py
+++ b/python/graphstorm/dataloading/sampler.py
@@ -224,7 +224,7 @@ class InbatchJointUniform(JointUniform):
         The number of negative examples per edge.
     '''
     def __init__(self, k):
-        super(JointUniform, self).__init__(k)
+        super(InbatchJointUniform, self).__init__(k)
 
     def _generate(self, g, eids, canonical_etype):
         _, _, vtype = canonical_etype

--- a/python/graphstorm/dataloading/sampler.py
+++ b/python/graphstorm/dataloading/sampler.py
@@ -217,14 +217,7 @@ class InbatchJointUniform(JointUniform):
     The main idea is to sample a set of nodes and use them to corrupt all edges in a mini-batch.
     This algorithm won't change the sampling probability for each individual edge, but can
     significantly reduce the number of nodes in a mini-batch.
-
-    Parameters
-    ----------
-    k : int
-        The number of negative examples per edge.
     '''
-    def __init__(self, k):
-        super(InbatchJointUniform, self).__init__(k)
 
     def _generate(self, g, eids, canonical_etype):
         _, _, vtype = canonical_etype

--- a/python/graphstorm/dataloading/sampler.py
+++ b/python/graphstorm/dataloading/sampler.py
@@ -220,6 +220,13 @@ class InbatchJointUniform(JointUniform):
     '''
 
     def _generate(self, g, eids, canonical_etype):
+        """ The return negative edges will be in the format of:
+            src-uniform-joint | src-in-batch
+            dst-uniform-joint | dst-in-batch
+
+            The first part comes from uniform joint negative sampling.
+            The second part comes from in batch negative sampling.
+        """
         _, _, vtype = canonical_etype
         shape = eids.shape
         dtype = eids.dtype

--- a/python/graphstorm/dataloading/sampler.py
+++ b/python/graphstorm/dataloading/sampler.py
@@ -212,6 +212,55 @@ class JointUniform(object):
                 g.canonical_etypes[0][0], g.canonical_etypes[0][2])
         return pos_neg_tuple
 
+class InbatchJointUniform(JointUniform):
+    '''Jointly corrupt a group of edges.
+    The main idea is to sample a set of nodes and use them to corrupt all edges in a mini-batch.
+    This algorithm won't change the sampling probability for each individual edge, but can
+    significantly reduce the number of nodes in a mini-batch.
+
+    Parameters
+    ----------
+    k : int
+        The number of negative examples per edge.
+    '''
+    def __init__(self, k):
+        self.k = k
+
+    def _generate(self, g, eids, canonical_etype):
+        _, _, vtype = canonical_etype
+        shape = eids.shape
+        dtype = eids.dtype
+        ctx = eids.device
+        pos_src, pos_dst = g.find_edges(eids, etype=canonical_etype)
+        pos_src = pos_src.numpy()
+        num_pos_edges = len(pos_src)
+        src = np.repeat(pos_src, self.k)
+        dst = th.randint(g.number_of_nodes(vtype), (shape[0],), dtype=dtype, device=ctx)
+        dst = np.tile(dst, self.k)
+        if num_pos_edges > 1:
+            # Only when there are more than 1 edges, we can do in batch negative
+            src_in_batch = np.repeat(pos_src, num_pos_edges)
+            dst_in_batch = np.repeat(pos_dst.reshape(1, -1), num_pos_edges, axis=0).reshape(-1,)
+
+            # remove false negatives
+            # 1 1 1 2 2 2 3 3 3
+            # 1 2 3 1 2 3 1 2 3
+            # ->
+            # 1 1 2 2 3 3
+            # 2 3 1 3 1 2
+            in_batch_negs = th.ones(num_pos_edges*num_pos_edges, dtype=th.bool)
+            false_negative_idx = th.arange(num_pos_edges) * (num_pos_edges + 1)
+            in_batch_negs[false_negative_idx] = 0
+            src_in_batch = th.as_tensor(src_in_batch)[in_batch_negs]
+            dst_in_batch = th.as_tensor(dst_in_batch)[in_batch_negs]
+
+            src = th.cat((th.as_tensor(src), src_in_batch))
+            dst = th.cat((th.as_tensor(dst), dst_in_batch))
+        else:
+            src = th.as_tensor(src)
+            dst = th.as_tensor(dst)
+        return src, dst
+
 class JointLocalUniform(JointUniform):
     '''Jointly corrupt a group of edges.
 
@@ -395,7 +444,7 @@ class FastMultiLayerNeighborSampler(NeighborSampler):
 
 class FileSamplerInterface:
     r"""File Sampler Interface. This interface defines the
-    # operation supported by a file sampler and the common 
+    # operation supported by a file sampler and the common
     # check and processing for dataset_path.
 
     Parameters:

--- a/python/graphstorm/run/gsgnn_lp/gsgnn_lm_lp.py
+++ b/python/graphstorm/run/gsgnn_lp/gsgnn_lm_lp.py
@@ -24,17 +24,19 @@ from graphstorm.config import GSConfig
 from graphstorm.trainer import GSgnnLinkPredictionTrainer
 from graphstorm.dataloading import GSgnnLPTrainData
 from graphstorm.dataloading import GSgnnLinkPredictionDataLoader
-from graphstorm.dataloading import GSgnnLPJointNegDataLoader
-from graphstorm.dataloading import GSgnnLPLocalUniformNegDataLoader
-from graphstorm.dataloading import GSgnnLPLocalJointNegDataLoader
+from graphstorm.dataloading import (GSgnnLPJointNegDataLoader,
+                                    GSgnnLPLocalUniformNegDataLoader,
+                                    GSgnnLPLocalJointNegDataLoader,
+                                    GSgnnLPInBatchJointNegDataLoader)
 from graphstorm.dataloading import GSgnnAllEtypeLPJointNegDataLoader
 from graphstorm.dataloading import GSgnnAllEtypeLinkPredictionDataLoader
 from graphstorm.dataloading import GSgnnLinkPredictionTestDataLoader
 from graphstorm.dataloading import GSgnnLinkPredictionJointTestDataLoader
-from graphstorm.dataloading import BUILTIN_LP_UNIFORM_NEG_SAMPLER
-from graphstorm.dataloading import BUILTIN_LP_JOINT_NEG_SAMPLER
-from graphstorm.dataloading import BUILTIN_LP_LOCALUNIFORM_NEG_SAMPLER
-from graphstorm.dataloading import BUILTIN_LP_LOCALJOINT_NEG_SAMPLER
+from graphstorm.dataloading import (BUILTIN_LP_UNIFORM_NEG_SAMPLER,
+                                    BUILTIN_LP_JOINT_NEG_SAMPLER,
+                                    BUILTIN_LP_INBATCH_JOINT_NEG_SAMPLER,
+                                    BUILTIN_LP_LOCALUNIFORM_NEG_SAMPLER,
+                                    BUILTIN_LP_LOCALJOINT_NEG_SAMPLER)
 from graphstorm.dataloading import BUILTIN_LP_ALL_ETYPE_UNIFORM_NEG_SAMPLER
 from graphstorm.dataloading import BUILTIN_LP_ALL_ETYPE_JOINT_NEG_SAMPLER
 from graphstorm.eval import GSgnnMrrLPEvaluator, GSgnnPerEtypeMrrLPEvaluator
@@ -113,6 +115,8 @@ def main(config_args):
         dataloader_cls = GSgnnLinkPredictionDataLoader
     elif config.train_negative_sampler == BUILTIN_LP_JOINT_NEG_SAMPLER:
         dataloader_cls = GSgnnLPJointNegDataLoader
+    elif config.train_negative_sampler == BUILTIN_LP_INBATCH_JOINT_NEG_SAMPLER:
+        dataloader_cls = GSgnnLPInBatchJointNegDataLoader
     elif config.train_negative_sampler == BUILTIN_LP_LOCALUNIFORM_NEG_SAMPLER:
         dataloader_cls = GSgnnLPLocalUniformNegDataLoader
     elif config.train_negative_sampler == BUILTIN_LP_LOCALJOINT_NEG_SAMPLER:

--- a/python/graphstorm/run/gsgnn_lp/gsgnn_lp.py
+++ b/python/graphstorm/run/gsgnn_lp/gsgnn_lp.py
@@ -24,17 +24,19 @@ from graphstorm.config import GSConfig
 from graphstorm.trainer import GSgnnLinkPredictionTrainer
 from graphstorm.dataloading import GSgnnLPTrainData
 from graphstorm.dataloading import GSgnnLinkPredictionDataLoader
-from graphstorm.dataloading import GSgnnLPJointNegDataLoader
-from graphstorm.dataloading import GSgnnLPLocalUniformNegDataLoader
-from graphstorm.dataloading import GSgnnLPLocalJointNegDataLoader
+from graphstorm.dataloading import (GSgnnLPJointNegDataLoader,
+                                    GSgnnLPLocalUniformNegDataLoader,
+                                    GSgnnLPLocalJointNegDataLoader,
+                                    GSgnnLPInBatchJointNegDataLoader)
 from graphstorm.dataloading import GSgnnAllEtypeLPJointNegDataLoader
 from graphstorm.dataloading import GSgnnAllEtypeLinkPredictionDataLoader
 from graphstorm.dataloading import GSgnnLinkPredictionTestDataLoader
 from graphstorm.dataloading import GSgnnLinkPredictionJointTestDataLoader
-from graphstorm.dataloading import BUILTIN_LP_UNIFORM_NEG_SAMPLER
-from graphstorm.dataloading import BUILTIN_LP_JOINT_NEG_SAMPLER
-from graphstorm.dataloading import BUILTIN_LP_LOCALUNIFORM_NEG_SAMPLER
-from graphstorm.dataloading import BUILTIN_LP_LOCALJOINT_NEG_SAMPLER
+from graphstorm.dataloading import (BUILTIN_LP_UNIFORM_NEG_SAMPLER,
+                                    BUILTIN_LP_JOINT_NEG_SAMPLER,
+                                    BUILTIN_LP_INBATCH_JOINT_NEG_SAMPLER,
+                                    BUILTIN_LP_LOCALUNIFORM_NEG_SAMPLER,
+                                    BUILTIN_LP_LOCALJOINT_NEG_SAMPLER)
 from graphstorm.dataloading import BUILTIN_LP_ALL_ETYPE_UNIFORM_NEG_SAMPLER
 from graphstorm.dataloading import BUILTIN_LP_ALL_ETYPE_JOINT_NEG_SAMPLER
 from graphstorm.dataloading import (BUILTIN_FAST_LP_UNIFORM_NEG_SAMPLER,
@@ -122,6 +124,8 @@ def main(config_args):
         dataloader_cls = GSgnnLinkPredictionDataLoader
     elif config.train_negative_sampler == BUILTIN_LP_JOINT_NEG_SAMPLER:
         dataloader_cls = GSgnnLPJointNegDataLoader
+    elif config.train_negative_sampler == BUILTIN_LP_INBATCH_JOINT_NEG_SAMPLER:
+        dataloader_cls = GSgnnLPInBatchJointNegDataLoader
     elif config.train_negative_sampler == BUILTIN_LP_LOCALUNIFORM_NEG_SAMPLER:
         dataloader_cls = GSgnnLPLocalUniformNegDataLoader
     elif config.train_negative_sampler == BUILTIN_LP_LOCALJOINT_NEG_SAMPLER:

--- a/tests/unit-tests/test_dataloading.py
+++ b/tests/unit-tests/test_dataloading.py
@@ -42,6 +42,7 @@ from graphstorm.dataloading import (GSgnnNodeDataLoader,
                                     GSgnnNodeSemiSupDataLoader)
 from graphstorm.dataloading import (GSgnnLinkPredictionDataLoader,
                                     GSgnnLPJointNegDataLoader,
+                                    GSgnnLPInBatchJointNegDataLoader,
                                     GSgnnLPLocalUniformNegDataLoader,
                                     GSgnnLPLocalJointNegDataLoader,
                                     FastGSgnnLinkPredictionDataLoader,
@@ -54,6 +55,8 @@ from graphstorm.dataloading import DistillDataloaderGenerator, DistillDataManage
 from graphstorm.dataloading import DistributedFileSampler
 from graphstorm.dataloading import BUILTIN_LP_UNIFORM_NEG_SAMPLER
 from graphstorm.dataloading import BUILTIN_LP_JOINT_NEG_SAMPLER
+
+from graphstorm.dataloading.sampler import InbatchJointUniform
 
 from graphstorm.dataloading.dataset import (prepare_batch_input,
                                             prepare_batch_edge_input)
@@ -1266,6 +1269,10 @@ def test_lp_dataloader_len(batch_size):
                                                device='cuda:0', train_task=True)
     assert len(dataloader) == len(list(dataloader))
 
+    dataloader = GSgnnLPInBatchJointNegDataLoader(ep_data, target_idx, [10], batch_size, num_negative_edges=2,
+                                               device='cuda:0', train_task=True)
+    assert len(dataloader) == len(list(dataloader))
+
     dataloader = GSgnnLPLocalJointNegDataLoader(ep_data, target_idx, [10], batch_size, num_negative_edges=2,
                                                device='cuda:0', train_task=False)
     assert len(dataloader) == len(list(dataloader))
@@ -1305,8 +1312,33 @@ def test_lp_dataloader_len(batch_size):
     dataloader = FastGSgnnLPLocalJointNegDataLoader(ep_data, target_idx, [10], batch_size, num_negative_edges=2,
                                                device='cuda:0', train_task=True)
     assert len(dataloader) == len(list(dataloader))
+
+@pytest.mark.parametrize("num_pos", [2, 10])
+@pytest.mark.parametrize("num_neg", [5, 20])
+def test_inbatch_joint_neg_sampler(num_pos, num_neg):
+    src = th.arange(num_pos)
+    dst = th.arange(num_pos)
+    g = dgl.heterograph({
+        ("n0", "r0", "n1"): (src, dst),
+    })
+    sampler = InbatchJointUniform(num_neg)
+    src, dst = sampler._generate(g, th.arange(num_pos), ("n0", "r0", "n1"))
+    assert len(src) == num_pos * (num_pos - 1) + num_pos * num_neg
+    assert len(dst) == num_pos * (num_pos - 1) + num_pos * num_neg
+    in_batch_src = src[-num_pos * (num_pos - 1):]
+    in_batch_dst = dst[-num_pos * (num_pos - 1):]
+
+    for i in range(num_pos):
+        assert_equal(in_batch_src[i*(num_pos-1):(i+1)*(num_pos-1)].numpy(), np.repeat(i, (num_pos-1)))
+        tmp_idx = np.ones(num_pos, dtype=bool)
+        tmp_idx[i] = False
+        assert_equal(in_batch_dst[i*(num_pos-1):(i+1)*(num_pos-1)].numpy(),
+                     np.arange(num_pos)[tmp_idx])
+
 
 if __name__ == '__main__':
+    test_inbatch_joint_neg_sampler(10, 20)
+
     test_np_dataloader_len(11)
     test_ep_dataloader_len(11)
     test_lp_dataloader_len(11)

--- a/tests/unit-tests/test_dataloading.py
+++ b/tests/unit-tests/test_dataloading.py
@@ -1323,8 +1323,10 @@ def test_inbatch_joint_neg_sampler(num_pos, num_neg):
     })
     sampler = InbatchJointUniform(num_neg)
     src, dst = sampler._generate(g, th.arange(num_pos), ("n0", "r0", "n1"))
-    assert len(src) == num_pos * (num_pos - 1) + num_pos * num_neg
-    assert len(dst) == num_pos * (num_pos - 1) + num_pos * num_neg
+    # In batch joint negative includes
+    # uniform negatives + in-batch negatives.
+    assert len(src) == num_pos * num_neg +  num_pos * (num_pos - 1)
+    assert len(dst) == num_pos * num_neg + num_pos * (num_pos - 1)
     in_batch_src = src[-num_pos * (num_pos - 1):]
     in_batch_dst = dst[-num_pos * (num_pos - 1):]
 


### PR DESCRIPTION
In addition to sharing negatives in the joint negative sampler, we add more negatives by using in-batch negatives.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
