### PR TITLE
[Bugfix] Update temporal emb and prediction file names

### DIFF
--- a/docs/source/tutorials/quick-start.rst
+++ b/docs/source/tutorials/quick-start.rst
@@ -159,7 +159,7 @@ Inference on link prediction is similar as shown in the command below.
             --save-embed-path /tmp/ogbn-arxiv-lp/predictions/ \
             --restore-model-path /tmp/ogbn-arxiv-lp/models/epoch-2/
 
-The inference outputs include a **"emb_info.json"** metadata file and the prediction result file, **"emb.part00000.pt"** in the ``/tmp/ogbn-arxiv-lp/predictions/`` folder.
+The inference outputs include a **"emb_info.json"** metadata file and the prediction result file, **"embed-00000.pt"** in the ``/tmp/ogbn-arxiv-lp/predictions/`` folder.
 
 Generating Embedding
 --------------------
@@ -185,7 +185,7 @@ Users need to specify ``--restore-model-path`` and ``--save-embed-path`` when us
     /tmp/ogbn-arxiv-nc/saved_embed
         emb_info.json
         node/
-            node_emb.part00000.pt
+            node_embed-00000.pt
 
 
 For node classification/regression task, if ``target_ntype`` is provided, the command will generate and save node embeddings on ``target_ntype``, otherwise it will generate embeddings for all node types.
@@ -201,18 +201,18 @@ The saved result will be like:
     /tmp/saved_embed
         emb_info.json
         node_type1/
-            nids.part00000.pt
-            nids.part00001.pt
+            embed_nids-00000.pt
+            embed_nids-00001.pt
             ...
-            emb.part00000.pt
-            emb.part00001.pt
+            embed-00000.pt
+            embed-00001.pt
             ...
         node_type2/
-            nids.part00000.pt
-            nids.part00001.pt
+            embed_nids-00000.pt
+            embed_nids-00001.pt
             ...
-            emb.part00000.pt
-            emb.part00001.pt
+            embed-00000.pt
+            embed-00001.pt
             ...
 
 **That is it!** You have learnt how to use GraphStorm in three steps.

--- a/python/graphstorm/gconstruct/remap_result.py
+++ b/python/graphstorm/gconstruct/remap_result.py
@@ -190,18 +190,18 @@ def remap_node_emb(emb_ntypes, node_emb_dir,
         --------
         # embedddings:
         #   ntype0:
-        #     nids.part00000.pt
-        #     nids.part00001.pt
+        #     embed_nids-00000.pt
+        #     embed_nids-00001.pt
         #     ...
-        #     emb.part00000.pt
-        #     emb.part00001.pt
+        #     embed-00000.pt
+        #     embed-00001.pt
         #     ...
         #   ntype1:
-        #     nids.part00000.pt
-        #     nids.part00001.pt
+        #     embed_nids-00000.pt
+        #     embed_nids-00001.pt
         #     ...
-        #     emb.part00000.pt
-        #     emb.part00001.pt
+        #     embed-00000.pt
+        #     embed-00001.pt
         #     ...
 
         The output files will be
@@ -246,9 +246,9 @@ def remap_node_emb(emb_ntypes, node_emb_dir,
         ntype_emb_files = os.listdir(input_emb_dir)
         # please note nid_files can be empty.
         nid_files = [fname for fname in ntype_emb_files \
-                     if fname.startswith("nids") and fname.endswith("pt")]
+                     if fname.startswith("embed_nids-") and fname.endswith("pt")]
         emb_files = [fname for fname in ntype_emb_files \
-                     if fname.startswith("emb") and fname.endswith("pt")]
+                     if fname.startswith("embed-") and fname.endswith("pt")]
 
         nid_files.sort()
         emb_files.sort()
