### PR TITLE
Add builtin GATv2 model

### DIFF
--- a/python/graphstorm/config/config.py
+++ b/python/graphstorm/config/config.py
@@ -16,7 +16,7 @@
     Builtin configs
 """
 
-BUILTIN_GNN_ENCODER = ["gat", "rgat", "rgcn", "sage", "hgt"]
+BUILTIN_GNN_ENCODER = ["gat", "rgat", "rgcn", "sage", "hgt", "gatv2"]
 BUILTIN_ENCODER = ["lm", "mlp"] + BUILTIN_GNN_ENCODER
 SUPPORTED_BACKEND = ["gloo", "nccl"]
 

--- a/python/graphstorm/gsf.py
+++ b/python/graphstorm/gsf.py
@@ -584,7 +584,8 @@ def set_encoder(model, g, config, train_task):
                                  num_ffn_layers_in_gnn=config.num_ffn_layers_in_gnn)
     elif model_encoder_type == "sage":
         # we need to check if the graph is homogeneous
-        assert check_homo(g) == True, 'The graph is not a homogeneous graph'
+        assert check_homo(g) == True, \
+            'The graph is not a homogeneous graph, can not use sage model encoder'
         # we need to set the num_layers -1 because there is an output layer that is hard coded.
         gnn_encoder = SAGEEncoder(h_dim=config.hidden_size,
                                   out_dim=config.hidden_size,
@@ -594,6 +595,9 @@ def set_encoder(model, g, config, train_task):
                                   num_ffn_layers_in_gnn=config.num_ffn_layers_in_gnn,
                                   norm=config.gnn_norm)
     elif model_encoder_type == "gat":
+        # we need to check if the graph is homogeneous
+        assert check_homo(g) == True, \
+            'The graph is not a homogeneous graph, can not use gat model encoder'
         gnn_encoder = GATEncoder(h_dim=config.hidden_size,
                                  out_dim=config.hidden_size,
                                  num_heads=config.num_heads,
@@ -601,6 +605,9 @@ def set_encoder(model, g, config, train_task):
                                  dropout=dropout,
                                  num_ffn_layers_in_gnn=config.num_ffn_layers_in_gnn)
     elif model_encoder_type == "gatv2":
+        # we need to check if the graph is homogeneous
+        assert check_homo(g) == True, \
+            'The graph is not a homogeneous graph, can not use gatv2 model encoder'
         gnn_encoder = GATv2Encoder(h_dim=config.hidden_size,
                                    out_dim=config.hidden_size,
                                    num_heads=config.num_heads,

--- a/python/graphstorm/gsf.py
+++ b/python/graphstorm/gsf.py
@@ -43,6 +43,7 @@ from .model.hgt_encoder import HGTEncoder
 from .model.gnn_with_reconstruct import GNNEncoderWithReconstructedEmbed
 from .model.sage_encoder import SAGEEncoder
 from .model.gat_encoder import GATEncoder
+from .model.gatv2_encoder import GATv2Encoder
 from .model.node_gnn import GSgnnNodeModel
 from .model.node_glem import GLEM
 from .model.edge_gnn import GSgnnEdgeModel
@@ -599,6 +600,13 @@ def set_encoder(model, g, config, train_task):
                                  num_hidden_layers=config.num_layers -1,
                                  dropout=dropout,
                                  num_ffn_layers_in_gnn=config.num_ffn_layers_in_gnn)
+    elif model_encoder_type == "gatv2":
+        gnn_encoder = GATv2Encoder(h_dim=config.hidden_size,
+                                   out_dim=config.hidden_size,
+                                   num_heads=config.num_heads,
+                                   num_hidden_layers=config.num_layers -1,
+                                   dropout=dropout,
+                                   num_ffn_layers_in_gnn=config.  num_ffn_layers_in_gnn)
     else:
         assert False, "Unknown gnn model type {}".format(model_encoder_type)
 

--- a/python/graphstorm/gsf.py
+++ b/python/graphstorm/gsf.py
@@ -613,7 +613,7 @@ def set_encoder(model, g, config, train_task):
                                    num_heads=config.num_heads,
                                    num_hidden_layers=config.num_layers -1,
                                    dropout=dropout,
-                                   num_ffn_layers_in_gnn=config.  num_ffn_layers_in_gnn)
+                                   num_ffn_layers_in_gnn=config.num_ffn_layers_in_gnn)
     else:
         assert False, "Unknown gnn model type {}".format(model_encoder_type)
 

--- a/python/graphstorm/model/__init__.py
+++ b/python/graphstorm/model/__init__.py
@@ -33,6 +33,8 @@ from .lp_gnn import (GSgnnLinkPredictionModel,
 from .rgcn_encoder import RelationalGCNEncoder, RelGraphConvLayer
 from .rgat_encoder import RelationalGATEncoder, RelationalAttLayer
 from .sage_encoder import SAGEEncoder, SAGEConv
+from .gat_encoder import GATEncoder, GATConv
+from .gatv2_encoder import GATv2Encoder, GATv2Conv
 from .hgt_encoder import HGTEncoder, HGTLayer
 
 from .node_decoder import EntityClassifier, EntityRegression

--- a/python/graphstorm/model/gat_encoder.py
+++ b/python/graphstorm/model/gat_encoder.py
@@ -162,7 +162,7 @@ class GATEncoder(GraphConvEncoder):
         Hidden dimension
     out_dim : int
         Output dimension
-    num_head : int
+    num_heads : int
         Number of multi-heads attention
     num_hidden_layers : int
         Number of hidden layers. Total GNN layers is equal to num_hidden_layers + 1. Default 1
@@ -170,6 +170,8 @@ class GATEncoder(GraphConvEncoder):
         Dropout. Default 0.
     activation : callable, optional
         Activation function. Default: None
+    last_layer_act: bool
+        Whether call activation function in the last GNN layer.
     num_ffn_layers_in_gnn: int
         Number of ngnn gnn layers between GNN layers
     """

