### PR TITLE
Accept the original input yaml file for homogeneous graph

### DIFF
--- a/python/graphstorm/config/argument.py
+++ b/python/graphstorm/config/argument.py
@@ -402,6 +402,15 @@ class GSConfig:
                 self._turn_off_gradient_checkpoint("GLEM model")
         # TODO(xiangsx): Add more check
 
+    def handle_homogeneous_config(self, ntypes, etypes):
+        if ntypes != [DEFAULT_NTYPE] or etypes != [DEFAULT_ETYPE[1]]:
+            return
+        if self.task_type in [BUILTIN_TASK_NODE_CLASSIFICATION, BUILTIN_TASK_NODE_REGRESSION]:
+            self.target_ntype = input_type
+            self.eval_target_ntype = input_type
+        if self.task_type in [BUILTIN_TASK_EDGE_CLASSIFICATION, BUILTIN_TASK_EDGE_REGRESSION]:
+            self.target_etype = [','.join(DEFAULT_ETYPE)]
+
     ###################### Environment Info ######################
     @property
     def save_perf_results_path(self):
@@ -1581,6 +1590,10 @@ class GSConfig:
                             "will treat the input graph as a homogeneous graph")
             return DEFAULT_NTYPE
 
+    @target_ntype.setter
+    def target_ntype(self, ntype):
+        self._target_ntype = ntype
+
     @property
     def eval_target_ntype(self):
         """ The node type for evaluation prediction
@@ -1599,6 +1612,10 @@ class GSConfig:
                 return self.target_ntype[0]
             else:
                 return None
+
+    @eval_target_ntype.setter
+    def eval_target_ntype(self, ntype):
+        self._eval_target_ntype = ntype
 
     #### edge related task variables ####
     @property
@@ -1668,6 +1685,10 @@ class GSConfig:
                 "dev team to support multi-task.", str(self._target_etype[0]))
 
         return [tuple(target_etype.split(',')) for target_etype in self._target_etype]
+
+    @target_etype.setter
+    def target_etype(self, etype):
+        self._target_etype = etype
 
     @property
     def remove_target_edge_type(self):

--- a/python/graphstorm/config/argument.py
+++ b/python/graphstorm/config/argument.py
@@ -408,8 +408,8 @@ class GSConfig:
         if ntypes != [DEFAULT_NTYPE] or etypes != [DEFAULT_ETYPE[1]]:
             return
         if self.task_type in [BUILTIN_TASK_NODE_CLASSIFICATION, BUILTIN_TASK_NODE_REGRESSION]:
-            self.target_ntype = input_type
-            self.eval_target_ntype = input_type
+            self.target_ntype = DEFAULT_NTYPE
+            self.eval_target_ntype = DEFAULT_NTYPE
         if self.task_type in [BUILTIN_TASK_EDGE_CLASSIFICATION, BUILTIN_TASK_EDGE_REGRESSION]:
             self.target_etype = [','.join(DEFAULT_ETYPE)]
 

--- a/python/graphstorm/config/argument.py
+++ b/python/graphstorm/config/argument.py
@@ -403,6 +403,8 @@ class GSConfig:
         # TODO(xiangsx): Add more check
 
     def handle_homogeneous_config(self, ntypes, etypes):
+        """Resolve target type conflict for homogeneous graph
+        """
         if ntypes != [DEFAULT_NTYPE] or etypes != [DEFAULT_ETYPE[1]]:
             return
         if self.task_type in [BUILTIN_TASK_NODE_CLASSIFICATION, BUILTIN_TASK_NODE_REGRESSION]:
@@ -1592,6 +1594,8 @@ class GSConfig:
 
     @target_ntype.setter
     def target_ntype(self, ntype):
+        """ Setter for node type for prediction
+        """
         self._target_ntype = ntype
 
     @property
@@ -1615,6 +1619,8 @@ class GSConfig:
 
     @eval_target_ntype.setter
     def eval_target_ntype(self, ntype):
+        """ Setter for node type for evaluation prediction
+        """
         self._eval_target_ntype = ntype
 
     #### edge related task variables ####
@@ -1688,6 +1694,8 @@ class GSConfig:
 
     @target_etype.setter
     def target_etype(self, etype):
+        """ Setter for the target etype
+        """
         self._target_etype = etype
 
     @property

--- a/python/graphstorm/dataloading/dataset.py
+++ b/python/graphstorm/dataloading/dataset.py
@@ -550,9 +550,12 @@ class GSgnnEdgeTrainData(GSgnnEdgeData):
         test_idxs = {}
         num_train = num_val = num_test = 0
         pb = g.get_partition_book()
-        if self.train_etypes is None:
+        if g.ntypes == [DEFAULT_NTYPE] and g.etypes == [DEFAULT_ETYPE[1]]:
+            self._train_etypes = [DEFAULT_ETYPE]
+            self._eval_etypes = [DEFAULT_ETYPE]
+        if self._train_etypes is None:
             self._train_etypes = g.canonical_etypes
-        for canonical_etype in self.train_etypes:
+        for canonical_etype in self._train_etypes:
             if 'train_mask' in g.edges[canonical_etype].data:
                 train_idx = dgl.distributed.edge_split(
                     g.edges[canonical_etype].data['train_mask'],
@@ -732,6 +735,8 @@ class GSgnnEdgeInferData(GSgnnEdgeData):
         test_idxs = {}
         infer_idxs = {}
         # If eval_etypes is None, we use all edge types.
+        if g.ntypes == [DEFAULT_NTYPE] and g.etypes == [DEFAULT_ETYPE[1]]:
+            self._eval_etypes = [DEFAULT_ETYPE]
         if self.eval_etypes is None:
             self._eval_etypes = g.canonical_etypes
         for canonical_etype in self.eval_etypes:
@@ -932,6 +937,9 @@ class GSgnnNodeTrainData(GSgnnNodeData):
         val_idxs = {}
         test_idxs = {}
         num_train = num_val = num_test = 0
+        if g.ntypes == [DEFAULT_NTYPE] and g.etypes == [DEFAULT_ETYPE[1]]:
+            self._train_ntypes = [DEFAULT_NTYPE]
+            self._eval_ntypes = [DEFAULT_NTYPE]
         for ntype in self.train_ntypes:
             assert 'train_mask' in g.nodes[ntype].data, \
                     f"For training dataset, train_mask must be provided on nodes of {ntype}."
@@ -1089,6 +1097,8 @@ class GSgnnNodeInferData(GSgnnNodeData):
         pb = g.get_partition_book()
         test_idxs = {}
         infer_idxs = {}
+        if g.ntypes == [DEFAULT_NTYPE] and g.etypes == [DEFAULT_ETYPE[1]]:
+            self._eval_ntypes = [DEFAULT_NTYPE]
         for ntype in self.eval_ntypes:
             node_trainer_ids = g.nodes[ntype].data['trainer_id'] \
                 if 'trainer_id' in g.nodes[ntype].data else None

--- a/python/graphstorm/gsf.py
+++ b/python/graphstorm/gsf.py
@@ -437,7 +437,6 @@ def create_builtin_lp_model(g, config, train_task):
     """
     model = GSgnnLinkPredictionModel(config.alpha_l2norm,
                                      config.lp_embed_normalizer)