@@ -302,8 +302,8 @@ def remap_node_pred(pred_ntypes, pred_dir,
         #    predict-00000.pt
         #    predict-00001.pt
         #    ...
-        #    nids-00000.pt
-        #    nids-00001.pt
+        #    predict_nids-00000.pt
+        #    predict_nids-00001.pt
 
         The output files will be
         #    predict-00000_00000.parquet
@@ -337,8 +337,8 @@ def remap_node_pred(pred_ntypes, pred_dir,
         input_pred_dir = os.path.join(pred_dir, ntype)
         out_pred_dir = os.path.join(output_dir, ntype)
         ntype_pred_files = os.listdir(input_pred_dir)
-        nid_files = [fname for fname in ntype_pred_files if fname.startswith("nids")]
-        pred_files = [fname for fname in ntype_pred_files if fname.startswith("predict")]
+        nid_files = [fname for fname in ntype_pred_files if fname.startswith("predict_nids-")]
+        pred_files = [fname for fname in ntype_pred_files if fname.startswith("predict-")]
 
         nid_files.sort()
         pred_files.sort()
@@ -432,9 +432,9 @@ def remap_edge_pred(pred_etypes, pred_dir,
         input_pred_dir = os.path.join(pred_dir, "_".join(etype))
         out_pred_dir = os.path.join(output_dir, "_".join(etype))
         etype_pred_files = os.listdir(input_pred_dir)
-        src_nid_files = [fname for fname in etype_pred_files if fname.startswith("src_nids")]
-        dst_nid_files = [fname for fname in etype_pred_files if fname.startswith("dst_nids")]
-        pred_files = [fname for fname in etype_pred_files if fname.startswith("predict")]
+        src_nid_files = [fname for fname in etype_pred_files if fname.startswith("src_nids-")]
+        dst_nid_files = [fname for fname in etype_pred_files if fname.startswith("dst_nids-")]
+        pred_files = [fname for fname in etype_pred_files if fname.startswith("predict-")]
         src_nid_files.sort()
         dst_nid_files.sort()
         pred_files.sort()

--- a/tests/end2end-tests/check_infer.py
+++ b/tests/end2end-tests/check_infer.py
@@ -58,8 +58,8 @@ if __name__ == '__main__':
         train_nids = []
         ntype_emb_path = os.path.join(args.train_embout, ntype)
         emb_files = os.listdir(ntype_emb_path)
-        ntype_emb_files = [file for file in emb_files if file.endswith(".pt") and file.startswith("emb")]
-        ntype_nid_files = [file for file in emb_files if file.endswith(".pt") and file.startswith("nids")]
+        ntype_emb_files = [file for file in emb_files if file.endswith(".pt") and file.startswith("embed-")]
+        ntype_nid_files = [file for file in emb_files if file.endswith(".pt") and file.startswith("embed_nids-")]
         ntype_emb_files = sorted(ntype_emb_files)
         ntype_nid_files = sorted(ntype_nid_files)
         for f in ntype_emb_files:
@@ -86,8 +86,8 @@ if __name__ == '__main__':
         infer_nids = []
         ntype_emb_path = os.path.join(args.infer_embout, ntype)
         emb_files = os.listdir(ntype_emb_path)
-        ntype_emb_files = [file for file in emb_files if file.endswith(".pt") and file.startswith("emb")]
-        ntype_nid_files = [file for file in emb_files if file.endswith(".pt") and file.startswith("nids")]
+        ntype_emb_files = [file for file in emb_files if file.endswith(".pt") and file.startswith("embed-")]
+        ntype_nid_files = [file for file in emb_files if file.endswith(".pt") and file.startswith("embed_nids-")]
         ntype_emb_files = sorted(ntype_emb_files)
         ntype_nid_files = sorted(ntype_nid_files)
         for f in ntype_emb_files:

--- a/tests/end2end-tests/check_np_infer_emb.py
+++ b/tests/end2end-tests/check_np_infer_emb.py
@@ -46,8 +46,8 @@ if __name__ == '__main__':
         train_nids = []
         ntype_emb_path = os.path.join(args.train_embout, ntype)
         emb_files = os.listdir(ntype_emb_path)
-        ntype_emb_files = [file for file in emb_files if file.endswith(".pt") and file.startswith("emb")]
-        ntype_nid_files = [file for file in emb_files if file.endswith(".pt") and file.startswith("nids")]
+        ntype_emb_files = [file for file in emb_files if file.endswith(".pt") and file.startswith("embed-")]
+        ntype_nid_files = [file for file in emb_files if file.endswith(".pt") and file.startswith("embed_nids-")]
         ntype_emb_files = sorted(ntype_emb_files)
         ntype_nid_files = sorted(ntype_nid_files)
         for f in ntype_emb_files:
@@ -74,8 +74,8 @@ if __name__ == '__main__':
         infer_nids = []
         ntype_emb_path = os.path.join(args.infer_embout, ntype)
         emb_files = os.listdir(ntype_emb_path)
-        ntype_emb_files = [file for file in emb_files if file.endswith(".pt") and file.startswith("emb")]
-        ntype_nid_files = [file for file in emb_files if file.endswith(".pt") and file.startswith("nids")]
+        ntype_emb_files = [file for file in emb_files if file.endswith(".pt") and file.startswith("embed-")]
+        ntype_nid_files = [file for file in emb_files if file.endswith(".pt") and file.startswith("embed_nids-")]
         ntype_emb_files = sorted(ntype_emb_files)
         ntype_nid_files = sorted(ntype_nid_files)
         for ef, nf in zip(ntype_emb_files, ntype_nid_files):

--- a/tests/end2end-tests/data_process/check_emb_remap.py
+++ b/tests/end2end-tests/data_process/check_emb_remap.py
@@ -30,25 +30,25 @@ def main(args):
 
     ntype0_emb_path = os.path.join(emb_path, ntype0)
     data = read_data_parquet(
-        os.path.join(ntype0_emb_path, "emb.part00000_00000.parquet"),
+        os.path.join(ntype0_emb_path, "embed-00000_00000.parquet"),
         data_fields=["emb", "nid"])
 
     assert_equal(data["emb"][:,0].astype("str"), data["nid"])
     assert_equal(data["emb"][:,1].astype("str"), data["nid"])
     data = read_data_parquet(
-        os.path.join(ntype0_emb_path, "emb.part00001_00000.parquet"),
+        os.path.join(ntype0_emb_path, "embed-00001_00000.parquet"),
         data_fields=["emb", "nid"])
     assert_equal(data["emb"][:,0].astype("str"), data["nid"])
     assert_equal(data["emb"][:,1].astype("str"), data["nid"])
 
     ntype1_emb_path = os.path.join(emb_path, ntype1)
     data = read_data_parquet(
-        os.path.join(ntype1_emb_path, "emb.part00000_00000.parquet"),
+        os.path.join(ntype1_emb_path, "embed-00000_00000.parquet"),
         data_fields=["emb", "nid"])
     assert_equal(data["emb"][:,0].astype("str"), data["nid"])
     assert_equal(data["emb"][:,1].astype("str"), data["nid"])
     data = read_data_parquet(
-        os.path.join(ntype1_emb_path, "emb.part00001_00000.parquet"),
+        os.path.join(ntype1_emb_path, "embed-00001_00000.parquet"),
         data_fields=["emb", "nid"])
     assert_equal(data["emb"][:,0].astype("str"), data["nid"])
     assert_equal(data["emb"][:,1].astype("str"), data["nid"])

--- a/tests/end2end-tests/data_process/gen_emb_predict_remap_test.py
+++ b/tests/end2end-tests/data_process/gen_emb_predict_remap_test.py
@@ -76,17 +76,17 @@ def main(args):
     emb_output_ntype1 = os.path.join(emb_output, ntype1)
     os.makedirs(emb_output_ntype0)
     os.makedirs(emb_output_ntype1)
-    th.save(th.tensor(emb0_0), os.path.join(emb_output_ntype0, f"emb.part{pad_file_index(0)}.pt"))
-    th.save(th.tensor(nid0_new_0), os.path.join(emb_output_ntype0, f"nids.part{pad_file_index(0)}.pt"))
+    th.save(th.tensor(emb0_0), os.path.join(emb_output_ntype0, f"embed-{pad_file_index(0)}.pt"))
+    th.save(th.tensor(nid0_new_0), os.path.join(emb_output_ntype0, f"embed_nids-{pad_file_index(0)}.pt"))
 
-    th.save(th.tensor(emb1_0), os.path.join(emb_output_ntype1, f"emb.part{pad_file_index(0)}.pt"))
-    th.save(th.tensor(nid1_new_0), os.path.join(emb_output_ntype1, f"nids.part{pad_file_index(0)}.pt"))
+    th.save(th.tensor(emb1_0), os.path.join(emb_output_ntype1, f"embed-{pad_file_index(0)}.pt"))
+    th.save(th.tensor(nid1_new_0), os.path.join(emb_output_ntype1, f"embed_nids-{pad_file_index(0)}.pt"))
 
-    th.save(th.tensor(emb0_1), os.path.join(emb_output_ntype0, f"emb.part{pad_file_index(1)}.pt"))
-    th.save(th.tensor(nid0_new_1), os.path.join(emb_output_ntype0, f"nids.part{pad_file_index(1)}.pt"))
+    th.save(th.tensor(emb0_1), os.path.join(emb_output_ntype0, f"embed-{pad_file_index(1)}.pt"))
+    th.save(th.tensor(nid0_new_1), os.path.join(emb_output_ntype0, f"embed_nids-{pad_file_index(1)}.pt"))
 
-    th.save(th.tensor(emb1_1), os.path.join(emb_output_ntype1, f"emb.part{pad_file_index(1)}.pt"))
-    th.save(th.tensor(nid1_new_1), os.path.join(emb_output_ntype1, f"nids.part{pad_file_index(1)}.pt"))
+    th.save(th.tensor(emb1_1), os.path.join(emb_output_ntype1, f"embed-{pad_file_index(1)}.pt"))
+    th.save(th.tensor(nid1_new_1), os.path.join(emb_output_ntype1, f"embed_nids-{pad_file_index(1)}.pt"))
 
     # Case two: All the nodes have node embeddings
     emb0_0 = np.stack((nid0[:500], nid0[:500]), axis=1)

--- a/tests/end2end-tests/data_process/gen_node_predict_remap_test.py
+++ b/tests/end2end-tests/data_process/gen_node_predict_remap_test.py
@@ -76,16 +76,16 @@ def main(args):
     os.makedirs(pred_output_ntype0)
     os.makedirs(pred_output_ntype1)
     th.save(th.tensor(pred0_0), os.path.join(pred_output_ntype0, f"predict-{pad_file_index(0)}.pt"))
-    th.save(th.tensor(nid0_new_0), os.path.join(pred_output_ntype0, f"nids-{pad_file_index(0)}.pt"))
+    th.save(th.tensor(nid0_new_0), os.path.join(pred_output_ntype0, f"predict_nids-{pad_file_index(0)}.pt"))
 
     th.save(th.tensor(pred1_0), os.path.join(pred_output_ntype1, f"predict-{pad_file_index(0)}.pt"))
-    th.save(th.tensor(nid1_new_0), os.path.join(pred_output_ntype1, f"nids-{pad_file_index(0)}.pt"))
+    th.save(th.tensor(nid1_new_0), os.path.join(pred_output_ntype1, f"predict_nids-{pad_file_index(0)}.pt"))
 
     th.save(th.tensor(pred0_1), os.path.join(pred_output_ntype0, f"predict-{pad_file_index(1)}.pt"))
-    th.save(th.tensor(nid0_new_1), os.path.join(pred_output_ntype0, f"nids-{pad_file_index(1)}.pt"))
+    th.save(th.tensor(nid0_new_1), os.path.join(pred_output_ntype0, f"predict_nids-{pad_file_index(1)}.pt"))
 
     th.save(th.tensor(pred1_1), os.path.join(pred_output_ntype1, f"predict-{pad_file_index(1)}.pt"))
-    th.save(th.tensor(nid1_new_1), os.path.join(pred_output_ntype1, f"nids-{pad_file_index(1)}.pt"))
+    th.save(th.tensor(nid1_new_1), os.path.join(pred_output_ntype1, f"predict_nids-{pad_file_index(1)}.pt"))
 
 if __name__ == '__main__':
     argparser = argparse.ArgumentParser("Check edge prediction remapping")

--- a/tests/end2end-tests/graphstorm-lp/mgpu_test.sh
+++ b/tests/end2end-tests/graphstorm-lp/mgpu_test.sh
@@ -212,28 +212,28 @@ error_and_exit $?
 cnt=$(ls /data/gsgnn_lp_ml_dot/save-emb/movie | grep .pt | wc -l)
 if test $cnt -ne 0
 then
-    echo "/data/gsgnn_lp_ml_dot/save-emb/movie/emb.part0000x.pt should be removed."
+    echo "/data/gsgnn_lp_ml_dot/save-emb/movie/embed-0000x.pt should be removed."
     exit -1
 fi
 
 cnt=$(ls /data/gsgnn_lp_ml_dot/save-emb/movie | grep .parquet | wc -l)
 if test $cnt -ne $NUM_TRAINERS
 then
-    echo "$NUM_TRAINERS /data/gsgnn_lp_ml_dot/save-emb/movie/emb.part0000x_0000x.parquet files must exist."
+    echo "$NUM_TRAINERS /data/gsgnn_lp_ml_dot/save-emb/movie/embed-0000x_0000x.parquet files must exist."
     exit -1
 fi
 
 cnt=$(ls /data/gsgnn_lp_ml_dot/save-emb/user | grep .pt | wc -l)
 if test $cnt -ne 0
 then
-    echo "/data/gsgnn_lp_ml_dot/save-emb/user/emb.part0000x.pt should be removed."
+    echo "/data/gsgnn_lp_ml_dot/save-emb/user/embed-0000x.pt should be removed."
     exit -1
 fi
 
 cnt=$(ls /data/gsgnn_lp_ml_dot/save-emb/user | grep .parquet | wc -l)
 if test $cnt -ne $NUM_TRAINERS
 then
-    echo "$NUM_TRAINERS /data/gsgnn_lp_ml_dot/save-emb/user/emb.part0000x_0000x.parquet files must exist."
+    echo "$NUM_TRAINERS /data/gsgnn_lp_ml_dot/save-emb/user/embed-0000x_0000x.parquet files must exist."
     exit -1
 fi
 

--- a/tests/end2end-tests/graphstorm-nc/mgpu_test.sh
+++ b/tests/end2end-tests/graphstorm-nc/mgpu_test.sh
@@ -299,10 +299,10 @@ then
     exit -1
 fi
 
-cnt=$(ls -l /data/gsgnn_nc_ml_text/prediction/movie/ | grep nids | wc -l)
+cnt=$(ls -l /data/gsgnn_nc_ml_text/prediction/movie/ | grep predict_nids | wc -l)
 if test $cnt != 0
 then
-    echo "nids-xxx should be removed"
+    echo "predict_nids-xxx should be removed"
     exit -1
 fi
 
@@ -346,7 +346,7 @@ then
     exit -1
 fi
 
-cnt=$(ls -l /data/gsgnn_nc_ml_text/infer-emb/movie/ | grep "emb.part" | wc -l)
+cnt=$(ls -l /data/gsgnn_nc_ml_text/infer-emb/movie/ | grep "embed-" | wc -l)
 if test $cnt != $NUM_INFERs * 2
 then
     echo "There must be $NUM_INFERs embedding parts"

--- a/tests/end2end-tests/graphstorm-nc/test.sh
+++ b/tests/end2end-tests/graphstorm-nc/test.sh
@@ -234,7 +234,7 @@ then
     exit -1
 fi
 
-cnt=$(ls -l /data/gsgnn_nc_ml/infer-emb/movie/ | grep "emb.part" | wc -l)
+cnt=$(ls -l /data/gsgnn_nc_ml/infer-emb/movie/ | grep "embed-" | wc -l)
 cnt=$(($cnt/2))
 if test $cnt != $NUM_TRAINERS
 then
@@ -242,7 +242,7 @@ then
     exit -1
 fi
 
-cnt=$(ls -l /data/gsgnn_nc_ml/infer-emb/user/ | grep "emb.part" | wc -l)
+cnt=$(ls -l /data/gsgnn_nc_ml/infer-emb/user/ | grep "embed-" | wc -l)
 cnt=$(($cnt/2))
 if test $cnt != $NUM_TRAINERS
 then

--- a/tests/unit-tests/test_utils.py
+++ b/tests/unit-tests/test_utils.py
@@ -593,9 +593,9 @@ def test_save_embeddings_with_id_mapping(num_embs, backend):
 
         # Load saved embeddings
         emb0 = th.load(os.path.join(os.path.join(tmpdirname, dgl.NTYPE),
-                                    f'emb.part{pad_file_index(0)}.pt'), weights_only=True)
+                                    f'embed-{pad_file_index(0)}.pt'), weights_only=True)
         emb1 = th.load(os.path.join(os.path.join(tmpdirname, dgl.NTYPE),
-                                    f'emb.part{pad_file_index(1)}.pt'), weights_only=True)
+                                    f'embed-{pad_file_index(1)}.pt'), weights_only=True)
         saved_emb = th.cat([emb0, emb1], dim=0)
         assert len(saved_emb) == len(emb)
         assert_equal(emb[nid_mapping].numpy(), saved_emb.numpy())
