### PR TITLE
[GSProcessing] Allow re-partitioning to run on the Spark leader

### DIFF
--- a/docs/source/gs-processing/gs-processing-getting-started.rst
+++ b/docs/source/gs-processing/gs-processing-getting-started.rst
@@ -112,11 +112,14 @@ cluster.
 
 To use the library to process your data, you will need to have your data
 in a tabular format, and a corresponding JSON configuration file that describes the
-data. The input data can be in CSV (with header(s)) or Parquet format.
+data. **The input data need to be in CSV (with header(s)) or Parquet format.**
 
 The configuration file can be in GraphStorm's GConstruct format,
 **with the caveat that the file paths need to be relative to the
-location of the config file.** See :ref:`gsp-relative-paths` for more details.
+location of the config file.** Also note that you'll need to convert
+all your input data to CSV or Parquet files.
+
+See :ref:`gsp-relative-paths` for more details.
 
 After installing the library, executing a processing job locally can be done using:
 
@@ -125,20 +128,9 @@ After installing the library, executing a processing job locally can be done usi
     gs-processing \
         --config-filename gconstruct-config.json \
         --input-prefix /path/to/input/data \
-        --output-prefix /path/to/output/data
+        --output-prefix /path/to/output/data \
+        --repartition-on-leader True
 
-Once the processing engine has processed the data, we want to ensure
-they match the requirements of the DGL distributed partitioning
-pipeline, so we need to run an additional script that will
-make sure the produced data matches the assumptions of DGL [#f1]_.
-
-.. note::
-
-    Ensure you pass the output path of the previous step as the input path here.
-
-.. code-block:: bash
-
-    gs-repartition --input-prefix /path/to/output/data
 
 Once this script completes, the data are ready to be fed into DGL's distributed
 partitioning pipeline.

--- a/docs/source/gs-processing/gs-processing-getting-started.rst
+++ b/docs/source/gs-processing/gs-processing-getting-started.rst
@@ -129,7 +129,7 @@ After installing the library, executing a processing job locally can be done usi
         --config-filename gconstruct-config.json \
         --input-prefix /path/to/input/data \
         --output-prefix /path/to/output/data \
-        --repartition-on-leader True
+        --do-repartition True
 
 
 Once this script completes, the data are ready to be fed into DGL's distributed

--- a/docs/source/gs-processing/usage/amazon-sagemaker.rst
+++ b/docs/source/gs-processing/usage/amazon-sagemaker.rst
@@ -70,7 +70,9 @@ Launch the gs-repartition job on Amazon SageMaker
 
 
 In the above we have set `--do-repartition True` to perform the re-partition step on the Spark
-leader instance. The re-partitioning job runs on a single instance, so for large graphs you will
+leader instance, since we know each individual feature and the edge structure are small
+enough to fit in the memory of the Spark leader.
+For large graphs you will
 want to launch that step as a separate job on an instance with more memory to avoid memory errors.
 `ml.r5` instances should allow you to re-partition graph data with billions of nodes and edges.
 For more details on the re-partitioning step see :doc:`row-count-alignment`.
@@ -79,7 +81,7 @@ To run the re-partition job as a separate job use:
 
 .. code-block:: bash
 
-    # Ensure the bash variables are as set as above
+    # Ensure the bash variables are as set as above.
     # This will only run the follow-up re-partitioning job on a single instance
     python scripts/run_repartitioning.py --s3-input-prefix ${OUTPUT_PREFIX} \
         --role ${ROLE} --image ${IMAGE_URI}  --config-filename "metadata.json" \

--- a/docs/source/gs-processing/usage/amazon-sagemaker.rst
+++ b/docs/source/gs-processing/usage/amazon-sagemaker.rst
@@ -62,20 +62,31 @@ job, followed by the re-partitioning job, both on SageMaker:
         --instance-type ${INSTANCE_TYPE} \
         --job-name "${GRAPH_NAME}-${INSTANCE_COUNT}x-${INSTANCE_TYPE//./-}-${NUM_FILES}files" \
         --num-output-files ${NUM_FILES} \
+        --do-repartition True \
         --wait-for-job
 
-    # This will run the follow-up re-partitioning job
+Launch the gs-repartition job on Amazon SageMaker
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+
+In the above we have set `--do-repartition True` to perform the re-partition step on the Spark
+leader instance. The re-partitioning job runs on a single instance, so for large graphs you will
+want to launch that step as a separate job on an instance with more memory to avoid memory errors.
+`ml.r5` instances should allow you to re-partition graph data with billions of nodes and edges.
+For more details on the re-partitioning step see :doc:`row-count-alignment`.
+
+To run the re-partition job as a separate job use:
+
+.. code-block:: bash
+
+    # Ensure the bash variables are as set as above
+    # This will only run the follow-up re-partitioning job on a single instance
     python scripts/run_repartitioning.py --s3-input-prefix ${OUTPUT_PREFIX} \
         --role ${ROLE} --image ${IMAGE_URI}  --config-filename "metadata.json" \
         --instance-type ${INSTANCE_TYPE} --wait-for-job
 
 
-.. note::
 
-    The re-partitioning job runs on a single instance, so for large graphs you will
-    want to scale up to an instance with more memory to avoid memory errors. `ml.r5` instances
-    should allow you to re-partition graph data with billions of nodes and edges.
-    For more details on the re-partitioning step see ::doc:`row-count-alignment`.
 
 The ``--num-output-files`` parameter
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/docs/source/gs-processing/usage/amazon-sagemaker.rst
+++ b/docs/source/gs-processing/usage/amazon-sagemaker.rst
@@ -86,8 +86,6 @@ To run the re-partition job as a separate job use:
         --instance-type ${INSTANCE_TYPE} --wait-for-job
 
 
-
-
 The ``--num-output-files`` parameter
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/docs/source/gs-processing/usage/emr-serverless.rst
+++ b/docs/source/gs-processing/usage/emr-serverless.rst
@@ -180,6 +180,7 @@ as described in :ref:`gsp-upload-data-ref`.
     GRAPH_NAME="small-graph"
     CONFIG_FILE="gconstruct-config.json"
     NUM_FILES="-1"
+    DO_REPARTITION="true"
     GSP_HOME="enter/path/to/graphstorm/graphstorm-processing/"
 
     LOCAL_ENTRY_POINT=$GSP_HOME/graphstorm_processing/distributed_executor.py
@@ -200,6 +201,7 @@ as described in :ref:`gsp-upload-data-ref`.
         --arg cfg "$CONFIG_FILE" \
         --arg nfiles "$NUM_FILES" \
         --arg gname "$GRAPH_NAME" \
+        --arg repart "$DO_REPARTITION" \
         '{
             sparkSubmit: {
                 entryPoint: $entry,
@@ -208,7 +210,8 @@ as described in :ref:`gsp-upload-data-ref`.
                     "--output-prefix", $out,
                     "--config-file", $cfg,
                     "--num-output-files", $nfiles,
-                    "--graph-name", $gname]
+                    "--graph-name", $gname,
+                    "--do-repartition", $repart]
             }
         }' )
 
@@ -222,7 +225,12 @@ as described in :ref:`gsp-upload-data-ref`.
         --execution-role-arn $ROLE \
         --job-driver "${ARGS_JSON}" # Need to surround ARGS_JSON with quotes here to maintain JSON formatting
 
-Similar to the SageMaker example, we need to run a follow-up job to align the output with the
+Running the re-partition job
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Similar to the SageMaker example, we set the ``do-repartition`` value to ``True``,  to try to re-partition our
+data on the Spark leader. If the data are too large to re-partition on the Spark leader,
+we need to run a follow-up job to align the output with the
 expectations of the DistDGL partitioning pipeline. The easiest is to run the job locally
 on an instance with S3 access (where we installed GSProcessing):
 
@@ -258,7 +266,7 @@ For more details on the re-partitioning step see
 Examine the output
 ------------------
 
-Once both jobs are finished we can examine the output created, which
+Once both the jobs are finished we can examine the output created, which
 should match the output we saw when running the same jobs locally
 in :ref:`gsp-examining-output`.
 

--- a/docs/source/gs-processing/usage/example.rst
+++ b/docs/source/gs-processing/usage/example.rst
@@ -110,7 +110,7 @@ Given the above we can run a job with local input data as:
 .. code-block:: bash
 
     > gs-processing --input-data /home/path/to/data \
-        --config-filename gconstruct-config.json --repartition-on-leader True
+        --config-filename gconstruct-config.json --do-repartition True
 
 The benefit with using relative paths is that we can move the same files
 to any location, including S3, and run the same job without making changes to the config