-    config.handle_homogeneous_config(g.ntypes, g.etypes)
     set_encoder(model, g, config, train_task)
     num_train_etype = len(config.train_etype) \
         if config.train_etype is not None \

--- a/python/graphstorm/gsf.py
+++ b/python/graphstorm/gsf.py
@@ -206,6 +206,7 @@ def create_builtin_node_model(g, config, train_task):
         model = GLEM(config.alpha_l2norm, config.target_ntype, **config.training_method["kwargs"])
     elif config.training_method["name"] == "default":
         model = GSgnnNodeModel(config.alpha_l2norm)
+    config.handle_homogeneous_config(g.ntypes, g.etypes)
     set_encoder(model, g, config, train_task)
 
     if config.task_type == BUILTIN_TASK_NODE_CLASSIFICATION:
@@ -282,6 +283,7 @@ def create_builtin_edge_model(g, config, train_task):
     GSgnnModel : The GNN model.
     """
     model = GSgnnEdgeModel(config.alpha_l2norm)
+    config.handle_homogeneous_config(g.ntypes, g.etypes)
     set_encoder(model, g, config, train_task)
     if config.task_type == BUILTIN_TASK_EDGE_CLASSIFICATION:
         num_classes = config.num_classes
@@ -435,6 +437,7 @@ def create_builtin_lp_model(g, config, train_task):
     """
     model = GSgnnLinkPredictionModel(config.alpha_l2norm,
                                      config.lp_embed_normalizer)
