### PR TITLE
[GSProcessing] Move to Spark 3.5, bump version to 0.3.0, add homogeneous edge mapping optimization

### DIFF
--- a/graphstorm-processing/docker/0.3.0/emr-serverless/Dockerfile.cpu
+++ b/graphstorm-processing/docker/0.3.0/emr-serverless/Dockerfile.cpu
@@ -1,0 +1,55 @@
+ARG ARCH=x86_64
+FROM public.ecr.aws/emr-serverless/spark/emr-7.0.0:20240206-${ARCH} as base
+
+USER root
+ENV PYTHON_VERSION=3.9.18
+
+# Python won’t try to write .pyc or .pyo files on the import of source modules
+# Force stdin, stdout and stderr to be totally unbuffered. Good for logging
+ENV PYTHONDONTWRITEBYTECODE=1
+ENV PYTHONUNBUFFERED=1
+ENV PYTHONIOENCODING=UTF-8
+
+
+FROM base AS arch-x86_64
+
+FROM base AS arch-arm64
+RUN yum install -y python3-devel && \
+        rm -rf /var/cache/yum
+
+FROM arch-${ARCH} AS runtime
+
+
+WORKDIR /usr/lib/spark/code/
+
+# Install GSProcessing requirements to pyenv Python
+COPY requirements.txt requirements.txt
+# Use --mount=type=cache,target=/root/.cache when Buildkit CI issue is fixed:
+# https://github.com/moby/buildkit/issues/1512
+RUN pip install -r /usr/lib/spark/code/requirements.txt \
+    && rm -rf /root/.cache
+
+# Install Huggingface model cache if it is necessary
+ARG MODEL=""
+ENV HF_HOME=/home/hadoop/.cache/huggingface/hub
+RUN if [ -z "${MODEL}" ]; then \
+        echo "Skip installing model cache"; \
+else \
+        echo "Installing model cache for $MODEL" && \
+        python3 -c "from transformers import AutoTokenizer; AutoTokenizer.from_pretrained('${MODEL}')"; \
+        python3 -c "from transformers import AutoModel; AutoModel.from_pretrained('${MODEL}')"; \
+fi
+
+
+# GSProcessing codebase
+COPY code/ /usr/lib/spark/code/
+
+FROM runtime AS prod
+RUN python -m pip install --no-deps /usr/lib/spark/code/graphstorm_processing-*.whl && \
+    rm /usr/lib/spark/code/graphstorm_processing-*.whl && rm -rf /root/.cache
+
+FROM runtime AS test
+RUN python -m pip install --no-deps /usr/lib/spark/code/graphstorm-processing/ && rm -rf /root/.cache
+
+USER hadoop:hadoop
+WORKDIR /home/hadoop

--- a/graphstorm-processing/docker/0.3.0/sagemaker/Dockerfile.cpu
+++ b/graphstorm-processing/docker/0.3.0/sagemaker/Dockerfile.cpu
@@ -1,0 +1,55 @@
+# syntax=docker/dockerfile:experimental
+FROM 153931337802.dkr.ecr.us-west-2.amazonaws.com/sagemaker-spark-processing:3.5-cpu-py39-v1.0 AS base
+
+# Python won’t try to write .pyc or .pyo files on the import of source modules
+# Force stdin, stdout and stderr to be totally unbuffered. Good for logging
+ENV PYTHONDONTWRITEBYTECODE=1
+ENV PYTHONUNBUFFERED=1
+ENV PYTHONIOENCODING=UTF-8
+ENV LANG=C.UTF-8
+ENV LC_ALL=C.UTF-8
+ENV LD_LIBRARY_PATH="${LD_LIBRARY_PATH}:/usr/local/lib"
+ENV LD_LIBRARY_PATH="${LD_LIBRARY_PATH}:/opt/conda/lib"
+ENV PATH=/opt/conda/bin:$PATH
+ENV PIP_NO_CACHE_DIR=1
+
+WORKDIR /usr/lib/spark/code/
+
+# Install GSProcessing dependencies to system Python 3.9
+COPY requirements.txt requirements.txt
+RUN /usr/local/bin/python3.9 -m pip install --no-cache-dir -r /usr/lib/spark/code/requirements.txt \
+    && rm -rf /root/.cache
+
+# Graphloader codebase
+COPY code/ /usr/lib/spark/code/
+
+# Base container assumes this is the workdir
+ENV SPARK_HOME /usr/lib/spark
+WORKDIR $SPARK_HOME
+
+# Ensure our python3 installation is the one used
+RUN echo 'alias python3=python3.9' >> ~/.bashrc
+
+# Install Huggingface model cache if it is necessary
+ARG MODEL=""
+ENV HF_HOME=/root/.cache/huggingface/hub
+RUN if [ -z "${MODEL}" ]; then \
+        echo "Skip installing model cache"; \
+else \
+        echo "Installing model cache for $MODEL" && \
+        python3 -c "from transformers import AutoTokenizer; AutoTokenizer.from_pretrained('${MODEL}')"; \
+        python3 -c "from transformers import AutoModel; AutoModel.from_pretrained('${MODEL}')"; \
+fi
+
+# Starts framework
+ENTRYPOINT ["bash", "/usr/lib/spark/code/docker-entry.sh"]
+
+FROM base AS prod
+RUN python3 -m pip install --no-deps /usr/lib/spark/code/graphstorm_processing-*.whl && \
+    rm /usr/lib/spark/code/graphstorm_processing-*.whl && rm -rf /root/.cache
+CMD ["gs-processing"]
+
+FROM base AS test
+RUN python3 -m pip install --no-deps /usr/lib/spark/code/graphstorm-processing/ mock pytest && \
+    rm -rf /root/.cache
+CMD ["sh", "-c", "pytest /usr/lib/spark/code/graphstorm-processing/tests/"]