@@ -635,25 +635,25 @@ def test_save_embeddings_with_id_mapping(num_embs, backend):
 
         # Load saved embeddings
         emb0 = th.load(os.path.join(os.path.join(tmpdirname, 'n0'),
-                                    f'emb.part{pad_file_index(0)}.pt'), weights_only=True)
+                                    f'embed-{pad_file_index(0)}.pt'), weights_only=True)
         emb1 = th.load(os.path.join(os.path.join(tmpdirname, 'n0'),
-                                    f'emb.part{pad_file_index(1)}.pt'), weights_only=True)
+                                    f'embed-{pad_file_index(1)}.pt'), weights_only=True)
         saved_emb = th.cat([emb0, emb1], dim=0)
         assert len(saved_emb) == len(embs['n0'])
         assert_equal(embs['n0'][nid_mappings['n0']].numpy(), saved_emb.numpy())
 
         emb0 = th.load(os.path.join(os.path.join(tmpdirname, 'n1'),
-                                    f'emb.part{pad_file_index(0)}.pt'), weights_only=True)
+                                    f'embed-{pad_file_index(0)}.pt'), weights_only=True)
         emb1 = th.load(os.path.join(os.path.join(tmpdirname, 'n1'),
-                                    f'emb.part{pad_file_index(1)}.pt'), weights_only=True)
+                                    f'embed-{pad_file_index(1)}.pt'), weights_only=True)
         saved_emb = th.cat([emb0, emb1], dim=0)
         assert len(saved_emb) == len(embs['n1'])
         assert_equal(embs['n1'][nid_mappings['n1']].numpy(), saved_emb.numpy())
 
         emb0 = th.load(os.path.join(os.path.join(tmpdirname, 'n2'),
-                                    f'emb.part{pad_file_index(0)}.pt'), weights_only=True)
+                                    f'embed-{pad_file_index(0)}.pt'), weights_only=True)
         emb1 = th.load(os.path.join(os.path.join(tmpdirname, 'n2'),
-                                    f'emb.part{pad_file_index(1)}.pt'), weights_only=True)
+                                    f'embed-{pad_file_index(1)}.pt'), weights_only=True)
         saved_emb = th.cat([emb0, emb1], dim=0)
         assert len(saved_emb) == len(embs['n2'])
         assert_equal(embs['n2'][nid_mappings['n2']].numpy(), saved_emb.numpy())
