### PR TITLE
[Bugfix] save_prediction_path should not use save_emb_path as its default value

### DIFF
--- a/docs/source/configuration/configuration-run.rst
+++ b/docs/source/configuration/configuration-run.rst
@@ -377,7 +377,7 @@ Classification and Regression Task
 
     - Yaml: ``save_prediction_path: /data/infer-output/predictions/``
     - Argument: ``--save-prediction-path /data/infer-output/predictions/``
-    - Default value: If not provided, it will be the same as save_embed_path.
+    - Default value: If not provided, no prediction results will be saved.
 
 Node Classification/Regression Specific
 .........................................

--- a/python/graphstorm/config/argument.py
+++ b/python/graphstorm/config/argument.py
@@ -272,7 +272,6 @@ class GSConfig:
         _ = self.eval_batch_size
         _ = self.eval_frequency
         _ = self.no_validation
-        _ = self.save_prediction_path
         _ = self.eval_etype
         if self.task_type is not None:
             _ = self.eval_metric
@@ -300,6 +299,9 @@ class GSConfig:
             _ = self.train_negative_sampler
             _ = self.train_etype
             _ = self.remove_target_edge_type
+        else:
+            # inference
+            _ = self.save_prediction_path
 
         # LM module
         if self.node_lm_configs:
@@ -1564,8 +1566,9 @@ class GSConfig:
             return self._save_prediction_path
 
         # if save_prediction_path is not specified in inference
-        # use save_embed_path
-        return self.save_embed_path
+        logging.warning("save_prediction_path is not set. Prediction results" \
+                        "will not be saved for node or edge prediction tasks.")
+        return None
 
     ### Node related task variables ###
     @property

--- a/tests/unit-tests/test_config.py
+++ b/tests/unit-tests/test_config.py
@@ -1303,7 +1303,7 @@ def test_load_io_info():
         assert config.save_model_path == os.path.join(Path(tmpdirname), "save")
         assert config.save_model_frequency == 100
         assert config.save_embed_path == "./save_emb"
-        assert config.save_prediction_path == "./save_emb"
+        assert config.save_prediction_path == None
 
         args = Namespace(yaml_config_file=os.path.join(Path(tmpdirname), 'io_test2.yaml'),
                          local_rank=0)


### PR DESCRIPTION
Originally, if save_prediction_path is not set, it will use save_emb_path. The prediction results and emb results will be saved in the save path and the nid files of prediction results and embeddings will be mixed up.

Changing: Set the default value of save_prediction_path to None.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
