### PR TITLE
[GSProcessing] Fix support for large integer values for noop transfomation

### DIFF
--- a/graphstorm-processing/graphstorm_processing/graph_loaders/schema_utils.py
+++ b/graphstorm-processing/graphstorm_processing/graph_loaders/schema_utils.py
@@ -19,13 +19,7 @@ the type of the columns from the type mentioned in the configuration.
 import logging
 from typing import Sequence, List, Type
 
-from pyspark.sql.types import (
-    StructType,
-    StructField,
-    StringType,
-    DataType,
-    FloatType,
-)
+from pyspark.sql.types import StructType, StructField, StringType, DataType, DoubleType
 
 from ..config.config_parser import EdgeConfig, NodeConfig
 from ..config.label_config_base import LabelConfig
@@ -99,8 +93,8 @@ def determine_spark_feature_type(feature_type: str) -> Type[DataType]:
         "multi-categorical",
     ] or feature_type.startswith("text"):
         return StringType
-    if feature_type in ["numerical", "bucket-numerical", "none"]:
-        return FloatType
+    if feature_type in ["numerical", "bucket-numerical"]:
+        return DoubleType
     else:
         raise NotImplementedError(f"Unknown feature type: {feature_type}")
 
@@ -115,7 +109,7 @@ def _parse_edge_labels_schema(edge_labels_objects: Sequence[LabelConfig]) -> Seq
         if target_task_type == "classification":
             field_list.append(StructField(label_col, StringType(), True))
         elif target_task_type == "regression":
-            field_list.append(StructField(label_col, FloatType(), True))
+            field_list.append(StructField(label_col, DoubleType(), True))
         elif target_task_type == "link_prediction" and label_col:
             logging.info(
                 "Bypassing edge label %s, as it is only used for link prediction", label_col
@@ -163,6 +157,6 @@ def _parse_node_labels_schema(node_labels_objects: List[LabelConfig]) -> Sequenc
             # Could be ints, would that be an issue?
             field_list.append(StructField(label_col, StringType(), True))
         elif target_task_type == "regression":
-            field_list.append(StructField(label_col, FloatType(), True))
+            field_list.append(StructField(label_col, DoubleType(), True))
 
     return field_list


### PR DESCRIPTION
For now we also parse all numerical CSV values as float64. In the future we'll allow the use the option to choose, defaulting at float32.

*Issue #, if available:* Fixes #706

*Description of changes:*

* For CSV numerical feature input always parse as float64. We plan to allow this to be user-defined in the future.
* For CSV regression label input always parse as float64. We plan to allow this to be user-defined in the future.
* For Parquet numerical feature input for noop transformation, use the input's data type, to avoid precision loss by converting to float32.
* For CSV numerical input for noop transformation (which is parsed as string), output to float64.

*How this was tested*:

* Added relevant unit test
* Tested on generated graph dataset with integer features with values up to 80M, results shown below

<img width="1094" alt="image" src="https://github.com/awslabs/graphstorm/assets/9048995/772dc549-fd09-416c-bf73-71fbf11e634b">


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
