### PR TITLE
[Bug fix] Fix ShageMaker S3 path bug

### DIFF
--- a/python/graphstorm/sagemaker/utils.py
+++ b/python/graphstorm/sagemaker/utils.py
@@ -274,7 +274,8 @@ def download_graph(graph_data_s3, graph_name, part_id, world_size,
         logging.info("Download graph from %s to %s",
                      os.path.join(graph_data_s3, graph_part),
                      graph_part_path)
-        S3Downloader.download(os.path.join(graph_data_s3, graph_part),
+        # add tailing / to s3:/xxxx/partN
+        S3Downloader.download(os.path.join(os.path.join(graph_data_s3, graph_part), ""),
             graph_part_path, sagemaker_session=sagemaker_session)
     except Exception as err: # pylint: disable=broad-except
         logging.error("Can not download graph_data from %s, %s.",

--- a/python/graphstorm/sagemaker/utils.py
+++ b/python/graphstorm/sagemaker/utils.py
@@ -272,7 +272,7 @@ def download_graph(graph_data_s3, graph_name, part_id, world_size,
             graph_path, sagemaker_session=sagemaker_session)
     try:
         logging.info("Download graph from %s to %s",
-                     os.path.join(graph_data_s3, graph_part),
+                     os.path.join(os.path.join(graph_data_s3, graph_part), ""),
                      graph_part_path)
         # add tailing / to s3:/xxxx/partN
         S3Downloader.download(os.path.join(os.path.join(graph_data_s3, graph_part), ""),


### PR DESCRIPTION
*Issue #, if available:*
`S3Downloader.download` use S3 path prefix match to find all matched file to download. This is different from folder match.

*Description of changes:*
Add "/" to the S3 path when downloading partitions


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
