### PR TITLE
[Bugfix] Fix a bug in launch.py when it is lauching remap commands.

### DIFF
--- a/python/graphstorm/run/launch.py
+++ b/python/graphstorm/run/launch.py
@@ -331,7 +331,7 @@ def wrap_dist_remap_command(
         with_shared_fs: bool,
         num_trainers: int,
         output_chunk_size: int = 100000,
-        preserve_input: bool = False):
+        preserve_input: bool = False) -> str:
     """ Wrap distributed remap command
 
         Parameters

--- a/python/graphstorm/run/launch.py
+++ b/python/graphstorm/run/launch.py
@@ -30,6 +30,7 @@ import signal
 import subprocess
 import sys
 import time
+import copy
 from functools import partial
 from threading import Thread
 from typing import Optional
@@ -324,7 +325,7 @@ def construct_torch_dist_launcher_cmd(
     )
 
 def wrap_dist_remap_command(
-        udf_command: str,
+        udf_command: list,
         rank: int,
         world_size: int,
         with_shared_fs: bool,
@@ -356,22 +357,23 @@ def wrap_dist_remap_command(
         if sys.executable is not None and sys.executable != "" \
         else "python3 "
 
-    udf_command[0] = "graphstorm.gconstruct.remap_result"
+    new_udf_command = copy.deepcopy(udf_command)
+    new_udf_command[0] = "graphstorm.gconstruct.remap_result"
 
     # Add remap related arguments
-    udf_command += ["--rank", str(rank)]
-    udf_command += ["--world-size", str(world_size)]
-    udf_command += ["--with-shared-fs", "True" if with_shared_fs else "False"]
-    udf_command += ["--num-processes", str(num_trainers)]
-    udf_command += ["--output-chunk-size", str(output_chunk_size)]
-    udf_command += ["--preserve-input", "True" if preserve_input else "False"]
+    new_udf_command += ["--rank", str(rank)]
+    new_udf_command += ["--world-size", str(world_size)]
+    new_udf_command += ["--with-shared-fs", "True" if with_shared_fs else "False"]
+    new_udf_command += ["--num-processes", str(num_trainers)]
+    new_udf_command += ["--output-chunk-size", str(output_chunk_size)]
+    new_udf_command += ["--preserve-input", "True" if preserve_input else "False"]
 
     # transforms the udf_command from:
     #     path/to/dist_trainer.py arg0 arg1
     # to:
     #     python -m torch.distributed.launch [DIST TORCH ARGS] path/to/dist_trainer.py arg0 arg1
-    udf_command = " ".join(udf_command)
-    new_udf_command = f"{python_bin} -m {udf_command}"
+    new_udf_command = " ".join(new_udf_command)
+    new_udf_command = f"{python_bin} -m {new_udf_command}"
 
     return new_udf_command
 

--- a/python/graphstorm/run/launch.py
+++ b/python/graphstorm/run/launch.py
@@ -33,7 +33,7 @@ import time
 import copy
 from functools import partial
 from threading import Thread
-from typing import Optional
+from typing import List, Optional
 from argparse import REMAINDER
 
 
@@ -325,7 +325,7 @@ def construct_torch_dist_launcher_cmd(
     )
 
 def wrap_dist_remap_command(
-        udf_command: list,
+        udf_command: List[str],
         rank: int,
         world_size: int,
         with_shared_fs: bool,
@@ -350,6 +350,11 @@ def wrap_dist_remap_command(
             Number of rows per output file.
         preserve_input:
             Whether we preserve the input data.
+
+        Returns
+        -------
+        A string of remap_result launch command that combines the original arguments list
+        with remap specific arguments.
     """
     # Get the python interpreter used right now.
     # If we can not get it we go with the default `python3`


### PR DESCRIPTION
*Issue #, if available:*
When launching remap commands in a distributed env, launch.py continuously appends new arguments into the launch command. For example:

```
PYTHONPATH=/opt/conda/bin:/root/dgl/tools:/opt/ml/code/graphstorm/python; /opt/conda/bin/python3 -m graphstorm.gconstruct.remap_result --cf config.yaml --restore-model-path /opt/ml/gsgnn_model --save-embed-path /tmp/infer_output/embs --save-embed-path /tmp/infer_output/embs --ip-config ip_list.txt --part-config metadata.json --rank 0 --world-size 16 --with-shared-fs False --num-processes 1 --output-chunk-size 100000 --preserve-input False --rank 1 --world-size 16 --with-shared-fs False --num-processes 1 --output-chunk-size 100000 --preserve-input False

PYTHONPATH=/opt/conda/bin:/root/dgl/tools:/opt/ml/code/graphstorm/python; /opt/conda/bin/python3 -m graphstorm.gconstruct.remap_result --cf config.yaml --restore-model-path /opt/ml/gsgnn_model --save-embed-path /tmp/infer_output/embs --save-embed-path /tmp/infer_output/embs --ip-config ip_list.txt --part-config metadata.json --rank 0 --world-size 16 --with-shared-fs False --num-processes 1 --output-chunk-size 100000 --preserve-input False --rank 1 --world-size 16 --with-shared-fs False --num-processes 1 --output-chunk-size 100000 --preserve-input False --rank 2 --world-size 16 --with-shared-fs False --num-processes 1 --output-chunk-size 100000 --preserve-input False
```

*Description of changes:*
Use `copy.deepcopy(udf_command)` to avoid appending args to the original `udf_command` in the `wrap_dist_remap_command` function.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
