### PR TITLE
BugFix: Fix the bug when fixed_test_size is set while the number of testing edges are smaller than fixed_test_size

### DIFF
--- a/python/graphstorm/dataloading/dataloading.py
+++ b/python/graphstorm/dataloading/dataloading.py
@@ -991,6 +991,8 @@ class GSgnnLinkPredictionTestDataLoader():
                                 "is %d, which is smaller than the expected"
                                 "test size %d, force it to %d",
                                 etype, len(t_idx), self._fixed_test_size[etype], len(t_idx))
+                self._fixed_test_size[etype] = len(t_idx)
+
         self._negative_sampler = self._prepare_negative_sampler(num_negative_edges)
         self._reinit_dataset()
 

--- a/tests/unit-tests/test_dataloading.py
+++ b/tests/unit-tests/test_dataloading.py
@@ -642,6 +642,8 @@ def test_GSgnnLinkPredictionTestDataLoader(batch_size, num_negative_edges):
                 assert neg_src.shape[1] == num_negative_edges
                 assert th.all(neg_src < g.number_of_nodes(canonical_etype[0]))
 
+        # The target idx size for ("n0", "r1", "n1") is 2
+        # The target idx size for ("n0", "r0", "n1") is 50
         fixed_test_size = 10
         dataloader = GSgnnLinkPredictionTestDataLoader(
             lp_data,
@@ -649,15 +651,26 @@ def test_GSgnnLinkPredictionTestDataLoader(batch_size, num_negative_edges):
             batch_size=batch_size,
             num_negative_edges=num_negative_edges,fixed_test_size=fixed_test_size)
         num_samples = 0
+        num_pos_pairs = 0
         for pos_neg_tuple, sample_type in dataloader:
             num_samples += 1
             assert isinstance(pos_neg_tuple, dict)
+            assert len(pos_src) > 0
             assert len(pos_neg_tuple) == 1
             for _, pos_neg in pos_neg_tuple.items():
                 pos_src, _, pos_dst, _ = pos_neg
                 assert len(pos_src) <= batch_size
+                num_pos_pairs += len(pos_src)
 
-        assert num_samples ==  -(-fixed_test_size // batch_size) * 2
+        expected_samples = 0
+        expected_pos_pairs = 0
+        for _, t_idx in lp_data.train_idxs.items():
+            expected_idx_len = fixed_test_size if fixed_test_size < len(t_idx) else len(t_idx)
+            expected_samples += -(-expected_idx_len // batch_size)
+            expected_pos_pairs += expected_idx_len
+
+        assert num_samples == expected_samples
+        assert num_pos_pairs == expected_pos_pairs
 
     # after test pass, destroy all process group
     th.distributed.destroy_process_group()
@@ -1457,6 +1470,7 @@ def test_GSgnnTrainData_homogeneous():
     th.distributed.destroy_process_group()
 
 if __name__ == '__main__':
+    test_GSgnnLinkPredictionTestDataLoader(1, 1)
     test_inbatch_joint_neg_sampler(10, 20)
 
     test_np_dataloader_len(11)
@@ -1476,7 +1490,6 @@ if __name__ == '__main__':
     test_node_dataloader_reconstruct()
     test_GSgnnAllEtypeLinkPredictionDataLoader(10)
     test_GSgnnAllEtypeLinkPredictionDataLoader(1)
-    test_GSgnnLinkPredictionTestDataLoader(1, 1)
     test_GSgnnLinkPredictionTestDataLoader(10, 20)
     test_GSgnnLinkPredictionJointTestDataLoader(1, 1)
     test_GSgnnLinkPredictionJointTestDataLoader(10, 20)


### PR DESCRIPTION
*What is the bug:*
When fixed_test_size is set while the number of testing edges are smaller than fixed_test_size, GraphStorm only print a warning of setting the fixed_test_size to the number of testing edges, but it does not take the real action. In certain cases, the link prediction test dataloader will generate empty mini-batches which will crash the testing process.

*Description of changes:*
Fix the bug and update the unit tests.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