@@ -176,7 +176,7 @@ we can use the following command to run the processing job locally:
     gs-processing --config-filename gconstruct-config.json \
         --input-prefix ./tests/resources/small_heterogeneous_graph \
         --output-prefix /tmp/gsprocessing-example/ \
-        --repartition-on-leader True
+        --do-repartition True
 
 About re-partitioning
 ~~~~~~~~~~~~~~~~~~~~~
@@ -187,7 +187,7 @@ guarantees the data conform to the expectations of DGL, after the
 Spark job is done.
 
 We have the option to run this additional step on the Spark leader
-as shown above by setting `--repartition-on-leader` to `"True"`.
+as shown above by setting `--do-repartition` to `"True"`.
 If our data are too large for the memory of our Spark leader
 we can run the step as a separate job:
 
@@ -196,7 +196,7 @@ we can run the step as a separate job:
     gs-repartition --input-prefix /tmp/gsprocessing-example/
 
 For more details on the re-partitioning step see
-::doc:`row-count-alignment`.
+:doc:`row-count-alignment`.
 
 .. _gsp-examining-output:
 

--- a/docs/source/gs-processing/usage/example.rst
+++ b/docs/source/gs-processing/usage/example.rst
@@ -110,7 +110,7 @@ Given the above we can run a job with local input data as:
 .. code-block:: bash
 
     > gs-processing --input-data /home/path/to/data \
-        --config-filename gconstruct-config.json
+        --config-filename gconstruct-config.json --repartition-on-leader True
 
 The benefit with using relative paths is that we can move the same files
 to any location, including S3, and run the same job without making changes to the config
@@ -175,12 +175,21 @@ we can use the following command to run the processing job locally:
 
     gs-processing --config-filename gconstruct-config.json \
         --input-prefix ./tests/resources/small_heterogeneous_graph \
-        --output-prefix /tmp/gsprocessing-example/
+        --output-prefix /tmp/gsprocessing-example/ \
+        --repartition-on-leader True
 
+About re-partitioning
+~~~~~~~~~~~~~~~~~~~~~
 
 To finalize processing and to wrangle the data into the structure that
 DGL distributed partitioning expects, we need an additional step that
-guarantees the data conform to the expectations of DGL:
+guarantees the data conform to the expectations of DGL, after the
+Spark job is done.
+
+We have the option to run this additional step on the Spark leader
+as shown above by setting `--repartition-on-leader` to `"True"`
+or if our data are too large for the memory of our Spark leader
+we can run as a separate job:
 
 .. code-block:: bash
 

--- a/docs/source/gs-processing/usage/example.rst
+++ b/docs/source/gs-processing/usage/example.rst
@@ -188,8 +188,8 @@ Spark job is done.
 
 We have the option to run this additional step on the Spark leader
 as shown above by setting `--repartition-on-leader` to `"True"`
-or if our data are too large for the memory of our Spark leader
-we can run as a separate job:
+If our data are too large for the memory of our Spark leader
+we can run the step as a separate job:
 
 .. code-block:: bash
 

--- a/docs/source/gs-processing/usage/example.rst
+++ b/docs/source/gs-processing/usage/example.rst
@@ -187,7 +187,7 @@ guarantees the data conform to the expectations of DGL, after the
 Spark job is done.
 
 We have the option to run this additional step on the Spark leader
-as shown above by setting `--repartition-on-leader` to `"True"`
+as shown above by setting `--repartition-on-leader` to `"True"`.
 If our data are too large for the memory of our Spark leader
 we can run the step as a separate job:
 

--- a/docs/source/gs-processing/usage/row-count-alignment.rst
+++ b/docs/source/gs-processing/usage/row-count-alignment.rst
@@ -67,7 +67,7 @@ Local repartitioning
 --------------------
 
 The simplest way to apply the re-partitioning step is to do so during the `gs-processing` step,
-by passing the additional `--repartition-on-leader True` argument to our launch script.
+by passing the additional `--do-repartition True` argument to our launch script.
 
 Alternatively, we can run a local re-partitioning job using a local
 installation of GSProcessing:

--- a/docs/source/gs-processing/usage/row-count-alignment.rst
+++ b/docs/source/gs-processing/usage/row-count-alignment.rst
@@ -66,7 +66,10 @@ after the processing step. This step performs two functions:
 Local repartitioning
 --------------------
 
-The simplest way to apply the re-partitioning step is to do so using a local
+The simplest way to apply the re-partitioning step is to do so during the `gs-processing` step,
+by passing the additional `--repartition-on-leader True` argument to our launch script.
+
+Alternatively, we can run a local re-partitioning job using a local
 installation of GSProcessing:
 
 .. code-block:: bash
@@ -101,7 +104,7 @@ on SageMaker:
     INSTANCE_TYPE="ml.t3.xlarge"
 
     python scripts/run_repartitioning.py --s3-input-prefix ${PROCESSED_OUTPUT} \
-        --role ${ROLE} --image ${IMAGE_URI}  --config-filename "metadata.json" \
+        --role ${ROLE} --image ${IMAGE_URI} \
         --instance-type ${INSTANCE_TYPE} --wait-for-job
 
 File streaming repartitioning

--- a/graphstorm-processing/docker/push_gsprocessing_image.sh
+++ b/graphstorm-processing/docker/push_gsprocessing_image.sh
@@ -106,19 +106,17 @@ else
     die "--environment parameter needs to be one of 'emr', 'emr-serverless' or 'sagemaker', got ${EXEC_ENV}"
 fi
 
+TAG="${VERSION}-${ARCH}${SUFFIX}"
+LATEST_TAG="latest-${ARCH}${SUFFIX}"
+IMAGE_WITH_ENV="${IMAGE}-${EXEC_ENV}"
 
-# script logic here
 msg "Execution parameters: "
 msg "- ENVIRONMENT: ${EXEC_ENV}"
 msg "- ARCHITECTURE: ${ARCH}"
 msg "- IMAGE: ${IMAGE}"
-msg "- VERSION: ${VERSION}"
+msg "- TAG: ${TAG}"
 msg "- REGION: ${REGION}"
 msg "- ACCOUNT: ${ACCOUNT}"
-
-TAG="${VERSION}-${ARCH}${SUFFIX}"
-LATEST_TAG="latest-${ARCH}${SUFFIX}"
-IMAGE_WITH_ENV="${IMAGE}-${EXEC_ENV}"
 
 
 FULLNAME="${ACCOUNT}.dkr.ecr.${REGION}.amazonaws.com/${IMAGE_WITH_ENV}:${TAG}"

--- a/graphstorm-processing/graphstorm_processing/data_transformations/spark_utils.py
+++ b/graphstorm-processing/graphstorm_processing/data_transformations/spark_utils.py
@@ -21,7 +21,7 @@ from graphstorm_processing import constants
 try:
     from smspark.bootstrapper import Bootstrapper
 except ImportError:
-    # smspark only exists on the Docker image
+    # smspark only exists on the SageMaker Docker image
     class Bootstrapper:  # type:ignore
         # pylint: disable=all
         def load_processing_job_config(self):
