### PR TITLE
Balance the training set in graph partitioning

### DIFF
--- a/python/graphstorm/gconstruct/utils.py
+++ b/python/graphstorm/gconstruct/utils.py
@@ -939,9 +939,17 @@ def partition_graph(g, node_data, edge_data, graph_name, num_partitions, output_
 
     balance_ntypes = {}
     for ntype in node_data:
+        balance_arr = th.zeros(g.number_of_nodes(ntype), dtype=th.int8)
         if "train_mask" in node_data[ntype]:
-            balance_ntypes[ntype] = th.tensor(node_data[ntype]["train_mask"])
+            balance_arr += node_data[ntype]["train_mask"]
             logging.debug("Balance training nodes on node %s.", ntype)
+        if "val_mask" in node_data[ntype]:
+            balance_arr += node_data[ntype]["val_mask"]
+            logging.debug("Balance validation nodes on node %s.", ntype)
+        if "test_mask" in node_data[ntype]:
+            balance_arr += node_data[ntype]["test_mask"]
+            logging.debug("Balance test nodes on node %s.", ntype)
+        balance_ntypes[ntype] = balance_arr
     mapping = \
         dgl.distributed.partition_graph(g, graph_name, num_partitions, output_dir,
                                         part_method=part_method,

--- a/python/graphstorm/gconstruct/utils.py
+++ b/python/graphstorm/gconstruct/utils.py
@@ -938,9 +938,10 @@ def partition_graph(g, node_data, edge_data, graph_name, num_partitions, output_
         part_method = "None" if num_partitions == 1 else "metis"
 
     balance_ntypes = {}
-    for ntype in g.ntypes:
-        if "train_mask" in g.nodes[ntype].data:
-            balance_ntypes[ntype] = g.nodes[ntype].data["train_mask"]
+    for ntype in node_data:
+        if "train_mask" in node_data[ntype]:
+            balance_ntypes[ntype] = th.tensor(node_data[ntype]["train_mask"])
+            logging.debug("Balance training nodes on node %s.", ntype)
     mapping = \
         dgl.distributed.partition_graph(g, graph_name, num_partitions, output_dir,
                                         part_method=part_method,

--- a/python/graphstorm/gconstruct/utils.py
+++ b/python/graphstorm/gconstruct/utils.py
@@ -940,14 +940,17 @@ def partition_graph(g, node_data, edge_data, graph_name, num_partitions, output_
     balance_ntypes = {}
     for ntype in node_data:
         balance_arr = th.zeros(g.number_of_nodes(ntype), dtype=th.int8)
+        balance_tag = 1
         if "train_mask" in node_data[ntype]:
-            balance_arr += node_data[ntype]["train_mask"]
+            balance_arr += node_data[ntype]["train_mask"] * balance_tag
+            balance_tag += 1
             logging.debug("Balance training nodes on node %s.", ntype)
         if "val_mask" in node_data[ntype]:
-            balance_arr += node_data[ntype]["val_mask"] * 2
+            balance_arr += node_data[ntype]["val_mask"] * balance_tag
+            balance_tag += 1
             logging.debug("Balance validation nodes on node %s.", ntype)
         if "test_mask" in node_data[ntype]:
-            balance_arr += node_data[ntype]["test_mask"] * 3
+            balance_arr += node_data[ntype]["test_mask"] * balance_tag
             logging.debug("Balance test nodes on node %s.", ntype)
         balance_ntypes[ntype] = balance_arr
     mapping = \

--- a/python/graphstorm/gconstruct/utils.py
+++ b/python/graphstorm/gconstruct/utils.py
@@ -937,11 +937,14 @@ def partition_graph(g, node_data, edge_data, graph_name, num_partitions, output_
     if part_method is None:
         part_method = "None" if num_partitions == 1 else "metis"
 
+    balance_ntypes = {}
+    for ntype in g.ntypes:
+        if "train_mask" in g.nodes[ntype].data:
+            balance_ntypes[ntype] = g.nodes[ntype].data["train_mask"]
     mapping = \
         dgl.distributed.partition_graph(g, graph_name, num_partitions, output_dir,
                                         part_method=part_method,
-                                        # TODO(zhengda) we need to enable balancing node types.
-                                        balance_ntypes=None,
+                                        balance_ntypes=balance_ntypes,
                                         balance_edges=True,
                                         return_mapping=save_mapping)
     sys_tracker.check('Graph partitioning')

--- a/python/graphstorm/gconstruct/utils.py
+++ b/python/graphstorm/gconstruct/utils.py
@@ -944,10 +944,10 @@ def partition_graph(g, node_data, edge_data, graph_name, num_partitions, output_
             balance_arr += node_data[ntype]["train_mask"]
             logging.debug("Balance training nodes on node %s.", ntype)
         if "val_mask" in node_data[ntype]:
-            balance_arr += node_data[ntype]["val_mask"]
+            balance_arr += node_data[ntype]["val_mask"] * 2
             logging.debug("Balance validation nodes on node %s.", ntype)
         if "test_mask" in node_data[ntype]:
-            balance_arr += node_data[ntype]["test_mask"]
+            balance_arr += node_data[ntype]["test_mask"] * 3
             logging.debug("Balance test nodes on node %s.", ntype)
         balance_ntypes[ntype] = balance_arr
     mapping = \

--- a/tests/unit-tests/gconstruct/test_construct_graph.py
+++ b/tests/unit-tests/gconstruct/test_construct_graph.py
@@ -1106,17 +1106,25 @@ def test_partition_graph(num_parts):
     assert np.all(dst[src >= 50].numpy() >= 50)
 
     train_mask1 = np.zeros((num_nodes['node1'],), dtype=np.int8)
-    train_mask1[0:num_nodes['node1']//2] = 1
+    train_mask1[0:num_nodes['node1']//3] = 1
+    test_mask1 = np.zeros((num_nodes['node1'],), dtype=np.int8)
+    test_mask1[num_nodes['node1']//3:num_nodes['node1']//2] = 1
+
     train_mask2 = np.zeros((num_nodes['node2'],), dtype=np.int8)
-    train_mask2[0:num_nodes['node2']//2] = 1
+    train_mask2[0:num_nodes['node2']//3] = 1
+    test_mask2 = np.zeros((num_nodes['node2'],), dtype=np.int8)
+    test_mask2[num_nodes['node2']//3:num_nodes['node2']//2] = 1
+
     node_data = {
             'node1': {
                 'feat': np.random.uniform(size=(num_nodes['node1'], 10)),
-                'train_mask': train_mask1
+                'train_mask': train_mask1,
+                'test_mask': test_mask1,
             },
             'node2': {
                 'feat': np.random.uniform(size=(num_nodes['node2'],)),
-                'train_mask': train_mask2
+                'train_mask': train_mask2,
+                'test_mask': test_mask2,
             }
     }
     edge_data = {('node1', 'rel1', 'node2'): {'feat': np.random.uniform(size=(g.number_of_edges('rel1'), 10))}}
@@ -1128,10 +1136,11 @@ def test_partition_graph(num_parts):
         for i in range(num_parts):
             part_dir = os.path.join(tmpdirname, "part" + str(i))
             node_data1 = dgl.data.utils.load_tensors(os.path.join(part_dir, 'node_feat.dgl'))
-            train_mask1 = node_data1['node1/train_mask']
-            train_mask2 = node_data1['node2/train_mask']
-            assert th.sum(train_mask1) > 0
-            assert th.sum(train_mask2) > 0
+            assert th.sum(node_data1['node1/train_mask']) > 0
+            assert th.sum(node_data1['node2/train_mask']) > 0
+            print(th.sum(node_data1['node1/test_mask']), th.sum(node_data1['node2/test_mask']))
+            assert th.sum(node_data1['node1/test_mask']) > 0
+            assert th.sum(node_data1['node2/test_mask']) > 0
 
     # Partition the graph with our own partition_graph.
     dgl.random.seed(0)

--- a/tests/unit-tests/gconstruct/test_construct_graph.py
+++ b/tests/unit-tests/gconstruct/test_construct_graph.py
@@ -1102,7 +1102,6 @@ def test_partition_graph(num_parts):
     g = dgl.heterograph(edges, num_nodes_dict=num_nodes)
     src, dst = g.edges(etype=('node1', 'rel1', 'node2'), order='srcdst')
     assert np.all(dst[src < 50].numpy() < 50)
-    print(np.sum(dst[src > 50].numpy() >= 50), len(dst[src > 50]))
     assert np.all(dst[src >= 50].numpy() >= 50)
 
     train_mask1 = np.zeros((num_nodes['node1'],), dtype=np.int8)
@@ -1138,7 +1137,6 @@ def test_partition_graph(num_parts):
             node_data1 = dgl.data.utils.load_tensors(os.path.join(part_dir, 'node_feat.dgl'))
             assert th.sum(node_data1['node1/train_mask']) > 0
             assert th.sum(node_data1['node2/train_mask']) > 0
-            print(th.sum(node_data1['node1/test_mask']), th.sum(node_data1['node2/test_mask']))
             assert th.sum(node_data1['node1/test_mask']) > 0
             assert th.sum(node_data1['node2/test_mask']) > 0
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Add a mechanism to balance training/val/test sets in each graph partition. This is important for distributed training.

https://github.com/awslabs/graphstorm/issues/715

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
