### PR TITLE
[Enhancement] Add default values for sparse_optimizer_lr and weight_decay

### DIFF
--- a/docs/source/configuration/configuration-run.rst
+++ b/docs/source/configuration/configuration-run.rst
@@ -185,7 +185,7 @@ GraphStorm provides a set of parameters to control training hyper-parameters.
 
     - Yaml: ``sparse_optimizer_lr: 0.5``
     - Argument: ``--sparse-optimizer-lr 0.5``
-    - Default value: ``0.01``.
+    - Default value: same as ``lr``.
 - **use_node_embeddings**: Set true to use extra learnable node embedding for each node.
 
     - Yaml: ``use_node_embeddings: true``

--- a/docs/source/configuration/configuration-run.rst
+++ b/docs/source/configuration/configuration-run.rst
@@ -185,7 +185,7 @@ GraphStorm provides a set of parameters to control training hyper-parameters.
 
     - Yaml: ``sparse_optimizer_lr: 0.5``
     - Argument: ``--sparse-optimizer-lr 0.5``
-    - Default value: Same as lr.
+    - Default value: ``0.01``.
 - **use_node_embeddings**: Set true to use extra learnable node embedding for each node.
 
     - Yaml: ``use_node_embeddings: true``

--- a/python/graphstorm/config/argument.py
+++ b/python/graphstorm/config/argument.py
@@ -1175,7 +1175,7 @@ class GSConfig:
                 "Sparse optimizer learning rate must be larger than 0"
             return sparse_optimizer_lr
 
-        return self.lr
+        return 0.01
 
     @property
     def use_node_embeddings(self):

--- a/python/graphstorm/config/argument.py
+++ b/python/graphstorm/config/argument.py
@@ -1175,7 +1175,7 @@ class GSConfig:
                 "Sparse optimizer learning rate must be larger than 0"
             return sparse_optimizer_lr
 
-        return 0.01
+        return self.lr
 
     @property
     def use_node_embeddings(self):

--- a/python/graphstorm/model/gnn.py
+++ b/python/graphstorm/model/gnn.py
@@ -711,7 +711,7 @@ class GSgnnModel(GSgnnModelBase):    # pylint: disable=abstract-method
         # restore sparse embeddings for node_input_encoder.
         load_sparse_embeds(restore_model_path, self.node_input_encoder)
 
-    def init_optimizer(self, lr, sparse_optimizer_lr=0.01, weight_decay=0, lm_lr=None):
+    def init_optimizer(self, lr, sparse_optimizer_lr=None, weight_decay=0, lm_lr=None):
         """initialize the model's optimizers
 
         Parameters
@@ -720,7 +720,7 @@ class GSgnnModel(GSgnnModelBase):    # pylint: disable=abstract-method
             The learning rate for dense parameters
             The learning rate for general dense parameters
         sparse_optimizer_lr : float
-            The learning rate for sparse parameters. Default is 0.01.
+            The learning rate for sparse parameters. Default is None and will use the lr value.
         weight_decay : float
             The weight decay for the optimizer. Default is 0.0.
         lm_lr: float
@@ -728,6 +728,9 @@ class GSgnnModel(GSgnnModelBase):    # pylint: disable=abstract-method
             langauge model dense parameters.
         """
         sparse_params = self.get_sparse_params()
+        # check and set the sparse optimizer learning rate
+        if sparse_optimizer_lr is None:
+            sparse_optimizer_lr = lr
         if len(sparse_params) > 0:
             emb_optimizer = dgl.distributed.optim.SparseAdam(sparse_params, lr=sparse_optimizer_lr)
             sparse_opts = [emb_optimizer]

--- a/python/graphstorm/model/gnn.py
+++ b/python/graphstorm/model/gnn.py
@@ -711,7 +711,7 @@ class GSgnnModel(GSgnnModelBase):    # pylint: disable=abstract-method
         # restore sparse embeddings for node_input_encoder.
         load_sparse_embeds(restore_model_path, self.node_input_encoder)
 
-    def init_optimizer(self, lr, sparse_optimizer_lr, weight_decay, lm_lr=None):
+    def init_optimizer(self, lr, sparse_optimizer_lr=0.01, weight_decay=0, lm_lr=None):
         """initialize the model's optimizers
 
         Parameters
@@ -720,9 +720,9 @@ class GSgnnModel(GSgnnModelBase):    # pylint: disable=abstract-method
             The learning rate for dense parameters
             The learning rate for general dense parameters
         sparse_optimizer_lr : float
-            The learning rate for sparse parameters
+            The learning rate for sparse parameters. Default is 0.01.
         weight_decay : float
-            The weight decay for the optimizer.
+            The weight decay for the optimizer. Default is 0.0.
         lm_lr: float
             Language model fine-tuning learning rate for
             langauge model dense parameters.

--- a/python/graphstorm/model/node_glem.py
+++ b/python/graphstorm/model/node_glem.py
@@ -156,10 +156,13 @@ class GLEM(GSgnnNodeModelBase):
         # GLEM is being trained: use gnn route if not training lm
         return not self.training_lm
 
-    def init_optimizer(self, lr, sparse_optimizer_lr=0.01, weight_decay=0, lm_lr=None):
+    def init_optimizer(self, lr, sparse_optimizer_lr=None, weight_decay=0, lm_lr=None):
         """Initialize optimzer, which will be stored in self.lm._optimizer, self.gnn._optimizer
         """
         sparse_params = self.lm.get_sparse_params()
+        # check and set the sparse optimizer learning rate
+        if sparse_optimizer_lr is None:
+            sparse_optimizer_lr = lr
         if len(sparse_params) > 0:
             emb_optimizer = dgl.distributed.optim.SparseAdam(sparse_params, lr=sparse_optimizer_lr)
             sparse_opts = [emb_optimizer]

--- a/python/graphstorm/model/node_glem.py
+++ b/python/graphstorm/model/node_glem.py
@@ -156,7 +156,7 @@ class GLEM(GSgnnNodeModelBase):
         # GLEM is being trained: use gnn route if not training lm
         return not self.training_lm
 
-    def init_optimizer(self, lr, sparse_optimizer_lr, weight_decay, lm_lr=None):
+    def init_optimizer(self, lr, sparse_optimizer_lr=0.01, weight_decay=0, lm_lr=None):
         """Initialize optimzer, which will be stored in self.lm._optimizer, self.gnn._optimizer
         """
         sparse_params = self.lm.get_sparse_params()


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This PR set default values for the sparse_optimizer_lr and weight_decay in Models' `init_optimizer()`. 

Reasons of this PR:
1. Most of users did not modify the two arguments values, rather than use values preset in our yaml files.
2. Set the two arguments will make API calls complex.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
