### PR TITLE
[Bug fix] Fix the error report when the input dir is empty

### DIFF
--- a/python/graphstorm/gconstruct/file_io.py
+++ b/python/graphstorm/gconstruct/file_io.py
@@ -389,6 +389,8 @@ def get_in_files(in_files):
     # If the input file has a wildcard, get all files that matches the input file name.
     if '*' in in_files:
         in_files = glob.glob(in_files)
+        assert len(in_files) > 0, \
+            f"There is no file matching {in_files} pattern"
     # This is a single file.
     elif not isinstance(in_files, list):
         in_files = [in_files]

--- a/tests/unit-tests/gconstruct/test_gconstruct_utils.py
+++ b/tests/unit-tests/gconstruct/test_gconstruct_utils.py
@@ -26,7 +26,10 @@ import pyarrow as pa
 from graphstorm.gconstruct.utils import _estimate_sizeof, _to_numpy_array, _to_shared_memory
 from graphstorm.gconstruct.utils import HDF5Array, ExtNumpyWrapper
 from graphstorm.gconstruct.utils import multiprocessing_data_read
-from graphstorm.gconstruct.file_io import write_data_hdf5, read_data_hdf5
+from graphstorm.gconstruct.file_io import (write_data_hdf5,
+                                           read_data_hdf5,
+                                           get_in_files,
+                                           write_data_parquet)
 from graphstorm.gconstruct.file_io import (read_data_csv,
                                            read_data_json,
                                            read_data_parquet)
@@ -250,7 +253,31 @@ def test_read_empty_parquet():
             pass_test = True
         assert pass_test
 
+def test_get_in_files():
+    with tempfile.TemporaryDirectory() as tmpdirname:
+        files = [os.path.join(tmpdirname, f"test{i}.parquet") for i in range(10)]
+        for i in range(10):
+            data = {"test": np.random.rand(10)}
+            write_data_parquet(data, files[i])
+
+        in_files = get_in_files(os.path.join(tmpdirname,"*.parquet"))
+        assert len(in_files) == 10
+        files.sort()
+        assert files == in_files
+
+        in_files = get_in_files(os.path.join(tmpdirname,"test9.parquet"))
+        assert len(in_files) == 1
+        assert os.path.join(tmpdirname,"test9.parquet") == in_files[0]
+
+        pass_test = False
+        try:
+            in_files = get_in_files(os.path.join(tmpdirname,"test10.parquet"))
+        except:
+            pass_test = True
+        assert pass_test
+
 if __name__ == '__main__':
+    test_get_in_files()
     test_read_empty_parquet()
     test_read_empty_json()
     test_read_empty_csv()


### PR DESCRIPTION
When wildcard is used to specify edge files while there is no file matching, gconstruct does not report the error as early as possible.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