+    config.handle_homogeneous_config(g.ntypes, g.etypes)
     set_encoder(model, g, config, train_task)
     num_train_etype = len(config.train_etype) \
         if config.train_etype is not None \

--- a/python/graphstorm/run/gsgnn_ep/gsgnn_ep.py
+++ b/python/graphstorm/run/gsgnn_ep/gsgnn_ep.py
@@ -15,10 +15,8 @@
 
     GSgnn edge prediction.
 """
-import logging
 import os
 
-from dgl.distributed.constants import DEFAULT_NTYPE, DEFAULT_ETYPE
 import graphstorm as gs
 from graphstorm.config import get_argument_parser
 from graphstorm.config import GSConfig

--- a/python/graphstorm/run/gsgnn_ep/gsgnn_ep.py
+++ b/python/graphstorm/run/gsgnn_ep/gsgnn_ep.py
@@ -15,6 +15,7 @@
 
     GSgnn edge prediction.
 """
+
 import os
 
 import graphstorm as gs

--- a/python/graphstorm/run/gsgnn_ep/gsgnn_ep.py
+++ b/python/graphstorm/run/gsgnn_ep/gsgnn_ep.py
@@ -15,9 +15,10 @@
 
     GSgnn edge prediction.
 """
-
+import logging
 import os
 
+from dgl.distributed.constants import DEFAULT_NTYPE, DEFAULT_ETYPE
 import graphstorm as gs
 from graphstorm.config import get_argument_parser
 from graphstorm.config import GSConfig

--- a/tests/end2end-tests/data_process/homogeneous_test.sh
+++ b/tests/end2end-tests/data_process/homogeneous_test.sh
@@ -67,3 +67,22 @@ error_and_exit $?
 
 rm -rf /tmp/homogeneous_node_model
 rm -rf /tmp/homogeneous_edge_model
+
+echo "********* Test Node Classification with original yaml file********"
+python3 -m graphstorm.run.gs_node_classification --workspace $GS_HOME/training_scripts/gsgnn_np/ --num-trainers $NUM_TRAINERS --num-servers 1 --num-samplers 0 --part-config /tmp/movielen_100k_train_val_1p_4t_homogeneous_rev/movie-lens-100k.json --ip-config ip_list.txt --ssh-port 2222 --cf ml_nc.yaml --save-model-path /tmp/homogeneous_node_model
+error_and_exit $?
+
+echo "********* Test Node Classification with original yaml file********"
+python3 -m graphstorm.run.gs_node_classification --inference --workspace $GS_HOME/training_scripts/gsgnn_np/ --num-trainers $NUM_TRAINERS --num-servers 1 --num-samplers 0 --part-config /tmp/movielen_100k_train_val_1p_4t_homogeneous_rev/movie-lens-100k.json --ip-config ip_list.txt --ssh-port 2222 --cf ml_nc.yaml --restore-model-path /tmp/homogeneous_node_model/epoch-2
+error_and_exit $?
+
+echo "********* Test Edge Classification with original yaml file********"
+python3 -m graphstorm.run.gs_edge_classification --workspace $GS_HOME/training_scripts/gsgnn_ep/ --num-trainers $NUM_TRAINERS --num-servers 1 --num-samplers 0 --part-config /tmp/movielen_100k_train_val_1p_4t_homogeneous_rev/movie-lens-100k.json --ip-config ip_list.txt --ssh-port 2222 --cf ml_ec.yaml --save-model-path /tmp/homogeneous_edge_model
+error_and_exit $?
+
+echo "********* Test Edge Classification with original yaml file********"
+python3 -m graphstorm.run.gs_edge_classification --inference --workspace $GS_HOME/training_scripts/gsgnn_ep/ --num-trainers $NUM_TRAINERS --num-servers 1 --num-samplers 0 --part-config /tmp/movielen_100k_train_val_1p_4t_homogeneous_rev/movie-lens-100k.json --ip-config ip_list.txt --ssh-port 2222 --cf ml_ec.yaml --restore-model-path /tmp/homogeneous_edge_model/epoch-2
+error_and_exit $?
+
+rm -rf /tmp/homogeneous_node_model
+rm -rf /tmp/homogeneous_edge_model


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

For the code change here, it will allow user to launch training/inference job on graphstorm on gconstruct homogeneous graph even if they provide wrong node/edge type, so that user can use their previous training/inference config to launch the training/inference.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