@@ -671,12 +671,12 @@ def test_save_embeddings():
 
         # Only work with torch 1.13+
         feats_type0 = [th.load(os.path.join(os.path.join(tmpdirname, "type0"),
-                                            f"emb.part{pad_file_index(i)}.pt"),
+                                            f"embed-{pad_file_index(i)}.pt"),
                                weights_only=True) for i in range(4)]
         feats_type0 = th.cat(feats_type0, dim=0)
         # Only work with torch 1.13+
         feats_type1 = [th.load(os.path.join(os.path.join(tmpdirname, "type1"),
-                                            f"emb.part{pad_file_index(i)}.pt"),
+                                            f"embed-{pad_file_index(i)}.pt"),
                                weights_only=True) for i in range(4)]
         feats_type1 = th.cat(feats_type1, dim=0)
 
@@ -867,12 +867,12 @@ def test_save_node_prediction_results():
 
         n0_feat0 = th.load(os.path.join(tmpdirname, os.path.join(ntype0, "predict-00000.pt")))
         n0_feat1 = th.load(os.path.join(tmpdirname, os.path.join(ntype0, "predict-00001.pt")))
-        n0_nid0 = th.load(os.path.join(tmpdirname, os.path.join(ntype0, "nids-00000.pt")))
-        n0_nid1 = th.load(os.path.join(tmpdirname, os.path.join(ntype0, "nids-00001.pt")))
+        n0_nid0 = th.load(os.path.join(tmpdirname, os.path.join(ntype0, "predict_nids-00000.pt")))
+        n0_nid1 = th.load(os.path.join(tmpdirname, os.path.join(ntype0, "predict_nids-00001.pt")))
         n1_feat0 = th.load(os.path.join(tmpdirname, os.path.join(ntype1, "predict-00000.pt")))
         n1_feat1 = th.load(os.path.join(tmpdirname, os.path.join(ntype1, "predict-00001.pt")))