@@ -99,7 +99,7 @@ def create_spark_session(sm_execution: bool, filesystem_type: str) -> SparkSessi
     # Avoid timeout errors due to connection pool starving
     # Allow sending large results to driver
     spark_builder = (
-        SparkSession.builder.appName("GraphlyticsGraphPreloading")
+        SparkSession.builder.appName("GSProcessing")
         .config("spark.hadoop.validateOutputSpecs", "false")
         .config("spark.driver.memory", f"{driver_mem_mb}m")
         .config("spark.driver.memoryOverhead", f"{driver_mem_overhead_mb}m")

--- a/graphstorm-processing/graphstorm_processing/data_transformations/spark_utils.py
+++ b/graphstorm-processing/graphstorm_processing/data_transformations/spark_utils.py
@@ -62,7 +62,7 @@ def create_spark_session(sm_execution: bool, filesystem_type: str) -> SparkSessi
         instance_mem_mb = instance_type_info["MemoryInfo"]["SizeInMiB"]
         instance_cores = instance_type_info["VCpuInfo"]["DefaultVCpus"]
         logging.info(
-            "Detected instance type: %s with " f"total memory: %dM and total cores: %d",
+            "Detected instance type: %s with total memory: %d MiB and total cores: %d",
             instance_type,
             instance_mem_mb,
             instance_cores,
@@ -71,7 +71,7 @@ def create_spark_session(sm_execution: bool, filesystem_type: str) -> SparkSessi
         instance_mem_mb = int(psutil.virtual_memory().total / (1024 * 1024))
         instance_cores = psutil.cpu_count(logical=True)
         logging.warning(
-            "Failed to detect instance type config. " "Found total memory: %dM and total cores: %d",
+            "Failed to detect instance type config. Found total memory: %d MiB and total cores: %d",
             instance_mem_mb,
             instance_cores,
         )

--- a/graphstorm-processing/graphstorm_processing/distributed_executor.py
+++ b/graphstorm-processing/graphstorm_processing/distributed_executor.py
@@ -258,7 +258,7 @@ class DistributedExecutor:
                 "All file row counts match, applying Parquet metadata modification on leader..."
             )
             modify_flat_array_metadata(graph_meta_dict, repartitioner)
-            logging.info("Data are now ready to be fed to DistPart pipeline")
+            logging.info("Data are now prepared for processing by the DistPart Partition pipeline.")
         else:
             if self.repartition_on_leader:
                 logging.info("Attempting to repartition graph data on Spark leader...")

--- a/graphstorm-processing/graphstorm_processing/distributed_executor.py
+++ b/graphstorm-processing/graphstorm_processing/distributed_executor.py
@@ -366,7 +366,10 @@ def main():
     """Main entry point for GSProcessing"""
     # Allows us to get typed arguments from the command line
     gsprocessing_args = GSProcessingArguments(**vars(parse_args()))
-    logging.basicConfig(level=gsprocessing_args.log_level)
+    logging.basicConfig(
+        level=gsprocessing_args.log_level,
+        format="%(asctime)s %(levelname)-8s %(message)s",
+    )
 
     # Determine if we're running within a SageMaker container
     is_sagemaker_execution = os.path.exists("/opt/ml/config/processingjobconfig.json")

--- a/graphstorm-processing/graphstorm_processing/distributed_executor.py
+++ b/graphstorm-processing/graphstorm_processing/distributed_executor.py
@@ -271,7 +271,9 @@ class DistributedExecutor:
                     ) as f:
                         json.dump(updated_metadata, f, indent=4)
                         f.flush()
-                    logging.info("Data are now ready to be fed to DistPart pipeline")
+                    logging.info(
+                        "Data are now prepared for processing by the DistPart Partition pipeline."
+                    )
                 except Exception as e:  # pylint: disable=broad-exception-caught
                     logging.error(
                         "Failed to repartition data on Spark leader, "

--- a/graphstorm-processing/graphstorm_processing/repartition_files.py
+++ b/graphstorm-processing/graphstorm_processing/repartition_files.py
@@ -37,9 +37,11 @@ import tempfile
 import time
 import uuid
 from collections import Counter, defaultdict
+from collections.abc import Sequence
+from dataclasses import dataclass
 from itertools import accumulate
 from pathlib import Path
-from typing import Collection, Dict, List, Optional
+from typing import Any, Dict, List, Optional
 
 import boto3
 import pyarrow
@@ -51,6 +53,8 @@ from joblib import Parallel, delayed
 
 from graphstorm_processing.data_transformations import s3_utils
 from graphstorm_processing.graph_loaders.row_count_utils import ParquetRowCounter
+
+NUM_WRITE_THREADS = 16
 
 
 class ParquetRepartitioner:
@@ -90,11 +94,14 @@ class ParquetRepartitioner:
         self.filesystem_type = filesystem_type
         if self.filesystem_type == "s3":
             self.bucket = self.input_prefix.split("/")[1]
-            self.pyarrow_fs = fs.S3FileSystem(region=region)
+            self.pyarrow_fs = fs.S3FileSystem(
+                region=region, retry_strategy=fs.AwsDefaultS3RetryStrategy(max_attempts=10)
+            )
         else:
             self.pyarrow_fs = fs.LocalFileSystem()
         self.verify_outputs = verify_outputs
         self.streaming_repartitioning = streaming_repartitioning
+        self.verbosity = 10 if logging.getLogger().getEffectiveLevel() <= logging.INFO else 0
 
     def read_dataset_from_relative_path(self, relative_path: str) -> ds.Dataset:
         """
@@ -143,7 +150,7 @@ class ParquetRepartitioner:
 
     @staticmethod
     def create_new_relative_path_from_existing(
-        original_relative_path: str, repartitioned_file_index: int, suffix: str = None
+        original_relative_path: str, repartitioned_file_index: int, suffix: Optional[str] = None
     ) -> str:
         """Changes the index of the filename ``part-<index>`` in `original_relative_path`
         to the one given in `repartitioned_file_index`.
@@ -210,9 +217,7 @@ class ParquetRepartitioner:
 
         return new_relative_path
 
-    def repartition_parquet_files(
-        self, data_entry_dict: Dict, desired_counts: Collection[int]
-    ) -> Dict:
+    def repartition_parquet_files(self, data_entry_dict: Dict, desired_counts: list[int]) -> Dict:
         """
         Re-partitions the Parquet files in `data_entry_dict` so that their row count
         matches the one provided in `desired_counts`. We assume that the number of files between the
@@ -255,7 +260,7 @@ class ParquetRepartitioner:
             return self._repartition_parquet_files_in_memory(data_entry_dict, desired_counts)
 
     def _repartition_parquet_files_in_memory(
-        self, data_entry_dict: Dict, desired_counts: Collection[int]
+        self, data_entry_dict: Dict, desired_counts: list[int]
     ) -> Dict:
         """
         In-memory, thread-parallel implementation of Parquet file repartitioning.
@@ -323,7 +328,9 @@ class ParquetRepartitioner:
             self.create_new_relative_path_from_existing(datafile_list[0], idx, uid_for_entry)
             for idx in range(len(desired_counts))
         ]
