### PR TITLE
In GLEM LM training phase, GNN use cached LM embeddings instead of hot ones

### DIFF
--- a/tests/unit-tests/test_embed.py
+++ b/tests/unit-tests/test_embed.py
@@ -498,6 +498,11 @@ def test_lm_embed_warmup(dev):
     emb_1 = layer(feat, input_nodes)
     assert_almost_equal(emb_0['n0'].detach().cpu().numpy(), emb_1['n0'].detach().cpu().numpy(), decimal=6)
 
+    # pass use_cache=False while model is frozen to override the using of cache
+    emb_12 = layer(feat, input_nodes, use_cache=False)
+    with assert_raises(AssertionError):
+        assert_almost_equal(emb_0['n0'].detach().cpu().numpy(), emb_12['n0'].detach().cpu().numpy(), decimal=1)
+
     # unfreeze the model, compute bert again
     feat = prepare_batch_input(g, input_nodes, dev=dev, feat_field=feat_field)
     layer.unfreeze()


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
GLEM iteratively trains LM and GNN. GNN depends on LM's embedding for its prediction, making it difficult to distill GNN into LM with predictions from GNN on pseudolabels. In this PR, LM training phase still maintain the LM cache for GNN to generate pseudolabels. 

- extend the `lm_embed.forward` with `use_cache` arg to override the forward computation even if cache is available
- changed the LM cache control in `GLEM.toggle`
- changed `GLEM._embed_nodes` to always use cached LM embeddings for GNN

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