-        n1_nid0 = th.load(os.path.join(tmpdirname, os.path.join(ntype1, "nids-00000.pt")))
-        n1_nid1 = th.load(os.path.join(tmpdirname, os.path.join(ntype1, "nids-00001.pt")))
+        n1_nid0 = th.load(os.path.join(tmpdirname, os.path.join(ntype1, "predict_nids-00000.pt")))
+        n1_nid1 = th.load(os.path.join(tmpdirname, os.path.join(ntype1, "predict_nids-00001.pt")))
 
         assert_almost_equal(th.cat([n0_feat0, n0_feat1]).numpy(),
                             th.cat([predictions0[ntype0][0], predictions1[ntype0][0]]).numpy())
@@ -912,13 +912,13 @@ def test_save_shuffled_node_embeddings():
 
         os.path.exists(os.path.join(tmpdirname, "emb_info.json"))
         os.path.exists(os.path.join(tmpdirname,
-                                    os.path.join(ntype0, "emb.part00000.pt")))
+                                    os.path.join(ntype0, "embed-00000.pt")))
         os.path.exists(os.path.join(tmpdirname,
-                                    os.path.join(ntype0, "emb.part00001.pt")))
+                                    os.path.join(ntype0, "embed-00001.pt")))
         os.path.exists(os.path.join(tmpdirname,
-                                    os.path.join(ntype1, "emb.part00000.pt")))
+                                    os.path.join(ntype1, "embed-00000.pt")))
         os.path.exists(os.path.join(tmpdirname,
-                                    os.path.join(ntype1, "emb.part00001.pt")))
+                                    os.path.join(ntype1, "embed-00001.pt")))
         with open(os.path.join(tmpdirname, "emb_info.json"), 'r', encoding='utf-8') as f:
             info = json.load(f)
             assert info["format"] == "pytorch"