-        with Parallel(n_jobs=min(16, os.cpu_count()), verbose=10, prefer="threads") as parallel:
+        with Parallel(
+            n_jobs=min(NUM_WRITE_THREADS, os.cpu_count()), verbose=self.verbosity, prefer="threads"
+        ) as parallel:
             parallel(
                 delayed(self.write_parquet_to_relative_path)(
                     relative_path,
@@ -338,7 +345,7 @@ class ParquetRepartitioner:
         return data_entry_dict
 
     def _repartition_parquet_files_streaming(
-        self, data_entry_dict: Dict, desired_counts: Collection[int]
+        self, data_entry_dict: Dict, desired_counts: Sequence[int]
     ) -> Dict:
         """Repartition parquet files using file streaming.
 
@@ -584,18 +591,20 @@ class ParquetRepartitioner:
                     file_relative_path, table.replace_schema_metadata(updated_metadata)
                 )
 
-        # Execute modify_file in parallel, with up to 16 threads.
-        Parallel(n_jobs=16, prefer="threads")(
+        # Execute modify_file in parallel, with up to NUM_WRITE_THREADS threads.
+        Parallel(n_jobs=NUM_WRITE_THREADS, prefer="threads", verbose=self.verbosity)(
             delayed(modify_file)(relative_path) for relative_path in file_list
         )
 
 
-def collect_frequencies_for_data_counts(data_meta: Dict) -> Dict[str, Counter]:
+def collect_frequencies_for_data_counts(
+    data_meta: Dict[str, Dict[str, Dict]]
+) -> Dict[str, Counter]:
     """Gather the frequency of each row count list for each feature type in the provided data dict.
 
     Parameters
     ----------
-    data_meta : Dict
+    data_meta : Dict[str, Dict[str, Dict]]
         A dictionary describing the data sources for multiple edge/node types.
         See example for expected schema.
 
@@ -740,7 +749,7 @@ def parse_args(args):
         "Note that this option is much slower than the in-memory default.",
     )
     parser.add_argument(
-        "--metadata-file-name",
+        "--input-metadata-file-name",
         default="metadata.json",
         type=str,
         required=False,
@@ -764,95 +773,66 @@ def parse_args(args):
     return parser.parse_args(args)
 
 
-def main():
+@dataclass
+class RepartitionConfig:
     """
-    Re-partitions the output of the distributed processing pipeline
-    to ensure all files that belong to the same edge/node type have the same
-    number of rows per corresponding part-file.
+    Repartition configuration object.
 
-    This is done by reading the metadata file and partitioning the files
-    according to the row counts of the features in the metadata file.
+    See graphstorm_processing.repartition_files.RepartitionConfig for details.
 
-    The output is written to the same location as the input, with the
-    updated metadata file.
+    Example:
 
-    Parameters
-    ----------
-    input_prefix : str
-        Prefix path to where the output was generated
-        from the distributed processing pipeline.
-        Can be a local path or S3 prefix (starting with 's3://').
-    streaming_repartitioning: bool
-        When True will use low-memory file-streaming repartitioning.
-        Note that this option is much slower than the in-memory default.
-    metadata_file_name : str
-        Name of the original partitioning pipeline metadata file.
-    updated_metadata_file_name : str
-        Name of the updated (output) partitioning pipeline metadata file.
-    log_level : str
-        Log level.
+    RepartitionConfig(
+        input_prefix="/path/to/input",
+        input_metadata_file_name="metadata.json",
+        updated_metadata_file_name="updated_row_counts_metadata.json",
+        streaming_repartitioning=False,
+        log_level="INFO",
+    )
 
     Notes
     -----
-    This function is meant to be used as a command-line tool.
+        - input_prefix can be a local path (starting with '/') or S3 prefix (starting with 's3://')
+        - input_metadata_file_name is the name of the original partitioning pipeline metadata file
+        - updated_metadata_file_name is the name of the output partitioning pipeline metadata file
+        - streaming_repartitioning is a boolean flag to enable/disable file-streaming repartitioning
+        - log_level is the logging level to use (e.g. "DEBUG", "INFO", "WARNING", "ERROR")
+        - input_prefix is the only required field
     """
-    args = parse_args(sys.argv[1:])
-    logging.basicConfig(level=getattr(logging, args.log_level.upper(), None))
-    if args.input_prefix.startswith("s3://"):
-        filesystem_type = "s3"
-    else:
-        input_prefix = str(Path(args.input_prefix).resolve(strict=True))
-        filesystem_type = "local"
 
-    # Trim trailing '/' from S3 URI
-    if filesystem_type == "s3":
-        input_prefix = s3_utils.s3_path_remove_trailing(args.input_prefix)
+    input_prefix: str
+    input_metadata_file_name: str = "metadata.json"
+    updated_metadata_file_name: str = "updated_row_counts_metadata.json"
+    streaming_repartitioning: bool = False
+    log_level: str = "INFO"
 
-    logging.info(
-        "Re-partitioning files under %s to ensure all files that belong to the same "
-        "edge/node type have the same number of rows per part-file.",
-        input_prefix,
-    )
 
-    t0 = time.time()
+def modify_flat_array_metadata(
+    metadata_dict: dict,
+    repartitioner: ParquetRepartitioner,
+):
+    """Modifies the Parquet metadata for any flat arrays in the data in `metadata_dict`.
 
-    logging.info("Reading metadata from %s/%s", input_prefix, args.metadata_file_name)
+    We need labels and masks to be treated as flat arrays downstream, but
+    DistPartitioning treats all arrays that don't include a `shape` metadata parameter,
+    as 2D arrays. So we modify the Parquet file metadata here. See:
+    https://github.com/dmlc/dgl/blob/9dc361c6b959e0de7af4565bf649670786ff0f36/tools/distpartitioning/array_readwriter/parquet.py#L21-L26
 
-    # Get the metadata file
-    region = None
-    if filesystem_type == "s3":
-        bucket = input_prefix.split("/")[2]
-        s3_key_prefix = input_prefix.split("/", 3)[3]
-        region = s3_utils.get_bucket_region(bucket)
-        s3_client = boto3.client("s3", region_name=region)
-        s3_client.download_file(
-            bucket, f"{s3_key_prefix}/{args.metadata_file_name}", f"/tmp/{args.metadata_file_name}"
-        )
-        metadata_filepath = os.path.join("/tmp/", args.metadata_file_name)
-    else:
-        metadata_filepath = os.path.join(input_prefix, args.metadata_file_name)
+    Parameters
+    ----------
+    metadata_dict : dict
+        A chunked graph metadata dictionary, augmented with the "graph_info" dict
+        that contains "task_type", "etype_label", "etype_label_property",
+        "ntype_label", "ntype_label_property".
+    repartitioner : ParquetRepartitioner
+        The partitioner object that performs the metadata modification.
+    """
+    edge_data_meta: dict = metadata_dict.get("edge_data", {})
+    node_data_meta: dict = metadata_dict.get("node_data", {})
 
-    metadata_filepath = str(Path(metadata_filepath).resolve(strict=True))
-
-    with open(metadata_filepath, "r", encoding="utf-8") as metafile:
-        metadata_dict = json.load(metafile)  # type: Dict[str, Dict]
-
-    edge_structure_meta = metadata_dict["edges"]  # type: Dict[str, Dict[str, Dict]]
-
-    task_type = metadata_dict["graph_info"].get("task_type", "link_prediction")  # type: str
-
-    edge_data_exist = "edge_data" in metadata_dict.keys() and metadata_dict["edge_data"]
-    node_data_exist = "node_data" in metadata_dict.keys() and metadata_dict["node_data"]
-    edge_data_meta: Optional[Dict[str, Dict[str, Dict]]] = None
-    node_data_meta: Optional[Dict[str, Dict[str, Dict]]] = None
-
-    # We first collect the most frequent row counts, to minimize the number of
-    # repartitions we have to perform.
-    if edge_data_exist:
-        edge_data_meta = metadata_dict["edge_data"]
-        # TODO: Frequencies are important, but so is data size,
-        # we would like to avoid downloading large feature files if possible
-        edge_row_counts_frequencies = collect_frequencies_for_data_counts(edge_data_meta)
+    if edge_data_meta:
+        task_type = metadata_dict["graph_info"].get("task_type", "link_prediction")  # type: str
+        print(f"{task_type=}")
         edge_types_with_labels = metadata_dict["graph_info"]["etype_label"]  # type: List[str]
         # If there exist edge types with labels
         if edge_types_with_labels:
@@ -861,195 +841,277 @@ def main():
                 etype_label_property = metadata_dict["graph_info"]["etype_label_property"][
                     0
                 ]  #  type: str
-    if node_data_exist:
-        node_data_meta = metadata_dict["node_data"]
-        node_row_counts_frequencies = collect_frequencies_for_data_counts(node_data_meta)
-        node_types_with_labels = metadata_dict["graph_info"]["ntype_label"]  # type: List[str]
-        if node_types_with_labels:
-            ntype_label_property = metadata_dict["graph_info"]["ntype_label_property"][
-                0
-            ]  #  type: str
-
-    # Re-partition the edge files based on the most frequent row counts for each edge type
-    if edge_data_exist:
-        logging.info("Repartitioning edge files")
-        assert edge_data_meta
-        for type_idx, (type_name, type_data_dict) in enumerate(edge_data_meta.items()):
-            src, relation, dst = type_name.split(":")
-
-            if relation.endswith("-rev"):
-                # Reverse edge types do not have their own data,
-                # and if needed we re-partition their structure while
-                # handling the "regular" edge type.
-                logging.info(
-                    "Skipping repartitioning for reverse edge type %d/%d:, '%s' "
-                    "because it happens during handling regular edge type...",
-                    type_idx + 1,
-                    len(edge_data_meta),
-                    type_name,
-                )
-                continue
-            reverse_edge_type_name = f"{dst}:{relation}-rev:{src}"
-            most_frequent_counts = list(edge_row_counts_frequencies[type_name].most_common(1)[0][0])
-            repartitioner = ParquetRepartitioner(
-                input_prefix,
-                filesystem_type,
-                region,
-                verify_outputs=True,
-                streaming_repartitioning=args.streaming_repartitioning,
-            )
-
-            structure_counts = edge_structure_meta[type_name]["row_counts"]
-
-            # Repartition edge structure files if the row counts don't match the most frequent
-            if structure_counts != most_frequent_counts:
-                logging.info(
-                    "Repartitioning structure files for edge type %d/%d: '%s'",
-                    type_idx + 1,
-                    len(edge_data_meta),
-                    type_name,
-                )
-
-                edge_structure_meta[type_name] = repartitioner.repartition_parquet_files(
-                    edge_structure_meta[type_name], most_frequent_counts
-                )
-            else:
-                logging.info(
-                    "Structure files for edge type %d/%d: '%s' match, skipping repartitioning",
-                    type_idx + 1,
-                    len(edge_data_meta),
-                    type_name,
-                )
-
-            # If the reverse structure counts don't match we'll need to re-partition
-            # them because the feature files are shared between regular and reverse
-            if reverse_edge_type_name in edge_structure_meta:
-                if (
-                    edge_structure_meta[reverse_edge_type_name]["row_counts"]
-                    != most_frequent_counts
-                ):
-                    logging.info(
-                        "Repartitioning structure files for reverse edge type '%s'",
-                        reverse_edge_type_name,
-                    )
-                    edge_structure_meta[reverse_edge_type_name] = (
-                        repartitioner.repartition_parquet_files(
-                            edge_structure_meta[reverse_edge_type_name], most_frequent_counts
-                        )
-                    )
-
-            # Repartition edge feature files if the row counts don't match the most frequent
-            for feature_idx, (feature_name, feature_dict) in enumerate(type_data_dict.items()):
-                if feature_dict["row_counts"] != most_frequent_counts:
-                    logging.info(
-                        "Repartitioning feature files for edge type, '%s', feature %d/%d '%s'",
-                        type_name,
-                        feature_idx + 1,
-                        len(type_data_dict),
-                        feature_name,
-                    )
-                    feature_dict = repartitioner.repartition_parquet_files(
-                        feature_dict, most_frequent_counts
-                    )
-                    if (
-                        reverse_edge_type_name in edge_data_meta
-                        and feature_name in edge_data_meta[reverse_edge_type_name]
-                    ):
-                        logging.info(
-                            "Assigning re-partitioned feature files for '%s' to reverse "
-                            "edge type '%s'",
-                            feature_name,
-                            reverse_edge_type_name,
-                        )
-                        edge_data_meta[reverse_edge_type_name][feature_name] = feature_dict
-                    else:
-                        logging.debug(
-                            "Did not find reverse of edge type '%s', %s in %s",
-                            type_name,
-                            reverse_edge_type_name,
-                            edge_data_meta.keys(),
-                        )
-                else:
-                    logging.info(
-                        "Skipping repartitioning feature files for edge type, '%s',"
-                        " feature %d/%d '%s'",
-                        type_name,
-                        feature_idx + 1,
-                        len(type_data_dict),
-                        feature_name,
-                    )
-
-            # Indicate label and mask 1D arrays should be read in as flat arrays by dispatch_data.py
-            if type_name in edge_types_with_labels:
-                # If the task is not link_prediction, we need to modify the label file's metadata
                 if task_type not in {"link_predict", "link_prediction"}:
                     assert etype_label_property, (
                         "When task is not link prediction, providing an 'etype_label_property' "
                         f"is required. Got task {task_type}, but `metadata_dict['graph_info']"
                         "['etype_label_property']` was empty."
                     )
+
+        for type_idx, (type_name, type_data_dict) in enumerate(edge_data_meta.items()):
+            _, relation, _ = type_name.split(":")
+
+            if relation.endswith("-rev"):
+                # Reverse edge types do not have their own data,
+                # and if needed we re-partition their structure while
+                # handling the "regular" edge type.
+                logging.info(
+                    "Skipping modifying Parquet metadata for reverse edge type %d/%d:, '%s' "
+                    "because it happens during handling regular edge type...",
+                    type_idx + 1,
+                    len(edge_data_meta),
+                    type_name,
+                )
+                continue
+            logging.info(
+                "Modifying parquet metadata for edge type %d/%d:, '%s' ",
+                type_idx + 1,
+                len(edge_data_meta),
+                type_name,
+            )
+            if type_name in edge_types_with_labels:
+                # If the task is not link_prediction, we need to modify the label file's metadata
+                if task_type not in {"link_predict", "link_prediction"}:
+                    assert etype_label_property in type_data_dict, (
+                        "When task is not link prediction, providing an 'etype_label_property' "
+                        f"is required. Got task {task_type}, but {etype_label_property=}"
+                        f"was not in {type_data_dict=}"
+                    )
+                    label_files = type_data_dict[etype_label_property]["data"]  # type: List[str]
                     logging.info(
-                        "Modifying metadata for label '%s' of edge type '%s'",
+                        "Modifying Parquet metadata for %d files of label '%s' of edge type '%s'",
+                        len(label_files),
                         etype_label_property,
                         type_name,
                     )
-                    label_files = type_data_dict[etype_label_property]["data"]  # type: List[str]
-                    # TODO: These ops are probably safe to parallelize, since the tables are likely
-                    # easy to fit in memory (one float/bool per row)
                     repartitioner.modify_metadata_for_flat_arrays(label_files)
                 for mask in ["train_mask", "test_mask", "val_mask"]:
-                    logging.info("Modifying metadata for '%s' of edge type '%s'", mask, type_name)
                     if mask in type_data_dict:
                         mask_files = type_data_dict[mask]["data"]  # type: List[str]
+                        logging.info(
+                            "Modifying Parquet metadata for %d files of '%s' for edge type '%s'",
+                            len(mask_files),
+                            mask,
+                            type_name,
+                        )
                         repartitioner.modify_metadata_for_flat_arrays(mask_files)
 
-    # Re-partition the node feature data files
-    if node_data_exist:
-        logging.info("Repartitioning node feature files")
-        assert node_data_meta
+    if node_data_meta:
+        node_types_with_labels = metadata_dict["graph_info"]["ntype_label"]  # type: List[str]
+        if node_types_with_labels:
+            ntype_label_property = metadata_dict["graph_info"]["ntype_label_property"][
+                0
+            ]  #  type: str
         for type_idx, (type_name, type_data_dict) in enumerate(node_data_meta.items()):
-            most_frequent_counts = list(node_row_counts_frequencies[type_name].most_common(1)[0][0])
-            repartitioner = ParquetRepartitioner(
-                input_prefix,
-                filesystem_type,
-                region,
-                verify_outputs=True,
-                streaming_repartitioning=args.streaming_repartitioning,
+            logging.info(
+                "Modifying Parquet metadata for node type '%s', %d/%d:",
+                type_name,
+                type_idx + 1,
+                len(node_data_meta),
             )
-
-            for feature_idx, (feature_name, feature_dict) in enumerate(type_data_dict.items()):
-                if feature_dict["row_counts"] != most_frequent_counts:
-                    logging.info(
-                        "Repartitioning feature files for node type '%s', feature '%s' (%d/%d)",
-                        type_name,
-                        feature_name,
-                        feature_idx + 1,
-                        len(type_data_dict),
-                    )
-                    repartitioner.repartition_parquet_files(feature_dict, most_frequent_counts)
-                else:
-                    logging.info(
-                        "Skipping repartitioning feature files for node type '%s',"
-                        " feature '%s' (%d/%d)",
-                        type_name,
-                        feature_name,
-                        feature_idx + 1,
-                        len(type_data_dict),
-                    )
-
             if type_name in node_types_with_labels:
+                node_label_files = type_data_dict[ntype_label_property]["data"]  # type: List[str]
                 logging.info(
-                    "Modifying metadata for label '%s' of node type '%s'",
+                    "Modifying Parquet metadata for %d files of label '%s' of node type '%s'",
+                    len(node_label_files),
                     ntype_label_property,
                     type_name,
                 )
-                node_label_files = type_data_dict[ntype_label_property]["data"]  # type: List[str]
                 repartitioner.modify_metadata_for_flat_arrays(node_label_files)
                 for mask in ["train_mask", "test_mask", "val_mask"]:
-                    logging.info("Modifying metadata for '%s' of node type '%s'", mask, type_name)
                     if mask in type_data_dict:
                         node_mask_files = type_data_dict[mask]["data"]  # type: List[str]
+                        logging.info(
+                            "Modifying Parquet metadata for %d files of '%s' for node type '%s'",
+                            len(mask_files),
+                            mask,
+                            type_name,
+                        )
                         repartitioner.modify_metadata_for_flat_arrays(node_mask_files)
+
+
+def _repartition_edge_files(metadata_dict: dict[str, Any], repartitioner: ParquetRepartitioner):
+    edge_structure_meta = metadata_dict["edges"]  # type: Dict[str, Dict[str, Dict]]
+    # We first collect the most frequent row counts, to minimize the number of
+    # repartitions we have to perform.
+    edge_data_meta = metadata_dict["edge_data"]
+    assert edge_data_meta
+    # TODO: Frequencies are important, but so is data size,
+    # we would like to avoid downloading large feature files if possible
+    edge_row_counts_frequencies = collect_frequencies_for_data_counts(edge_data_meta)
+
+    logging.info("Repartitioning edge files")
+
+    # Re-partition the edge files based on the most frequent row counts for each edge type
+    for type_idx, (type_name, type_data_dict) in enumerate(edge_data_meta.items()):
+        src, relation, dst = type_name.split(":")
+
+        if relation.endswith("-rev"):
+            # Reverse edge types do not have their own data,
+            # and if needed we re-partition their structure while
+            # handling the "regular" edge type.
+            logging.info(
+                "Skipping repartitioning for reverse edge type %d/%d:, '%s' "
+                "because it happens during handling regular edge type...",
+                type_idx + 1,
+                len(edge_data_meta),
+                type_name,
+            )
+            continue
+
+        logging.info(
+            "Repartitioning edge type %d/%d:, '%s' ",
+            type_idx + 1,
+            len(edge_data_meta),
+            type_name,
+        )
+        reverse_edge_type_name = f"{dst}:{relation}-rev:{src}"
+        most_frequent_counts = list(edge_row_counts_frequencies[type_name].most_common(1)[0][0])
+
+        structure_counts = edge_structure_meta[type_name]["row_counts"]
+
+        # Repartition edge structure files if the row counts don't match the most frequent
+        if structure_counts != most_frequent_counts:
+            logging.info(
+                "Repartitioning structure files for edge type %d/%d: '%s'",
+                type_idx + 1,
+                len(edge_data_meta),
+                type_name,
+            )
+
+            edge_structure_meta[type_name] = repartitioner.repartition_parquet_files(
+                edge_structure_meta[type_name], most_frequent_counts
+            )
+        else:
+            logging.info(
+                "Structure files for edge type %d/%d: '%s' match, skipping repartitioning",
+                type_idx + 1,
+                len(edge_data_meta),
+                type_name,
+            )
+
+        # If the reverse structure counts don't match we'll need to re-partition
+        # them because the feature files are shared between regular and reverse
+        if reverse_edge_type_name in edge_structure_meta:
+            if edge_structure_meta[reverse_edge_type_name]["row_counts"] != most_frequent_counts:
+                logging.info(
+                    "Repartitioning structure files for reverse edge type '%s'",
+                    reverse_edge_type_name,
+                )
+                edge_structure_meta[reverse_edge_type_name] = (
+                    repartitioner.repartition_parquet_files(
+                        edge_structure_meta[reverse_edge_type_name], most_frequent_counts
+                    )
+                )
+
+        # Repartition edge feature files if the row counts don't match the most frequent
+        for feature_idx, (feature_name, feature_dict) in enumerate(type_data_dict.items()):
+            if feature_dict["row_counts"] != most_frequent_counts:
+                logging.info(
+                    "Repartitioning feature files for edge type, '%s', feature %d/%d '%s'",
+                    type_name,
+                    feature_idx + 1,
+                    len(type_data_dict),
+                    feature_name,
+                )
+                feature_dict = repartitioner.repartition_parquet_files(
+                    feature_dict, most_frequent_counts
+                )
+                if (
+                    reverse_edge_type_name in edge_data_meta
+                    and feature_name in edge_data_meta[reverse_edge_type_name]
+                ):
+                    logging.info(
+                        "Assigning re-partitioned feature files for '%s' to reverse "
+                        "edge type '%s'",
+                        feature_name,
+                        reverse_edge_type_name,
+                    )
+                    edge_data_meta[reverse_edge_type_name][feature_name] = feature_dict
+                else:
+                    logging.debug(
+                        "Did not find reverse of edge type '%s', %s in %s",
+                        type_name,
+                        reverse_edge_type_name,
+                        edge_data_meta.keys(),
+                    )
+            else:
+                logging.info(
+                    "Skipping repartitioning feature files for edge type, '%s',"
+                    " feature %d/%d '%s', they already have the correct row counts.",
+                    type_name,
+                    feature_idx + 1,
+                    len(type_data_dict),
+                    feature_name,
+                )
+
+
+def _repartition_node_files(metadata_dict: dict[str, Any], repartitioner: ParquetRepartitioner):
+    node_data_meta = metadata_dict["node_data"]
+    assert node_data_meta
+    node_row_counts_frequencies = collect_frequencies_for_data_counts(node_data_meta)
+
+    logging.info("Repartitioning node feature files")
+    for type_idx, (type_name, type_data_dict) in enumerate(node_data_meta.items()):
+        logging.info(
+            "Repartitioning feature files for node type '%s', (%d/%d)",
+            type_name,
+            type_idx + 1,
+            len(node_data_meta),
+        )
+        most_frequent_counts = list(node_row_counts_frequencies[type_name].most_common(1)[0][0])
+
+        for feature_idx, (feature_name, feature_dict) in enumerate(type_data_dict.items()):
+            if feature_dict["row_counts"] != most_frequent_counts:
+                logging.info(
+                    "Repartitioning feature files for node type '%s', feature '%s' (%d/%d)",
+                    type_name,
+                    feature_name,
+                    feature_idx + 1,
+                    len(type_data_dict),
+                )
+                repartitioner.repartition_parquet_files(feature_dict, most_frequent_counts)
+            else:
+                logging.info(
+                    "Skipping repartitioning feature files for node type '%s',"
+                    " feature '%s' (%d/%d)",
+                    type_name,
+                    feature_name,
+                    feature_idx + 1,
+                    len(type_data_dict),
+                )
+
+
+def repartition_files(metadata_dict: Dict[str, Any], repartitioner: ParquetRepartitioner):
+    """Applies repartition of node and edge data files and modifies flat array Parquet metadata.
+
+    The `metadata_dict` argument is modified in-place.
+
+    Returns
+    -------
+    dict
+        The provided `metadata_dict`, modified in-place.
+    """
+    edge_data_exist = "edge_data" in metadata_dict.keys() and metadata_dict["edge_data"]
+    node_data_exist = "node_data" in metadata_dict.keys() and metadata_dict["node_data"]
+
+    if not edge_data_exist and not node_data_exist:
+        logging.info("No edge or node data found in metadata, skipping repartitioning")
+        return metadata_dict
+
+    edge_data_meta: Optional[Dict[str, Dict[str, Dict]]] = None
+    node_data_meta: Optional[Dict[str, Dict[str, Dict]]] = None
+
+    if edge_data_exist:
+        _repartition_edge_files(metadata_dict, repartitioner)
+
+    # Re-partition the node feature data files
+    if node_data_exist:
+        _repartition_node_files(metadata_dict, repartitioner)
+
+    # Modify label and mask 1D arrays metadata so they will be read in as flat arrays
+    # by dispatch_data.py
+    modify_flat_array_metadata(metadata_dict, repartitioner)
 
     # Ensure output dict has the correct order of keys
     if edge_data_exist:
@@ -1062,28 +1124,122 @@ def main():
             if node_type in metadata_dict["node_data"].keys():
                 metadata_dict["node_data"][node_type] = metadata_dict["node_data"].pop(node_type)
 
+    edge_structure_meta = metadata_dict["edges"]
+    verify_metadata(edge_structure_meta, edge_data_meta, node_data_meta)
+
+    return metadata_dict
+
+
+def main():
+    """
+    Re-partitions the output of the distributed processing pipeline
+    to ensure all files that belong to the same edge/node type have the same
+    number of rows per corresponding part-file.
+
+    This is done by reading the metadata file and partitioning the files
+    according to the row counts of the features in the metadata file.
+
+    The output is written under the same prefix as the input, with the
+    updated metadata file name.
+
+    Parameters
+    ----------
+    input_prefix : str
+        Prefix path to where the output was generated
+        from the distributed processing pipeline.
+        Can be a local path or S3 prefix (starting with 's3://').
+    streaming_repartitioning: bool
+        When True will use low-memory file-streaming repartitioning.
+        Note that this option is much slower than the in-memory default.
+    input_metadata_file_name : str
+        Name of the original partitioning pipeline metadata file.
+    updated_metadata_file_name : str
+        Name of the updated (output) partitioning pipeline metadata file.
+    log_level : str
+        Log level.
+
+    Notes
+    -----
+    This function is meant to be used as a command-line tool.
+    """
+    repartition_config = RepartitionConfig(**vars(parse_args(sys.argv[1:])))
+    logging.basicConfig(level=getattr(logging, repartition_config.log_level.upper(), None))
+
+    if repartition_config.input_prefix.startswith("s3://"):
+        filesystem_type = "s3"
+    else:
+        input_prefix = str(Path(repartition_config.input_prefix).resolve(strict=True))
+        filesystem_type = "local"
+
+    # Trim trailing '/' from S3 URI
+    if filesystem_type == "s3":
+        input_prefix = s3_utils.s3_path_remove_trailing(repartition_config.input_prefix)
+
+    logging.info(
+        "Re-partitioning files under %s to ensure all files that belong to the same "
+        "edge/node type have the same number of rows per part-file.",
+        input_prefix,
+    )
+
+    t0 = time.time()
+
+    logging.info(
+        "Reading metadata from %s/%s", input_prefix, repartition_config.input_metadata_file_name
+    )
+
+    # Get the metadata file
+    region = None
+    if filesystem_type == "s3":
+        bucket = input_prefix.split("/")[2]
+        s3_key_prefix = input_prefix.split("/", 3)[3]
+        region = s3_utils.get_bucket_region(bucket)
+        s3_client = boto3.client("s3", region_name=region)
+        s3_client.download_file(
+            bucket,
+            f"{s3_key_prefix}/{repartition_config.input_metadata_file_name}",
+            f"/tmp/{repartition_config.input_metadata_file_name}",
+        )
+        metadata_filepath = os.path.join("/tmp/", repartition_config.input_metadata_file_name)
+    else:
+        metadata_filepath = os.path.join(input_prefix, repartition_config.input_metadata_file_name)
+
+    metadata_filepath = str(Path(metadata_filepath).resolve(strict=True))
+
+    with open(metadata_filepath, "r", encoding="utf-8") as metafile:
+        metadata_dict = json.load(metafile)  # type: Dict[str, Dict]
+
+    repartitioner = ParquetRepartitioner(
+        input_prefix,
+        filesystem_type,
+        region,
+        verify_outputs=True,
+        streaming_repartitioning=repartition_config.streaming_repartitioning,
+    )
+
+    metadata_dict = repartition_files(metadata_dict, repartitioner)
+
     with tempfile.NamedTemporaryFile(mode="w") as metafile:
         json.dump(metadata_dict, metafile, indent=4)
         metafile.flush()
-        verify_metadata(edge_structure_meta, edge_data_meta, node_data_meta)
+
         # Upload the updated metadata file to S3
-        if node_data_exist or edge_data_exist:
-            if filesystem_type == "s3":
-                s3_client.upload_file(
-                    metafile.name, bucket, f"{s3_key_prefix}/{args.updated_metadata_file_name}"
-                )
-                logging.info(
-                    "Uploaded updated metadata file to s3://%s/%s/%s",
-                    bucket,
-                    s3_key_prefix,
-                    args.updated_metadata_file_name,
-                )
-            else:
-                shutil.copyfile(
-                    metafile.name, os.path.join(input_prefix, args.updated_metadata_file_name)
-                )
+        if filesystem_type == "s3":
+            s3_client.upload_file(
+                metafile.name,
+                bucket,
+                f"{s3_key_prefix}/{repartition_config.updated_metadata_file_name}",
+            )
+            logging.info(
+                "Uploaded updated metadata file to s3://%s/%s/%s",
+                bucket,
+                s3_key_prefix,
+                repartition_config.updated_metadata_file_name,
+            )
         else:
-            logging.warning("No edge or node feature data to re-partition, exiting.")
+            shutil.copyfile(
+                metafile.name,
+                os.path.join(input_prefix, repartition_config.updated_metadata_file_name),
+            )
 
     t1 = time.time()
     logging.info("File repartitioning time: %s", t1 - t0)

--- a/graphstorm-processing/graphstorm_processing/repartition_files.py
+++ b/graphstorm-processing/graphstorm_processing/repartition_files.py
@@ -830,7 +830,6 @@ def modify_flat_array_metadata(
 
     if edge_data_meta:
         task_type = metadata_dict["graph_info"].get("task_type", "link_prediction")  # type: str
-        print(f"{task_type=}")
         edge_types_with_labels = metadata_dict["graph_info"]["etype_label"]  # type: List[str]
         # If there exist edge types with labels
         if edge_types_with_labels:
@@ -868,6 +867,9 @@ def modify_flat_array_metadata(
                 type_name,
             )
             if type_name in edge_types_with_labels:
+                # TODO: To support multi-task training, we'll have to handle train_mask_a,
+                # train_mask_b, etc. and similarly for multiple label columns.
+
                 # If the task is not link_prediction, we need to modify the label file's metadata
                 if task_type not in {"link_predict", "link_prediction"}:
                     assert etype_label_property in type_data_dict, (

--- a/graphstorm-processing/scripts/run_distributed_processing.py
+++ b/graphstorm-processing/scripts/run_distributed_processing.py
@@ -258,7 +258,7 @@ if __name__ == "__main__":
         str(args.num_output_files),
         "--add-reverse-edges",
         "True" if args.add_reverse_edges else "False",
-        "--repartition-on-leader",
+        "--do-repartition",
         "True" if args.do_repartition else "False",
         "--log-level",
         args.container_log_level,

--- a/graphstorm-processing/scripts/run_distributed_processing.py
+++ b/graphstorm-processing/scripts/run_distributed_processing.py
@@ -107,9 +107,9 @@ def parse_args() -> argparse.Namespace:
         help="When set to True, will create reverse edges for every edge type.",
     )
     parser.add_argument(
-        "--repartition-on-leader",
+        "--do-repartition",
         type=lambda x: (str(x).lower() in ["true", "1"]),
-        default=True,
+        default=False,
         help="When set to True, will re-partition the graph data files on the Spark leader.",
     )
     parser.add_argument(
@@ -259,7 +259,7 @@ if __name__ == "__main__":
         "--add-reverse-edges",
         "True" if args.add_reverse_edges else "False",
         "--repartition-on-leader",
-        "True" if args.repartition_on_leader else "False",
+        "True" if args.do_repartition else "False",
         "--log-level",
         args.container_log_level,
     ]

--- a/graphstorm-processing/scripts/run_distributed_processing.py
+++ b/graphstorm-processing/scripts/run_distributed_processing.py
@@ -45,8 +45,11 @@ Optional:
     Number of EC2 instances to use for the processing job. (Default: 2)
 --instance-type: str
     EC2 instance type for the processing job. (Default: 'ml.r5.4xlarge')
---add-reverse-edges: bool
-    When set to True, will create reverse edges for every edge type. (Default: True)
+--add-reverse-edges: str
+    When set to "True", will create reverse edges for every edge type. (Default: "True")
+--repartition-on-leader: str
+    When set to "True", will repartition the graph files on the leader node if needed.
+    (Default: "True")
 --num-output-files: int
     Number of output files to generate. If not specified, the number of output files
     will be determined by Spark.
@@ -102,6 +105,12 @@ def parse_args() -> argparse.Namespace:
         type=lambda x: (str(x).lower() in ["true", "1"]),
         default=True,
         help="When set to True, will create reverse edges for every edge type.",
+    )
+    parser.add_argument(
+        "--repartition-on-leader",
+        type=lambda x: (str(x).lower() in ["true", "1"]),
+        default=True,
+        help="When set to True, will re-partition the graph data files on the Spark leader.",
     )
     parser.add_argument(
         "--num-output-files",
@@ -249,6 +258,8 @@ if __name__ == "__main__":
         str(args.num_output_files),
         "--add-reverse-edges",
         "True" if args.add_reverse_edges else "False",
+        "--repartition-on-leader",
+        "True" if args.repartition_on_leader else "False",
         "--log-level",
         args.container_log_level,
     ]

--- a/graphstorm-processing/scripts/run_repartitioning.py
+++ b/graphstorm-processing/scripts/run_repartitioning.py
@@ -108,7 +108,7 @@ def main():
         s3_input_prefix,
         "--streaming-repartitioning",
         "True" if args.streaming_repartitioning else "False",
-        "--metadata-file-name",
+        "--input-metadata-file-name",
         args.config_filename,
         "--log-level",
         args.container_log_level,

--- a/graphstorm-processing/tests/resources/repartitioning/partitioned_metadata.json
+++ b/graphstorm-processing/tests/resources/repartitioning/partitioned_metadata.json
@@ -123,9 +123,63 @@
                 }
         }
     },