--- a/graphstorm-processing/docker/push_gsprocessing_image.sh
+++ b/graphstorm-processing/docker/push_gsprocessing_image.sh
@@ -98,7 +98,7 @@ cleanup() {
   # script cleanup here
 }
 
-parse_params "$@"
+parse_params "${@}"
 
 if [[ ${EXEC_ENV} == "sagemaker" || ${EXEC_ENV} == "emr-serverless" ]]; then
     :  # Do nothing

--- a/graphstorm-processing/graphstorm_processing/distributed_executor.py
+++ b/graphstorm-processing/graphstorm_processing/distributed_executor.py
@@ -101,7 +101,7 @@ class ExecutorConfig:
         Whether to create reverse edges for each edge type.
     graph_name: str
         The name of the graph being processed
-    apply_repartition: bool
+    do_repartition: bool
         Whether to apply repartitioning to the graph on the Spark leader.
     """
 
@@ -247,7 +247,6 @@ class DistributedExecutor:
         data_configs = create_config_objects(self.graph_config_dict)
 
         t0 = time.time()
-        logging.info("Constructing DGLGraph for Heterogeneous Graph")
         # Prefer explicit arguments for clarity
         loader = DistHeterogeneousGraphLoader(
             spark=self.spark,

--- a/graphstorm-processing/pyproject.toml
+++ b/graphstorm-processing/pyproject.toml
@@ -10,7 +10,7 @@ authors = [
 
 [tool.poetry.dependencies]
 python = "~3.9.12"
-pyspark = ">=3.3.0, <= 3.5.0"
+pyspark = ">=3.3.0, < 3.6.0"
 pyarrow = "~14.0.1"
 boto3 = "~1.28.1"
 joblib = "^1.3.1"

--- a/graphstorm-processing/pyproject.toml
+++ b/graphstorm-processing/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "graphstorm_processing"
-version = "0.2.2"
+version = "0.3.0"
 description = "Distributed graph pre-processing for GraphStorm"
 readme = "README.md"
 packages = [{include = "graphstorm_processing"}]
@@ -10,7 +10,7 @@ authors = [
 
 [tool.poetry.dependencies]
 python = "~3.9.12"
-pyspark = ">=3.3.0, < 3.5.0"
+pyspark = ">=3.3.0, <= 3.5.0"
 pyarrow = "~14.0.1"
 boto3 = "~1.28.1"
 joblib = "^1.3.1"

--- a/graphstorm-processing/scripts/run_distributed_processing.py
+++ b/graphstorm-processing/scripts/run_distributed_processing.py
@@ -47,7 +47,7 @@ Optional:
     EC2 instance type for the processing job. (Default: 'ml.r5.4xlarge')
 --add-reverse-edges: str
     When set to "True", will create reverse edges for every edge type. (Default: "True")
---repartition-on-leader: str
+--do-repartition: str
     When set to "True", will repartition the graph files on the leader node if needed.
     (Default: "True")
 --num-output-files: int


### PR DESCRIPTION

*Issue #, if available:*

*Description of changes:*

* Optimizations for edge re-mapping:
    * When an edge is homogeneous (same src and dst node type) we cache and re-use the node id mapping DF instead of loading from storage twice. 
    * Remove enforced re-partitions where possible, because they'd trigger entire DF shuffles.
    * These changes combined have improved total job runtime by up to 33% in a random graph with 10B edges and 1B nodes.
* Bumps GSProcessing version to 0.3.0.
* Allows Spark up to 3.5 in project dependencies.
* Adds 0.3.0 Dockerfiles with Spark 3.5 for emr-s and sagemaker.

*Testing*

pytest, test jobs on SageMaker and EMR-S using the latest image versions with ml-100k, and large-scale test on SM with 1B-edges-100M-nodes-1024feat graph.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