@@ -926,21 +926,21 @@ def test_save_shuffled_node_embeddings():
             assert set(info["emb_name"]) == set([ntype0, ntype1])
 
         n0_feat0 = th.load(os.path.join(tmpdirname,
-                                        os.path.join(ntype0, "emb.part00000.pt")))
+                                        os.path.join(ntype0, "embed-00000.pt")))
         n0_feat1 = th.load(os.path.join(tmpdirname,
-                                        os.path.join(ntype0, "emb.part00001.pt")))
+                                        os.path.join(ntype0, "embed-00001.pt")))
         n0_nid0 = th.load(os.path.join(tmpdirname,
-                                       os.path.join(ntype0, "nids.part00000.pt")))
+                                       os.path.join(ntype0, "embed_nids-00000.pt")))
         n0_nid1 = th.load(os.path.join(tmpdirname,
-                                       os.path.join(ntype0, "nids.part00001.pt")))
+                                       os.path.join(ntype0, "embed_nids-00001.pt")))
         n1_feat0 = th.load(os.path.join(tmpdirname,
-                                        os.path.join(ntype1, "emb.part00000.pt")))
+                                        os.path.join(ntype1, "embed-00000.pt")))
         n1_feat1 = th.load(os.path.join(tmpdirname,
-                                        os.path.join(ntype1, "emb.part00001.pt")))
+                                        os.path.join(ntype1, "embed-00001.pt")))
         n1_nid0 = th.load(os.path.join(tmpdirname,
-                                       os.path.join(ntype1, "nids.part00000.pt")))
+                                       os.path.join(ntype1, "embed_nids-00000.pt")))
         n1_nid1 = th.load(os.path.join(tmpdirname,
-                                       os.path.join(ntype1, "nids.part00001.pt")))
+                                       os.path.join(ntype1, "embed_nids-00001.pt")))
 
         assert_almost_equal(th.cat([n0_feat0, n0_feat1]).numpy(),
                             th.cat([embs0[ntype0][0], embs1[ntype0][0]]).numpy())