+    "node_type": [
+        "src",
+        "dst"
+    ],
+    "node_data": {
+        "src": {
+            "label": {
+                "data":[
+                    "node_data/src-label/parquet/part-00000.parquet",
+                    "node_data/src-label/parquet/part-00001.parquet",
+                    "node_data/src-label/parquet/part-00002.parquet",
+                    "node_data/src-label/parquet/part-00003.parquet",
+                    "node_data/src-label/parquet/part-00004.parquet"
+                ],
+                "row_counts": [10, 12, 10, 8, 10],
+                "format": {
+                    "name": "parquet",
+                    "delimiter": ""
+                }
+            },
+            "feature_one": {
+                "data":[
+                    "node_data/src-feature_one/parquet/part-00000.parquet",
+                    "node_data/src-feature_one/parquet/part-00001.parquet",
+                    "node_data/src-feature_one/parquet/part-00002.parquet",
+                    "node_data/src-feature_one/parquet/part-00003.parquet",
+                    "node_data/src-feature_one/parquet/part-00004.parquet"
+                ],
+                "row_counts": [10, 10, 10, 10, 10],
+                "format": {
+                    "name": "parquet",
+                    "delimiter": ""
+                }
+            },
+            "feature_two": {
+                "data":[
+                    "node_data/src-feature_two/parquet/part-00000.parquet",
+                    "node_data/src-feature_two/parquet/part-00001.parquet",
+                    "node_data/src-feature_two/parquet/part-00002.parquet",
+                    "node_data/src-feature_two/parquet/part-00003.parquet",
+                    "node_data/src-feature_two/parquet/part-00004.parquet"
+                ],
+                "row_counts": [10, 10, 10, 10, 10],
+                "format": {
+                    "name": "parquet",
+                    "delimiter": ""
+                }
+            }
+        }
+    },
     "graph_info": {
-        "ntype_label": [],
-        "ntype_label_property": [],
+        "ntype_label": [
+            "src"
+        ],
+        "ntype_label_property": [
+            "label"
+        ],
         "etype_label": [
             "src:dummy_type:dst"
         ],

--- a/graphstorm-processing/tests/test_repartition_files.py
+++ b/graphstorm-processing/tests/test_repartition_files.py
@@ -19,6 +19,7 @@ from pathlib import Path
 import os
 import shutil
 import sys
+from ast import literal_eval
 from typing import Callable, List
 
 from numpy.testing import assert_array_equal
@@ -35,7 +36,7 @@ TEMP_DATA_PREFIX = os.path.join(_ROOT, "resources/repartitioning/generated_parqu
 
 
 def create_feature_table(col_name: str, num_rows: int, feature_start_val: int) -> pa.Table:
-    """Creates a PyArrow table with a sinle column of integer values.
+    """Creates a PyArrow table with a single column of integer values.
 
     For example passing `num_rows` 5 and `feature_start_val` 5 will
     return a table with 5 rows, containing [5, 6, 7, 8, 9] as values
@@ -64,8 +65,8 @@ def create_feature_table(col_name: str, num_rows: int, feature_start_val: int) -
 def create_parquet_files_fixture():
     """This fixture creates all the Parquet files that are needed by the tests in this module.
 
-    We create files for a graph with 1 edge type, 1 edge label, and 2 edge features,
-    with 50 edges.
+    We create files for a graph with 1 edge type, 1 edge label, 2 edge features,
+    with 50 edges. We also include 1 node type with 1 node feature.
 
     Each file source is represented using 5 parquet files, named part-[00000-00004].parquet.
     The files are created such that the most frequent row count between them is
@@ -91,7 +92,7 @@ def create_parquet_files_fixture():
 
     # The edge structure files will have different row count from all data files.
     edges_rows = [8, 8, 8, 8, 18]
-    # For edge data files, the label will have a different row count from the rest
+    # For edge and node data files, the label will have a different row count from the rest
     # and [10, 10, 10, 10, 10] will be the most frequent row count, so all other
     # files will be re-partitioned to match that.
     per_file_rows = [
@@ -118,21 +119,33 @@ def create_parquet_files_fixture():
         for col_name, generated_rows in zip(col_names, per_file_rows):
             edge_data_counts = metadata_dict["edge_data"][meta_etype][col_name]["row_counts"]
             assert edge_data_counts == generated_rows
+    # Do the same for the node files
+    for col_name, generated_rows in zip(col_names, per_file_rows):
+        edge_data_counts = metadata_dict["node_data"]["src"][col_name]["row_counts"]
+        assert edge_data_counts == generated_rows
 
     # Generate data and write edge data files to disk
     for row_distribution, col_name in zip(per_file_rows, col_names):
         total_rows = 0
-        feat_path = os.path.join(
+        edge_feat_path = os.path.join(
             TEMP_DATA_PREFIX,
             "edge_data",
             f"dummy_type-{col_name}",
             "parquet",
         )
-        os.makedirs(feat_path)
+        node_feat_path = os.path.join(
+            TEMP_DATA_PREFIX,
+            "node_data",
+            f"src-{col_name}",
+            "parquet",
+        )
+        os.makedirs(edge_feat_path)
+        os.makedirs(node_feat_path)
         for i, row_count in enumerate(row_distribution):
             feat_part = create_feature_table(col_name, row_count, total_rows)
             filename = f"part-{str(i).zfill(5)}.parquet"
-            pq.write_table(feat_part, os.path.join(feat_path, filename))
+            pq.write_table(feat_part, os.path.join(edge_feat_path, filename))
+            pq.write_table(feat_part, os.path.join(node_feat_path, filename))
             total_rows += row_count
 
     # Generate edge structure files
@@ -333,6 +346,7 @@ def test_collect_frequencies_for_data_counts():
         "edge_class",
         "link_predict",
         "link_prediction",
+        "node_class",
     ],
 )
 def test_repartition_files_integration(monkeypatch, task_type):
@@ -345,7 +359,7 @@ def test_repartition_files_integration(monkeypatch, task_type):
                 "repartition_files.py",
                 "--input-prefix",
                 TEMP_DATA_PREFIX,
-                "--metadata-file-name",
+                "--input-metadata-file-name",
                 "partitioned_metadata.json",
                 "--updated-metadata-file-name",
                 "updated_row_counts_metadata.json",
@@ -396,6 +410,33 @@ def test_repartition_files_integration(monkeypatch, task_type):
                     expected_counts, edge_feature_dict["data"]
                 ):
                     absolute_feature_filepath = os.path.join(TEMP_DATA_PREFIX, feature_filepath)
+                    filemeta = pq.read_metadata(absolute_feature_filepath)
+                    file_rows = filemeta.num_rows
                     assert (
-                        expected_count == pq.read_metadata(absolute_feature_filepath).num_rows
+                        expected_count == file_rows
                     ), f"Count mismatch for {feature_name}, {absolute_feature_filepath}"
+                    # Ensure the flat array has the correct metadata embedded
+                    if feature_name == "label" and task_type not in {
+                        "link_predict",
+                        "link_prediction",
+                    }:
+                        arrow_meta = filemeta.schema.to_arrow_schema().metadata
+                        bshape = arrow_meta.get(b"shape", None)
+                        shape = tuple(literal_eval(bshape.decode()))
+                        assert shape == (file_rows,)
+
+        # Do the same for node data
+        for feature_name, node_feature_dict in new_metadata_dict["node_data"]["src"].items():
+            assert node_feature_dict["row_counts"] == expected_counts
+            for expected_count, feature_filepath in zip(expected_counts, node_feature_dict["data"]):
+                absolute_feature_filepath = os.path.join(TEMP_DATA_PREFIX, feature_filepath)
+                filemeta = pq.read_metadata(absolute_feature_filepath)
+                file_rows = filemeta.num_rows
+                assert (
+                    expected_count == file_rows
+                ), f"Count mismatch for {feature_name}, {absolute_feature_filepath}"
+                if feature_name == "label":
+                    arrow_meta = filemeta.schema.to_arrow_schema().metadata
+                    bshape = arrow_meta.get(b"shape", None)
+                    shape = tuple(literal_eval(bshape.decode()))
+                    assert shape == (file_rows,)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

With this change we allow the re-partition step to run on the leader instance, removing the need to run a separate job for it. If no files need re-partitioning, and only Parquet modification is needed for labels/masks we _always_ apply that on the leader.

To accomplish this we make the following changes:

* Add new `--do-repartition` argument
* Refactor repartition_files.py to allow separate execution of just Parquet metadata modification, and full repartition that runs both the row count alignment and the Parquet metadata modification.
    * As part of this refactoring we also split the previously verbose `main` function into multiple smaller functions to allow easier maintenance. Each step is now performed by a separate function, namely `_repartition_edge_files`, `_repartition_node_files` and `modify_flat_array_metadata`. A combined public function `repartition_files` calls these three functions as needed in sequence. All functions take the graph metadata dict as input, and a ParquetRepartitioner instance.
* Introduce checks for node data and Parquet metadata modification in our unit tests. Test coverage for `repartition_files.py` is now increased to 89% (from 81%).

## Testing

Unit testing, and ran jobs on SageMaker and EMR-S with ml25M. For large-scale random 100M-edges-10M-nodes graph, the repartition step completed successfully on SageMaker (large memory instances) and failed (gracefully) on EMR-S. When the repart step fails we print an error in the logs to indicate to the user they'll need to run the additional gs-repartition job separately.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