--- a/python/graphstorm/model/gat_encoder.py
+++ b/python/graphstorm/model/gat_encoder.py
@@ -53,15 +53,15 @@ class GATConv(nn.Module):
     num_heads : int
         Number of heads in Multi-head attention.
     activation : callable, optional
-        Activation function. Default: None
+        Activation function. Default: relu
     dropout : float, optional
         Dropout rate. Default: 0.0
     bias : bool, optional
         True if bias is added. Default: True
     num_ffn_layers_in_gnn: int, optional
-        Number of layers of ngnn between gnn layers
-    ffn_actication: torch.nn.functional
-        Activation Method for ngnn
+        Number of layers of ngnn between gnn layers. Default: 0
+    ffn_actication: torch.nn.functional, optional
+        Activation Method for ngnn. Default: relu
     """
     def __init__(self,
                  in_feat,
@@ -170,10 +170,10 @@ class GATEncoder(GraphConvEncoder):
         Dropout. Default 0.
     activation : callable, optional
         Activation function. Default: None
-    last_layer_act: bool
-        Whether call activation function in the last GNN layer.
-    num_ffn_layers_in_gnn: int
-        Number of ngnn gnn layers between GNN layers
+    last_layer_act: bool, optional
+        Whether call activation function in the last GNN layer. Default: False
+    num_ffn_layers_in_gnn: int, optional
+        Number of ngnn gnn layers between GNN layers. Default: 0
     """
     def __init__(self,
                  h_dim, out_dim,

--- a/python/graphstorm/model/gatv2_encoder.py
+++ b/python/graphstorm/model/gatv2_encoder.py
@@ -33,6 +33,10 @@ class GATv2Conv(nn.Module):
     -----
     * GATv2Conv is only effective on the homogeneous graph, not like other conv implementation.
 
+    The implementation follows dgl.nn.pytorch.conv.GATv2Conv:
+    `How Attentive are Graph Attention Networks?
+    <https://arxiv.org/pdf/2105.14491.pdf>`__
+
     Examples:
     ----------
 

--- a/python/graphstorm/model/gatv2_encoder.py
+++ b/python/graphstorm/model/gatv2_encoder.py
@@ -166,7 +166,7 @@ class GATv2Encoder(GraphConvEncoder):
         Hidden dimension
     out_dim : int
         Output dimension
-    num_head : int
+    num_heads : int
         Number of multi-heads attention
     num_hidden_layers : int
         Number of hidden layers. Total GNN layers is equal to num_hidden_layers + 1. Default 1
@@ -174,6 +174,8 @@ class GATv2Encoder(GraphConvEncoder):
         Dropout. Default 0.
     activation : callable, optional
         Activation function. Default: None
+    last_layer_act: bool
+        Whether call activation function in the last GNN layer.
     num_ffn_layers_in_gnn: int
         Number of ngnn gnn layers between GNN layers
     """

--- a/python/graphstorm/model/gatv2_encoder.py
+++ b/python/graphstorm/model/gatv2_encoder.py
@@ -57,15 +57,15 @@ class GATv2Conv(nn.Module):
     num_heads : int
         Number of heads in Multi-head attention.
     activation : callable, optional
-        Activation function. Default: None
+        Activation function. Default: relu
     dropout : float, optional
         Dropout rate. Default: 0.0
     bias : bool, optional
         True if bias is added. Default: True
     num_ffn_layers_in_gnn: int, optional
-        Number of layers of ngnn between gnn layers
-    ffn_actication: torch.nn.functional
-        Activation Method for ngnn
+        Number of layers of ngnn between gnn layers. Default: 0
+    ffn_actication: torch.nn.functional, optional
+        Activation Method for ngnn. Default: relu
     """
     def __init__(self,
                  in_feat,
@@ -174,10 +174,10 @@ class GATv2Encoder(GraphConvEncoder):
         Dropout. Default 0.
     activation : callable, optional
         Activation function. Default: None
-    last_layer_act: bool
-        Whether call activation function in the last GNN layer.
-    num_ffn_layers_in_gnn: int
-        Number of ngnn gnn layers between GNN layers
+    last_layer_act: bool, optional
+        Whether call activation function in the last GNN layer. Default: False
+    num_ffn_layers_in_gnn: int, optional
+        Number of ngnn gnn layers between GNN layers. Default: 0
     """
     def __init__(self,
                  h_dim, out_dim,

--- a/python/graphstorm/model/gatv2_encoder.py
+++ b/python/graphstorm/model/gatv2_encoder.py
@@ -1,0 +1,209 @@
+"""
+    Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+    GAT V2 layer implementation.
+"""
+import torch as th
+from torch import nn
+import torch.nn.functional as F
+import dgl
+import dgl.nn as dglnn
+from dgl.distributed.constants import DEFAULT_NTYPE
+
+from .ngnn_mlp import NGNNMLP
+from .gnn_encoder_base import GraphConvEncoder
+
+
+class GATv2Conv(nn.Module):
+    r"""GATv2 Convolutional layer
+
+    Note:
+    -----
+    * GATv2Conv is only effective on the homogeneous graph, not like other conv implementation.
+
+    Examples:
+    ----------
+
+    .. code:: python
+
+        # suppose graph and input_feature are ready
+        from graphstorm.model.gat_encoder import GATv2Conv
+
+        layer = GATv2Conv(h_dim, h_dim, num_heads, num_ffn_layers_in_gnn)
+        h = layer(g, input_feature)
+
+    Parameters
+    ----------
+    in_feat : int
+        Input feature size.
+    out_feat : int
+        Output feature size.
+    num_heads : int
+        Number of heads in Multi-head attention.
+    activation : callable, optional
+        Activation function. Default: None
+    dropout : float, optional
+        Dropout rate. Default: 0.0
+    bias : bool, optional
+        True if bias is added. Default: True
+    num_ffn_layers_in_gnn: int, optional
+        Number of layers of ngnn between gnn layers
+    ffn_actication: torch.nn.functional
+        Activation Method for ngnn
+    """
+    def __init__(self,
+                 in_feat,
+                 out_feat,
+                 num_heads,
+                 activation=F.relu,
+                 dropout=0.0,
+                 bias=True,
+                 num_ffn_layers_in_gnn=0,
+                 ffn_activation=F.relu):
+        super(GATv2Conv, self).__init__()
+        self.conv = dglnn.conv.GATv2Conv(in_feat, out_feat // num_heads, num_heads, dropout,
+                                  activation=activation, allow_zero_in_degree=True,
+                                  bias=bias)
+
+        # ngnn
+        self.num_ffn_layers_in_gnn = num_ffn_layers_in_gnn
+        self.ngnn_mlp = NGNNMLP(out_feat, out_feat,
+                                 num_ffn_layers_in_gnn, ffn_activation, dropout)
+
+    def forward(self, g, inputs):
+        """Forward computation
+
+        Parameters
+        ----------
+        g : DGLHeteroGraph
+            Input graph.
+        inputs : dict[DEFAULT_NTYPE, torch.Tensor]
+            Node feature for each node type.
+        Returns
+        -------
+        dict{DEFAULT_NTYPE, torch.Tensor}
+            New node features for each node type.
+        """
+        # add self-loop during computation.
+        src, dst = g.edges()
+        src = th.cat([src, th.arange(g.num_dst_nodes(), device=g.device)], dim=0)
+        dst = th.cat([dst, th.arange(g.num_dst_nodes(), device=g.device)], dim=0)
+        new_g= dgl.create_block(
+            (src, dst),
+            num_src_nodes=g.num_src_nodes(),
+            num_dst_nodes=g.num_dst_nodes(),
+            device=g.device
+        )
+
+        new_g.nodes[DEFAULT_NTYPE].data[dgl.NID] = g.nodes[DEFAULT_NTYPE].data[dgl.NID]
+        g = g.local_var()
+
+        assert DEFAULT_NTYPE in inputs, "GAT encoder only support homogeneous graph."
+        inputs = inputs[DEFAULT_NTYPE]
+
+        h_conv = self.conv(g, inputs)
+        h_conv = h_conv.view(h_conv.shape[0], h_conv.shape[1] * h_conv.shape[2])
+
+        if self.num_ffn_layers_in_gnn > 0:
+            h_conv = self.ngnn_mlp(h_conv)
+
+        return {DEFAULT_NTYPE: h_conv}
+
+class GATv2Encoder(GraphConvEncoder):
+    r""" GATv2 Conv Encoder
+
+    The GATv2Encoder employs several GATv2Conv Layers as its encoding mechanism.
+    The GATv2Encoder should be designated as the model's encoder within Graphstorm.
+
+    Examples:
+    ----------
+
+    .. code:: python
+
+        # Build model and do full-graph inference on GATv2Encoder
+        from graphstorm import get_node_feat_size
+        from graphstorm.model.gat_encoder import GATv2Encoder
+        from graphstorm.model.node_decoder import EntityClassifier
+        from graphstorm.model import GSgnnNodeModel, GSNodeEncoderInputLayer
+        from graphstorm.dataloading import GSgnnNodeTrainData
+        from graphstorm.model import do_full_graph_inference
+
+        np_data = GSgnnNodeTrainData(...)
+
+        model = GSgnnNodeModel(alpha_l2norm=0)
+        feat_size = get_node_feat_size(np_data.g, 'feat')
+        encoder = GSNodeEncoderInputLayer(g, feat_size, 4,
+                                          dropout=0,
+                                          use_node_embeddings=True)
+        model.set_node_input_encoder(encoder)
+
+        gnn_encoder = GATv2Encoder(4, 4, num_heads=2
+                                   num_hidden_layers=1)
+        model.set_gnn_encoder(gnn_encoder)
+        model.set_decoder(EntityClassifier(model.gnn_encoder.out_dims, 3, False))
+
+        h = do_full_graph_inference(model, np_data)
+
+    Parameters
+    ----------
+    h_dim : int
+        Hidden dimension
+    out_dim : int
+        Output dimension
+    num_head : int
+        Number of multi-heads attention
+    num_hidden_layers : int
+        Number of hidden layers. Total GNN layers is equal to num_hidden_layers + 1. Default 1
+    dropout : float
+        Dropout. Default 0.
+    activation : callable, optional
+        Activation function. Default: None
+    num_ffn_layers_in_gnn: int
+        Number of ngnn gnn layers between GNN layers
+    """
+    def __init__(self,
+                 h_dim, out_dim,
+                 num_heads,
+                 num_hidden_layers=1,
+                 dropout=0,
+                 activation=F.relu,
+                 last_layer_act=False,
+                 num_ffn_layers_in_gnn=0):
+        super(GATv2Encoder, self).__init__(h_dim, out_dim, num_hidden_layers)
+
+        self.layers = nn.ModuleList()
+        for _ in range(num_hidden_layers):
+            self.layers.append(GATv2Conv(h_dim, h_dim, num_heads,
+                                        activation=activation,
+                                        dropout=dropout, bias=True,
+                                        num_ffn_layers_in_gnn=num_ffn_layers_in_gnn))
+
+        self.layers.append(GATv2Conv(h_dim, out_dim, num_heads,
+                                    activation=activation if last_layer_act else None,
+                                    dropout=dropout, bias=True))
+
+    def forward(self, blocks, h):
+        """Forward computation
+
+        Parameters
+        ----------
+        blocks: DGL MFGs
+            Sampled subgraph in DGL MFG
+        h: dict[DEFAULT_NTYPE, torch.Tensor]
+            Input node feature for each node type.
+        """
+        for layer, block in zip(self.layers, blocks):
+            h = layer(block, h)
+        return h

--- a/tests/end2end-tests/data_process/homogeneous_test.sh
+++ b/tests/end2end-tests/data_process/homogeneous_test.sh
@@ -30,8 +30,16 @@ echo "********* Test Node Classification on GConstruct Homogeneous Graph *******
 python3 -m graphstorm.run.gs_node_classification --workspace $GS_HOME/training_scripts/gsgnn_np/ --num-trainers $NUM_TRAINERS --num-servers 1 --num-samplers 0 --part-config /tmp/movielen_100k_train_val_1p_4t_homogeneous/movie-lens-100k.json --ip-config ip_list.txt --ssh-port 2222 --cf ml_nc.yaml --target-ntype _N
 error_and_exit $?
 
+echo "********* Test Node Classification on GConstruct Homogeneous Graph with gatv2 encoder********"
+python3 -m graphstorm.run.gs_node_classification --workspace $GS_HOME/training_scripts/gsgnn_np/ --num-trainers $NUM_TRAINERS --num-servers 1 --num-samplers 0 --part-config /tmp/movielen_100k_train_val_1p_4t_homogeneous/movie-lens-100k.json --ip-config ip_list.txt --ssh-port 2222 --cf ml_nc.yaml --target-ntype _N --model-encoder-type gatv2
+error_and_exit $?
+
 echo "********* Test Edge Classification on GConstruct Homogeneous Graph ********"
 python3 -m graphstorm.run.gs_edge_classification --workspace $GS_HOME/training_scripts/gsgnn_ep/ --num-trainers $NUM_TRAINERS --num-servers 1 --num-samplers 0 --part-config /tmp/movielen_100k_train_val_1p_4t_homogeneous/movie-lens-100k.json --ip-config ip_list.txt --ssh-port 2222 --cf ml_ec.yaml --target-etype _N,_E,_N
+error_and_exit $?
+
+echo "********* Test Edge Classification on GConstruct Homogeneous Graph with gatv2 encoder********"
+python3 -m graphstorm.run.gs_edge_classification --workspace $GS_HOME/training_scripts/gsgnn_ep/ --num-trainers $NUM_TRAINERS --num-servers 1 --num-samplers 0 --part-config /tmp/movielen_100k_train_val_1p_4t_homogeneous/movie-lens-100k.json --ip-config ip_list.txt --ssh-port 2222 --cf ml_ec.yaml --target-etype _N,_E,_N --model-encoder-type gatv2
 error_and_exit $?
 
 echo "********* Test Homogeneous Graph Optimization on reverse edge********"

--- a/tests/unit-tests/test_gnn.py
+++ b/tests/unit-tests/test_gnn.py
@@ -43,7 +43,7 @@ from graphstorm.model.rgcn_encoder import RelationalGCNEncoder, RelGraphConvLaye
 from graphstorm.model.rgat_encoder import RelationalGATEncoder
 from graphstorm.model.sage_encoder import SAGEEncoder
 from graphstorm.model.gat_encoder import GATEncoder
-from graphstorm.model.gat_encoder import GATv2Encoder
+from graphstorm.model.gatv2_encoder import GATv2Encoder
 from graphstorm.model.hgt_encoder import HGTEncoder
 from graphstorm.model.edge_decoder import (DenseBiDecoder,
                                            MLPEdgeDecoder,


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Add GATv2 model as a built-in model.

Performance:
|     | ogbn-arxiv | ogbn-product |
|---|---|---|
| gat (batchsize=512) |  0.7061  |  0.7836 |
| gatv2 (batchsize=512) | 0.7134 | 0.8024 |



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