@@ -1068,14 +1068,14 @@ def test_full_node_embeddings():
         assert p0.exitcode == 0
 
         ntype0_emb_path = os.path.join(emb_path, target_ntype0)
-        ntype0_emb = th.load(os.path.join(ntype0_emb_path, "emb.part00000.pt"))
-        ntype0_nid = th.load(os.path.join(ntype0_emb_path, "nids.part00000.pt"))
+        ntype0_emb = th.load(os.path.join(ntype0_emb_path, "embed-00000.pt"))
+        ntype0_nid = th.load(os.path.join(ntype0_emb_path, "embed_nids-00000.pt"))
         assert_equal(embeddings[target_ntype0].numpy(), ntype0_emb.numpy())
         assert_equal(ori_nid_maps[target_ntype0].numpy(), ntype0_nid.numpy())
 
         ntype1_emb_path = os.path.join(emb_path, target_ntype1)
-        ntype1_emb = th.load(os.path.join(ntype1_emb_path, "emb.part00000.pt"))
-        ntype1_nid = th.load(os.path.join(ntype1_emb_path, "nids.part00000.pt"))
+        ntype1_emb = th.load(os.path.join(ntype1_emb_path, "embed-00000.pt"))
+        ntype1_nid = th.load(os.path.join(ntype1_emb_path, "embed_nids-00000.pt"))
         assert_equal(embeddings[target_ntype1].numpy(), ntype1_emb.numpy())
         assert_equal(ori_nid_maps[target_ntype1].numpy(), ntype1_nid.numpy())
 


### PR DESCRIPTION
*Issue #, if available:*
The file names of temporal output embedding files and node prediction files are confusing.

*Description of changes:*
Update the file names.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
