### PR TITLE
Fix a bug in gconstruct when saving intermediate data on disks

### DIFF
--- a/python/graphstorm/gconstruct/utils.py
+++ b/python/graphstorm/gconstruct/utils.py
@@ -42,7 +42,10 @@ def _to_ext_memory(name, data, path):
     if isinstance(data, np.ndarray):
         assert name is not None
         path = os.path.join(path, f"{name}.npy")
-        if len(data) > 0:
+        # We only save a data matrix to the disk.
+        # This avoids the problem of saving an array of objects to disks.
+        # Note: There is a bug in Numpy when saving an array of objects to disks.
+        if len(data) > 0 and len(data.shape) > 1 and np.prod(data.shape[1:]) > 1:
             logging.debug("save data %s in %s.", name, path)
             data = convert_to_ext_mem_numpy(path, data)
             # We need to pass the array to another process. We don't want it

--- a/python/graphstorm/gconstruct/utils.py
+++ b/python/graphstorm/gconstruct/utils.py
@@ -38,14 +38,19 @@ SHARED_MEMORY_CROSS_PROCESS_STORAGE = "shared_memory"
 PICKLE_CROSS_PROCESS_STORAGE = "pickle"
 EXT_MEMORY_STORAGE = "ext_memory"
 
+def _is_numeric(arr):
+    """ Check if the input array has the numeric data type.
+    """
+    return np.issubdtype(arr.dtype, np.number) or arr.dtype == bool
+
 def _to_ext_memory(name, data, path):
     if isinstance(data, np.ndarray):
         assert name is not None
         path = os.path.join(path, f"{name}.npy")
-        # We only save a data matrix to the disk.
+        # We only save a data array with numeric or boolean values to the disk.
         # This avoids the problem of saving an array of objects to disks.
         # Note: There is a bug in Numpy when saving an array of objects to disks.
-        if len(data) > 0 and len(data.shape) > 1 and np.prod(data.shape[1:]) > 1:
+        if len(data) > 0 and _is_numeric(data):
             logging.debug("save data %s in %s.", name, path)
             data = convert_to_ext_mem_numpy(path, data)
             # We need to pass the array to another process. We don't want it

--- a/tests/unit-tests/gconstruct/test_gconstruct_utils.py
+++ b/tests/unit-tests/gconstruct/test_gconstruct_utils.py
@@ -197,7 +197,7 @@ def test_ext_mem_array():
         assert isinstance(arr_dict1["test1"][1], ExtNumpyWrapper)
         assert isinstance(arr_dict1["test2"][0], ExtNumpyWrapper)
         assert isinstance(arr_dict1["test2"][1], ExtNumpyWrapper)
-        assert isinstance(arr_dict1["test2"][3], np.ndarray)
+        assert isinstance(arr_dict1["test2"][2], np.ndarray)
         assert np.all(arr_dict1["test1"][0].to_numpy() == data1)
         assert np.all(arr_dict1["test1"][1].to_numpy() == data2)
         assert np.all(arr_dict1["test2"][0].to_numpy() == data3)

--- a/tests/unit-tests/gconstruct/test_gconstruct_utils.py
+++ b/tests/unit-tests/gconstruct/test_gconstruct_utils.py
@@ -182,9 +182,10 @@ def test_ext_mem_array():
         data2 = np.random.uniform(size=(1000,)).astype(np.float32)
         data3 = np.random.uniform(size=(1000, 10)).astype(np.float32)
         data4 = np.random.uniform(size=(1000,)).astype(np.float32)
+        data5 = np.random.uniform(size=(1000,)).astype(str)
         arr_dict = {
                 "test1": (data1, data2),
-                "test2": [data3, data4],
+                "test2": [data3, data4, data5],
         }
         arr_dict1 = _to_ext_memory(None, arr_dict, tmpdirname)
         assert isinstance(arr_dict1, dict)
@@ -196,6 +197,7 @@ def test_ext_mem_array():
         assert isinstance(arr_dict1["test1"][1], ExtNumpyWrapper)
         assert isinstance(arr_dict1["test2"][0], ExtNumpyWrapper)
         assert isinstance(arr_dict1["test2"][1], ExtNumpyWrapper)
+        assert isinstance(arr_dict1["test2"][3], np.ndarray)
         assert np.all(arr_dict1["test1"][0].to_numpy() == data1)
         assert np.all(arr_dict1["test1"][1].to_numpy() == data2)
         assert np.all(arr_dict1["test2"][0].to_numpy() == data3)


### PR DESCRIPTION
*Description of changes:*
Numpy has a bug when storing a list of objects in numpy memmap array. We should avoid saving such a list to a memmap array.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
