### PR TITLE
[GConstruct] Allow users define train/validation/test masks

### DIFF
--- a/python/graphstorm/gconstruct/construct_graph.py
+++ b/python/graphstorm/gconstruct/construct_graph.py
@@ -286,12 +286,19 @@ def process_node_data(process_confs, arr_merger, remap_id,
 
     Returns
     -------
-    dict: node ID map
-    dict: node features.
+    node_id_map: dict
+        Node ID map.
+    node_data: dict
+        Node features.
+    label_stats: dict
+        Node label statistics.
+    label_masks: dict
+        Node label mask field names.
     """
     node_data = {}
     node_id_map = {}
     label_stats = {}
+    label_masks = {}
     for process_conf in process_confs:
         # each iteration is to process a node type.
         assert 'node_type' in process_conf, \
@@ -305,8 +312,8 @@ def process_node_data(process_confs, arr_merger, remap_id,
         (feat_ops, two_phase_feat_ops, after_merge_feat_ops, _) = \
             parse_feat_ops(process_conf['features'], process_conf['format']['name']) \
                 if 'features' in process_conf else (None, [], {}, [])
-        label_ops = parse_label_ops(process_conf, is_node=True) \
-                if 'labels' in process_conf else None
+        label_ops, label_mask_fields = parse_label_ops(process_conf, is_node=True) \
+                if 'labels' in process_conf else (None, None)
 
         # If it requires multiprocessing, we need to read data to memory.
         node_id_col = process_conf['node_id_col'] if 'node_id_col' in process_conf else None
@@ -374,6 +381,11 @@ def process_node_data(process_confs, arr_merger, remap_id,
 
         if node_type not in label_stats:
             label_stats[node_type] = {}
+            label_masks[node_type] = []
+
+        if label_mask_fields is not None:
+            label_masks[node_type].extend(label_mask_fields)
+
         for feat_name in list(type_node_data):
             # features start with LABEL_STATS_FIELD store label statistics
             if feat_name.startswith(LABEL_STATS_FIELD):
@@ -416,7 +428,7 @@ def process_node_data(process_confs, arr_merger, remap_id,
                     f"Node data and node IDs for node type {node_type} does not match: " + \
                     f"{len(data)} vs. {len(node_id_map[node_type])}"
     sys_tracker.check('Finish processing node data')
-    return (node_id_map, node_data, label_stats)
+    return (node_id_map, node_data, label_stats, label_masks)
 
 def process_edge_data(process_confs, node_id_map, arr_merger,
                       ext_mem_workspace=None, num_processes=1,
@@ -469,12 +481,15 @@ def process_edge_data(process_confs, node_id_map, arr_merger,
         Edge features.
     label_stats: dict
         Edge label statistics.
+    label_masks: dict
+        Edge label mask field names.
     hard_edge_neg_ops: list
         Hard edge negative ops.
     """
     edges = {}
     edge_data = {}
     label_stats = {}
+    label_masks = {}
     for process_conf in process_confs:
         # each iteration is to process an edge type.
         assert 'relation' in process_conf, \
@@ -488,8 +503,8 @@ def process_edge_data(process_confs, node_id_map, arr_merger,
         (feat_ops, two_phase_feat_ops, after_merge_feat_ops, hard_edge_neg_ops) = \
             parse_feat_ops(process_conf['features'], process_conf['format']['name'])\
                 if 'features' in process_conf else (None, [], {}, [])
-        label_ops = parse_label_ops(process_conf, is_node=False) \
-                if 'labels' in process_conf else None
+        label_ops, label_mask_fields = parse_label_ops(process_conf, is_node=False) \
+                if 'labels' in process_conf else (None, None)
 
         # We don't need to copy all node ID maps to the worker processes.
         # Only the node ID maps of the source node type and destination node type
@@ -543,6 +558,11 @@ def process_edge_data(process_confs, node_id_map, arr_merger,
         edge_type = tuple(edge_type)
         if edge_type not in label_stats:
             label_stats[edge_type] = {}
+            label_masks[edge_type] = []
+
+        if label_mask_fields is not None:
+            label_masks[edge_type].extend(label_mask_fields)
+
         # handle edge type
         for feat_name in list(type_edge_data):
             # features start with LABEL_STATS_FIELD store label statistics
@@ -595,7 +615,7 @@ def process_edge_data(process_confs, node_id_map, arr_merger,
                 f"does not match the number of edges of {edge_type}. " \
                 f"Expecting {len(edges[edge_type][0])}, but get {len(efeats)}"
 
-    return (edges, edge_data, label_stats, hard_edge_neg_ops)
+    return (edges, edge_data, label_stats, label_masks, hard_edge_neg_ops)
 
 def is_homogeneous(confs):
     """ Verify if it is a homogeneous graph
@@ -638,7 +658,8 @@ def verify_confs(confs):
         for edge in confs['edges']:
             edge['relation'] = list(DEFAULT_ETYPE)
 
-def print_graph_info(g, node_data, edge_data, node_label_stats, edge_label_stats):
+def print_graph_info(g, node_data, edge_data, node_label_stats, edge_label_stats,
+                     node_label_masks, edge_label_masks):
     """ Print graph information.
 
     Parameters
@@ -653,6 +674,10 @@ def print_graph_info(g, node_data, edge_data, node_label_stats, edge_label_stats
         Node label stats
     edge_label_stats: dict of dict of tuple.
         Edge label stats
+    node_label_masks: dict of list of tuple.
+        Node label masks
+    edge_label_masks: dict of list of tuple.
+        Edge label masks
     """
     logging.info("The graph has %d node types and %d edge types.",
                  len(g.ntypes), len(g.etypes))
@@ -664,27 +689,35 @@ def print_graph_info(g, node_data, edge_data, node_label_stats, edge_label_stats
     for ntype in node_data:
         feat_names = list(node_data[ntype].keys())
         logging.info("Node type %s has features: %s.", ntype, str(feat_names))
-        num_train = np.sum(node_data[ntype]["train_mask"]) \
-                if "train_mask" in node_data[ntype] else 0
-        num_val = np.sum(node_data[ntype]["val_mask"]) \
-                if "val_mask" in node_data[ntype] else 0
-        num_test = np.sum(node_data[ntype]["test_mask"]) \
-                if "test_mask" in node_data[ntype] else 0
-        if num_train + num_val + num_test > 0:
-            logging.info("Train/val/test on %s: %d, %d, %d",
-                         ntype, num_train, num_val, num_test)
+
+        for label_mask in node_label_masks[ntype]:
+            train_mask, val_mask, test_mask = label_mask
+            num_train = np.sum(node_data[ntype][train_mask]) \
+                    if train_mask in node_data[ntype] else 0
+            num_val = np.sum(node_data[ntype][val_mask]) \
+                    if val_mask in node_data[ntype] else 0
+            num_test = np.sum(node_data[ntype][test_mask]) \
+                    if test_mask in node_data[ntype] else 0
+            if num_train + num_val + num_test > 0:
+                logging.info("Train/val/test on %s with mask %s, %s, %s: %d, %d, %d",
+                            ntype, train_mask, val_mask, test_mask,
+                            num_train, num_val, num_test)
     for etype in edge_data:
         feat_names = list(edge_data[etype].keys())
         logging.info("Edge type %s has features: %s.", str(etype), str(feat_names))
-        num_train = np.sum(edge_data[etype]["train_mask"]) \
-                if "train_mask" in edge_data[etype] else 0
-        num_val = np.sum(edge_data[etype]["val_mask"]) \
-                if "val_mask" in edge_data[etype] else 0
-        num_test = np.sum(edge_data[etype]["test_mask"]) \
-                if "test_mask" in edge_data[etype] else 0
-        if num_train + num_val + num_test > 0:
-            logging.info("Train/val/test on %s: %d, %d, %d",
-                         str(etype), num_train, num_val, num_test)
+
+        for label_mask in edge_label_masks[etype]:
+            train_mask, val_mask, test_mask = label_mask
+            num_train = np.sum(edge_data[etype][train_mask]) \
+                    if train_mask in edge_data[etype] else 0
+            num_val = np.sum(edge_data[etype][val_mask]) \
+                    if val_mask in edge_data[etype] else 0
+            num_test = np.sum(edge_data[etype][test_mask]) \
+                    if test_mask in edge_data[etype] else 0
+            if num_train + num_val + num_test > 0:
+                logging.info("Train/val/test on %s with mask %s, %s, %s: %d, %d, %d",
+                            str(etype), train_mask, val_mask, test_mask,
+                            num_train, num_val, num_test)
 
     for ntype in node_label_stats:
         for label_name, stats in node_label_stats[ntype].items():
@@ -717,12 +750,12 @@ def process_graph(args):
         if len(output_format) == 1 and output_format[0] == "DistDGL" else None
     convert2ext_mem = ExtMemArrayMerger(ext_mem_workspace, args.ext_mem_feat_size)
 
-    raw_node_id_maps, node_data, node_label_stats = \
+    raw_node_id_maps, node_data, node_label_stats, node_label_masks = \
         process_node_data(process_confs['nodes'], convert2ext_mem,
                           args.remap_node_id, ext_mem_workspace,
                           num_processes=num_processes_for_nodes)
     sys_tracker.check('Process the node data')
-    edges, edge_data, edge_label_stats, hard_edge_neg_ops = \
+    edges, edge_data, edge_label_stats, edge_label_masks, hard_edge_neg_ops = \
         process_edge_data(process_confs['edges'], raw_node_id_maps,
                           convert2ext_mem, ext_mem_workspace,
                           num_processes=num_processes_for_edges,
@@ -752,7 +785,7 @@ def process_graph(args):
                 logging.warning("Reverse edge for homogeneous graph will have same feature as "
                                 "what we have in the original edges")
                 for key, value in data.items():
-                    if key not in ["train_mask", "test_mask", "val_mask"]:
+                    if key not in edge_label_masks[DEFAULT_ETYPE]:
                         data[key] = np.concatenate([value, value])
                     else:
                         data[key] = np.concatenate([value, np.zeros(value.shape,
@@ -768,24 +801,27 @@ def process_graph(args):
         edges = edges1
         sys_tracker.check('Add reverse edges')
     g = dgl.heterograph(edges, num_nodes_dict=num_nodes)
-    print_graph_info(g, node_data, edge_data, node_label_stats, edge_label_stats)
+    print_graph_info(g, node_data, edge_data, node_label_stats, edge_label_stats,
+                     node_label_masks, edge_label_masks)
     os.makedirs(args.output_dir, exist_ok=True)
     sys_tracker.check('Construct DGL graph')
 
     # reshape customized mask
     for srctype_etype_dsttype in edge_data:
-        if "train_mask" in edge_data[srctype_etype_dsttype].keys() and \
-            len(edge_data[srctype_etype_dsttype]["train_mask"].shape) == 2:
-            edge_data[srctype_etype_dsttype]["train_mask"] = \
-                edge_data[srctype_etype_dsttype]["train_mask"].squeeze(1).astype('int8')
-        if "val_mask" in edge_data[srctype_etype_dsttype].keys() and \
-            len(edge_data[srctype_etype_dsttype]["val_mask"].shape) == 2:
-            edge_data[srctype_etype_dsttype]["val_mask"] = \
-                edge_data[srctype_etype_dsttype]["val_mask"].squeeze(1).astype('int8')
-        if "test_mask" in edge_data[srctype_etype_dsttype].keys() and \
-            len(edge_data[srctype_etype_dsttype]["test_mask"].shape) == 2:
-            edge_data[srctype_etype_dsttype]["test_mask"] = \
-                edge_data[srctype_etype_dsttype]["test_mask"].squeeze(1).astype('int8')
+        for label_mask in edge_label_masks[srctype_etype_dsttype]:
+            train_mask, val_mask, test_mask = label_mask
+            if train_mask in edge_data[srctype_etype_dsttype].keys() and \
+                len(edge_data[srctype_etype_dsttype][train_mask].shape) == 2:
+                edge_data[srctype_etype_dsttype][train_mask] = \
+                edge_data[srctype_etype_dsttype][train_mask].squeeze(1).astype('int8')
+            if val_mask in edge_data[srctype_etype_dsttype].keys() and \
+                len(edge_data[srctype_etype_dsttype][val_mask].shape) == 2:
+                edge_data[srctype_etype_dsttype][val_mask] = \
+                edge_data[srctype_etype_dsttype][val_mask].squeeze(1).astype('int8')
+            if test_mask in edge_data[srctype_etype_dsttype].keys() and \
+                len(edge_data[srctype_etype_dsttype][test_mask].shape) == 2:
+                edge_data[srctype_etype_dsttype][test_mask] = \
+                edge_data[srctype_etype_dsttype][test_mask].squeeze(1).astype('int8')
 
     if  "DistDGL" in output_format:
         assert args.part_method in ["metis", "random"], \

--- a/python/graphstorm/gconstruct/construct_graph.py
+++ b/python/graphstorm/gconstruct/construct_graph.py
@@ -313,7 +313,7 @@ def process_node_data(process_confs, arr_merger, remap_id,
             parse_feat_ops(process_conf['features'], process_conf['format']['name']) \
                 if 'features' in process_conf else (None, [], {}, [])
         label_ops = parse_label_ops(process_conf, is_node=True) \
-                if 'labels' in process_conf else (None, None)
+                if 'labels' in process_conf else None
 
         # If it requires multiprocessing, we need to read data to memory.
         node_id_col = process_conf['node_id_col'] if 'node_id_col' in process_conf else None
@@ -383,11 +383,12 @@ def process_node_data(process_confs, arr_merger, remap_id,
             label_stats[node_type] = {}
             label_masks[node_type] = []
 
-        for label_op in label_ops:
-            train_mask = label_op.train_mask_name
-            val_mask = label_op.val_mask_name
-            test_mask = label_op.test_mask_name
-            label_masks[node_type].append((train_mask, val_mask, test_mask))
+        if label_ops is not None:
+            for label_op in label_ops:
+                train_mask = label_op.train_mask_name
+                val_mask = label_op.val_mask_name
+                test_mask = label_op.test_mask_name
+                label_masks[node_type].append((train_mask, val_mask, test_mask))
 
         for feat_name in list(type_node_data):
             # features start with LABEL_STATS_FIELD store label statistics
@@ -507,7 +508,7 @@ def process_edge_data(process_confs, node_id_map, arr_merger,
             parse_feat_ops(process_conf['features'], process_conf['format']['name'])\
                 if 'features' in process_conf else (None, [], {}, [])
         label_ops = parse_label_ops(process_conf, is_node=False) \
-                if 'labels' in process_conf else (None, None)
+                if 'labels' in process_conf else None
 
         # We don't need to copy all node ID maps to the worker processes.
         # Only the node ID maps of the source node type and destination node type
@@ -563,11 +564,12 @@ def process_edge_data(process_confs, node_id_map, arr_merger,
             label_stats[edge_type] = {}
             label_masks[edge_type] = []
 
-        for label_op in label_ops:
-            train_mask = label_op.train_mask_name
-            val_mask = label_op.val_mask_name
-            test_mask = label_op.test_mask_name
-            label_masks[edge_type].append((train_mask, val_mask, test_mask))
+        if label_ops is not None:
+            for label_op in label_ops:
+                train_mask = label_op.train_mask_name
+                val_mask = label_op.val_mask_name
+                test_mask = label_op.test_mask_name
+                label_masks[edge_type].append((train_mask, val_mask, test_mask))
 
         # handle edge type
         for feat_name in list(type_edge_data):

--- a/python/graphstorm/gconstruct/remap_result.py
+++ b/python/graphstorm/gconstruct/remap_result.py
@@ -509,7 +509,7 @@ def remap_node_pred(pred_ntypes, pred_dir,
     multiprocessing_remap(task_list, num_proc, worker_remap_node_data)
 
     dur = time.time() - start_time
-    logging.info("{%d} Remapping edge predictions takes {%f} secs", rank, dur)
+    logging.info("{%d} Remapping node predictions takes {%f} secs", rank, dur)
     return files_to_remove
 
 def remap_edge_pred(pred_etypes, pred_dir,
@@ -750,6 +750,9 @@ def main(args, gs_config_args):
             emb_names = [e_name for e_name in emb_names if e_name != "emb_info.json"]
 
             emb_ntypes = emb_names
+    else:
+        logging.info("Node embedding directory is not provided. "
+                     "Skip remapping node embeddings.")
 
     ################## remap prediction #############
     if predict_dir is not None:
@@ -816,6 +819,8 @@ def main(args, gs_config_args):
     else:
         pred_etypes = []
         pred_ntypes = []
+        logging.info("Prediction result directory is not provided. "
+                     "Skip remapping prediction result.")
 
 
     ntypes = []

--- a/python/graphstorm/gconstruct/transform.py
+++ b/python/graphstorm/gconstruct/transform.py
@@ -1397,7 +1397,9 @@ class CustomLabelProcessor:
         self._stats_type = stats_type
 
         assert isinstance(mask_field_names, tuple) and len(mask_field_names) == 3, \
-            "mask_field_names must be a tuple with three strings."
+            "mask_field_names must be a tuple with three strings " \
+            "for training mask, validation mask and test mask, respectively." \
+            "For example ('tmask', 'vmask', 'tmask')."
         self._mask_field_names = mask_field_names
 
     @property
@@ -1528,7 +1530,9 @@ class LabelProcessor:
         self._split_pct = split_pct
         self._stats_type = stats_type
         assert isinstance(mask_field_names, tuple) and len(mask_field_names) == 3, \
-            "mask_field_names must be a tuple with three strings."
+            "mask_field_names must be a tuple with three strings " \
+            "for training mask, validation mask and test mask, respectively." \
+            "For example ('tmask', 'vmask', 'tmask')."
         self._mask_field_names = mask_field_names
 
     @property

--- a/python/graphstorm/gconstruct/transform.py
+++ b/python/graphstorm/gconstruct/transform.py
@@ -1491,12 +1491,18 @@ class LabelProcessor:
         The percentage of training, validation and test.
     stats_type: str
         Speicfy how to summarize label statistics
+        Default: None
+    mask_field_names: tuple of str
+        Specify the field name of train, validation and test masks
+        Default: ["train_mask", "val_mask", "test_mask"]
     """
-    def __init__(self, col_name, label_name, split_pct, stats_type=None):
+    def __init__(self, col_name, label_name, split_pct,
+                 stats_type=None, mask_field_names=("train_mask", "val_mask", "test_mask")):
         self._col_name = col_name
         self._label_name = label_name
         self._split_pct = split_pct
         self._stats_type = stats_type
+        self._mask_field_names = mask_field_names
 
     @property
     def col_name(self):
@@ -1509,6 +1515,30 @@ class LabelProcessor:
         """ The label name.
         """
         return self._label_name
+
+    @property
+    def mask_field_names(self):
+        """ The field names of train, validation and test masks
+        """
+        return self._mask_field_names
+
+    @property
+    def train_mask_name(self):
+        """ The field name of the train mask
+        """
+        return self._mask_field_names[0]
+
+    @property
+    def val_mask_name(self):
+        """ The field name of the validation mask
+        """
+        return self._mask_field_names[1]
+
+    @property
+    def test_mask_name(self):
+        """ The field name of the test mask
+        """
+        return self._mask_field_names[2]
 
     def data_split(self, get_valid_idx, num_samples):
         """ Split the data
@@ -1548,9 +1578,9 @@ class LabelProcessor:
         train_mask[train_idx] = 1
         val_mask[val_idx] = 1
         test_mask[test_idx] = 1
-        train_mask_name = 'train_mask'
-        val_mask_name = 'val_mask'
-        test_mask_name = 'test_mask'
+        train_mask_name = self.train_mask_name # default: 'train_mask'
+        val_mask_name = self.val_mask_name # default: 'val_mask'
+        test_mask_name = self.test_mask_name # default: 'test_mask'
         return {train_mask_name: train_mask,
                 val_mask_name: val_mask,
                 test_mask_name: test_mask}
@@ -1588,7 +1618,7 @@ class ClassificationProcessor(LabelProcessor):
             if self._stats_type == LABEL_STATS_FREQUENCY_COUNT:
                 # get train labels
                 train_labels = res[self.label_name][ \
-                    res['train_mask'].astype(np.bool_)]
+                    res[self.train_mask_name].astype(np.bool_)]
                 vals, counts = np.unique(train_labels, return_counts=True)
                 res[LABEL_STATS_FIELD+self.label_name] = \
                     (LABEL_STATS_FREQUENCY_COUNT, vals, counts)
@@ -1660,7 +1690,9 @@ def parse_label_ops(confs, is_node):
 
     Returns
     -------
-    list of LabelProcessor : the label processors generated from the configurations.
+    A tuple of
+        list of LabelProcessor : the label processors generated from the configurations.
+        list of tuple of strings: the train, validation and mask names for each label.
     """
     label_confs = confs['labels']
     assert len(label_confs) == 1, "We only support one label per node/edge type."
@@ -1670,6 +1702,17 @@ def parse_label_ops(confs, is_node):
     label_stats_type = label_conf['label_stats_type'] \
         if 'label_stats_type' in label_conf else None
     label_stats_type = _check_label_stats_type(task_type, label_stats_type)
+
+    # default mask names
+    mask_field_names = ("train_mask", "val_mask", "test_mask")
+    if "mask_field_names" in label_conf:
+        # User defined mask names
+        assert isinstance(label_conf["mask_field_names"], list) \
+            and len(label_conf["mask_field_names"]) == 3, \
+            "User defined mask_field_names must be a list of three strings." \
+            f"But get {label_conf["mask_field_names"]}"
+        mask_field_names = tuple(label_conf["mask_field_names"])
+
     if 'custom_split_filenames' in label_conf:
         custom_split = label_conf['custom_split_filenames']
         assert isinstance(custom_split, dict), \
@@ -1682,12 +1725,12 @@ def parse_label_ops(confs, is_node):
             return [CustomLabelProcessor(col_name=label_col, label_name=label_col,
                                          id_col=confs["node_id_col"],
                                          task_type=task_type, train_idx=train_idx, val_idx=val_idx,
-                                         test_idx=test_idx, stats_type=label_stats_type)]
+                                         test_idx=test_idx, stats_type=label_stats_type)], [mask_field_names]
         elif "source_id_col" in confs and "dest_id_col" in confs:
             return [CustomLabelProcessor(col_name=label_col, label_name=label_col,
                                          id_col=(confs["source_id_col"], confs["dest_id_col"]),
                                          task_type=task_type, train_idx=train_idx, val_idx=val_idx,
-                                         test_idx=test_idx, stats_type=label_stats_type)]
+                                         test_idx=test_idx, stats_type=label_stats_type)], [mask_field_names]
         else:
             raise AttributeError("Custom data segmentation should be "
                                  "applied to either node or edge tasks.")
@@ -1703,17 +1746,20 @@ def parse_label_ops(confs, is_node):
         assert 'label_col' in label_conf, \
                 "'label_col' must be defined in the label field."
         label_col = label_conf['label_col']
-        return [ClassificationProcessor(label_col, label_col, split_pct, label_stats_type)]
+        return [ClassificationProcessor(label_col, label_col, split_pct,
+                                        label_stats_type, mask_field_names)], [mask_field_names]
     elif task_type == 'regression':
         assert 'label_col' in label_conf, \
                 "'label_col' must be defined in the label field."
         label_col = label_conf['label_col']
-        return [RegressionProcessor(label_col, label_col, split_pct, label_stats_type)]
+        return [RegressionProcessor(label_col, label_col, split_pct,
+                                    label_stats_type, mask_field_names)], [mask_field_names]
     else:
         assert task_type == 'link_prediction', \
                 "The task type must be classification, regression or link_prediction."
         assert not is_node, "link_prediction task must be defined on edges."
-        return [LinkPredictionProcessor(None, None, split_pct, label_stats_type)]
+        return [LinkPredictionProcessor(None, None, split_pct,
+                                        label_stats_type, mask_field_names)], [mask_field_names]
 
 def process_labels(data, label_processors):
     """ Process labels

--- a/python/graphstorm/gconstruct/transform.py
+++ b/python/graphstorm/gconstruct/transform.py
@@ -1719,7 +1719,6 @@ def parse_label_ops(confs, is_node):
     -------
     A tuple of
         list of LabelProcessor : the label processors generated from the configurations.
-        list of tuple of strings: the train, validation and mask names for each label.
     """
     label_confs = confs['labels']
     assert len(label_confs) == 1, "We only support one label per node/edge type."
@@ -1753,13 +1752,13 @@ def parse_label_ops(confs, is_node):
                                          id_col=confs["node_id_col"],
                                          task_type=task_type, train_idx=train_idx, val_idx=val_idx,
                                          test_idx=test_idx, stats_type=label_stats_type,
-                                         mask_field_names=mask_field_names)], [mask_field_names]
+                                         mask_field_names=mask_field_names)]
         elif "source_id_col" in confs and "dest_id_col" in confs:
             return [CustomLabelProcessor(col_name=label_col, label_name=label_col,
                                          id_col=(confs["source_id_col"], confs["dest_id_col"]),
                                          task_type=task_type, train_idx=train_idx, val_idx=val_idx,
                                          test_idx=test_idx, stats_type=label_stats_type,
-                                         mask_field_names=mask_field_names)], [mask_field_names]
+                                         mask_field_names=mask_field_names)]
         else:
             raise AttributeError("Custom data segmentation should be "
                                  "applied to either node or edge tasks.")
@@ -1776,19 +1775,19 @@ def parse_label_ops(confs, is_node):
                 "'label_col' must be defined in the label field."
         label_col = label_conf['label_col']
         return [ClassificationProcessor(label_col, label_col, split_pct,
-                                        label_stats_type, mask_field_names)], [mask_field_names]
+                                        label_stats_type, mask_field_names)]
     elif task_type == 'regression':
         assert 'label_col' in label_conf, \
                 "'label_col' must be defined in the label field."
         label_col = label_conf['label_col']
         return [RegressionProcessor(label_col, label_col, split_pct,
-                                    label_stats_type, mask_field_names)], [mask_field_names]
+                                    label_stats_type, mask_field_names)]
     else:
         assert task_type == 'link_prediction', \
                 "The task type must be classification, regression or link_prediction."
         assert not is_node, "link_prediction task must be defined on edges."
         return [LinkPredictionProcessor(None, None, split_pct,
-                                        label_stats_type, mask_field_names)], [mask_field_names]
+                                        label_stats_type, mask_field_names)]
 
 def process_labels(data, label_processors):
     """ Process labels

--- a/python/graphstorm/gconstruct/transform.py
+++ b/python/graphstorm/gconstruct/transform.py
@@ -550,8 +550,8 @@ class NumericalMinMaxTransform(TwoPhaseFeatTransform):
             fifo = np.finfo(out_dtype)
         else:
             fifo = np.finfo(np.float32)
-        self._max_bound = fifo.max if max_bound>=fifo.max else max_bound
-        self._min_bound = -fifo.max if min_bound<=-fifo.max else min_bound
+        self._max_bound = fifo.max if max_bound >= fifo.max else max_bound
+        self._min_bound = -fifo.max if min_bound <= -fifo.max else min_bound
         out_dtype = np.float32 if out_dtype is None else out_dtype
         super(NumericalMinMaxTransform, self).__init__(col_name, feat_name, out_dtype)
 
@@ -1732,13 +1732,13 @@ def parse_label_ops(confs, is_node):
 
     # default mask names
     mask_field_names = ("train_mask", "val_mask", "test_mask")
-    if "mask_field_names" in label_conf:
+    if 'mask_field_names' in label_conf:
         # User defined mask names
-        assert isinstance(label_conf["mask_field_names"], list) \
-            and len(label_conf["mask_field_names"]) == 3, \
+        assert isinstance(label_conf['mask_field_names'], list) and \
+            len(label_conf['mask_field_names']) == 3, \
             "User defined mask_field_names must be a list of three strings." \
-            f"But get {label_conf["mask_field_names"]}"
-        mask_field_names = tuple(label_conf["mask_field_names"])
+            f"But get {label_conf['mask_field_names']}"
+        mask_field_names = tuple(label_conf['mask_field_names'])
 
     if 'custom_split_filenames' in label_conf:
         custom_split = label_conf['custom_split_filenames']

--- a/python/graphstorm/gconstruct/transform.py
+++ b/python/graphstorm/gconstruct/transform.py
@@ -1395,6 +1395,9 @@ class CustomLabelProcessor:
         self._test_idx = set(test_idx) if test_idx is not None else None
         self._task_type = task_type
         self._stats_type = stats_type
+
+        assert isinstance(mask_field_names, tuple) and len(mask_field_names) == 3, \
+            "mask_field_names must be a tuple with three strings."
         self._mask_field_names = mask_field_names
 
     @property
@@ -1524,6 +1527,8 @@ class LabelProcessor:
         self._label_name = label_name
         self._split_pct = split_pct
         self._stats_type = stats_type
+        assert isinstance(mask_field_names, tuple) and len(mask_field_names) == 3, \
+            "mask_field_names must be a tuple with three strings."
         self._mask_field_names = mask_field_names
 
     @property

--- a/python/graphstorm/gconstruct/transform.py
+++ b/python/graphstorm/gconstruct/transform.py
@@ -1803,6 +1803,7 @@ def process_labels(data, label_processors):
     -------
     dict of tensors : labels (optional) and train/validation/test masks.
     """
+    print(label_processors)
     assert len(label_processors) == 1, "We only support one label per node/edge type."
     return label_processors[0](data)
 

--- a/python/graphstorm/gconstruct/utils.py
+++ b/python/graphstorm/gconstruct/utils.py
@@ -937,6 +937,9 @@ def partition_graph(g, node_data, edge_data, graph_name, num_partitions, output_
         part_method = "None" if num_partitions == 1 else "metis"
 
     balance_ntypes = {}
+    # TODO: Support balance training set for multi-task learning.
+    # Only handle the single task case with the default mask names as
+    # train_mask, val_mask and test_mask.
     for ntype in node_data:
         balance_arr = th.zeros(g.number_of_nodes(ntype), dtype=th.int8)
         balance_tag = 1

--- a/python/graphstorm/gconstruct/utils.py
+++ b/python/graphstorm/gconstruct/utils.py
@@ -937,9 +937,9 @@ def partition_graph(g, node_data, edge_data, graph_name, num_partitions, output_
         part_method = "None" if num_partitions == 1 else "metis"
 
     balance_ntypes = {}
-    # TODO: Support balance training set for multi-task learning.
     # Only handle the single task case with the default mask names as
     # train_mask, val_mask and test_mask.
+    # TODO: Support balance training set for multi-task learning.
     for ntype in node_data:
         balance_arr = th.zeros(g.number_of_nodes(ntype), dtype=th.int8)
         balance_tag = 1

--- a/tests/end2end-tests/data_process/data_gen.py
+++ b/tests/end2end-tests/data_process/data_gen.py
@@ -557,4 +557,9 @@ edge_conf = [
     }
 ]
 
+transform_conf = {
+    "nodes": node_conf,
+    "edges": edge_conf,
+}
+
 json.dump(transform_conf, open(os.path.join(in_dir, 'test_data_transform_custom_mask.conf'), 'w'), indent=4)

--- a/tests/end2end-tests/data_process/data_gen.py
+++ b/tests/end2end-tests/data_process/data_gen.py
@@ -455,3 +455,106 @@ transform_conf = {
     "edges": edge_conf,
 }
 json.dump(transform_conf, open(os.path.join(in_dir, 'test_data_transform.conf'), 'w'), indent=4)
+
+node_conf = [
+    {
+        "node_type": "node1",
+        "format": {"name": "hdf5"},
+        "files": os.path.join(in_dir, "node_data1_2.hdf5"),
+        "features": [
+            {
+                "feature_col": "data",
+                "feature_name": "feat1",
+            }
+        ]
+    },
+    {
+        "node_id_col": "id",
+        "node_type": "node1",
+        "format": {"name": "parquet"},
+        "files": os.path.join(in_dir, "node_data1_*.parquet"),
+        "features": [
+            {
+                "feature_col": "data",
+                "feature_name": "feat",
+            }
+        ],
+        "labels":       [
+            {
+                "label_col":    "label",
+                "task_type":    "classification",
+                "custom_split_filenames": {"train": os.path.join(in_dir, 'node1_train.json'),
+                                           "valid": os.path.join(in_dir, 'node1_valid.json')},
+                "label_stats_type": "frequency_cnt",
+                "mask_field_names": ["train_m", "val_m", "test_m"]
+            },
+        ],
+    },
+    {
+        "node_id_col": "id",
+        "node_type": "node2",
+        "format": {"name": "parquet"},
+        "files": os.path.join(in_dir, "node_data2_*.parquet"),
+        "features": [
+            {
+                "feature_col": "data",
+                "feature_name": "category",
+                "transform": {"name": "to_categorical"},
+            },
+        ],
+    }
+]
+
+edge_conf = [
+    {
+        "source_id_col":    "src",
+        "dest_id_col":      "dst",
+        "relation":         ("node1", "relation1", "node2"),
+        "format":           {"name": "csv"},
+        "files":            os.path.join(in_dir, "edge_data1_*.csv"),
+        "labels":       [
+            {
+                "label_col":    "label",
+                "task_type":    "classification",
+                "split_pct":   [0.8, 0.2, 0.0],
+                "label_stats_type": "frequency_cnt",
+                "mask_field_names": ["train_m", "val_m", "test_m"]
+            },
+        ],
+    },
+    {
+        "source_id_col": "src",
+        "dest_id_col": "dst",
+        "relation": ("node1", "relation_custom", "node2"),
+        "format": {"name": "csv"},
+        "files": os.path.join(in_dir, "edge_data1_*.csv"),
+        "labels": [
+            {
+                "task_type": "link_prediction",
+                "custom_split_filenames": {"train": os.path.join(in_dir, 'edge1_train.json'),
+                                           "valid": os.path.join(in_dir, 'edge1_valid.json'),
+                                           "test": os.path.join(in_dir, 'edge1_test.json')},
+                "mask_field_names": ["train_m", "val_m", "test_m"]
+            },
+        ],
+    },
+    {
+
+        "relation": ("node1", "relation1", "node2"),
+        "format": {"name": "hdf5"},
+        "files": os.path.join(in_dir, "edge_data1_2.hdf5"),
+        "features": [
+            {
+                "feature_col": "float1",
+                "feature_name": "feat1",
+            },
+            {
+                "feature_col": "float1_max_min",
+                "feature_name": "max_min_norm",
+                "transform": {"name": 'max_min_norm'}
+            }
+        ]
+    }
+]
+
+json.dump(transform_conf, open(os.path.join(in_dir, 'test_data_transform_custom_mask.conf'), 'w'), indent=4)

--- a/tests/end2end-tests/data_process/test.sh
+++ b/tests/end2end-tests/data_process/test.sh
@@ -83,6 +83,7 @@ error_and_exit $?
 
 python3 $GS_HOME/tests/end2end-tests/data_process/test_custom_mask_data.py --graph-format DistDGL --graph_dir /tmp/test_partition3 --conf_file /tmp/test_data/test_data_transform_custom_mask_new.conf
 
+error_and_exit $?
 
 # Test remap edge prediction results
 python3 -m graphstorm.gconstruct.remap_result --num-processes 16 --node-id-mapping /tmp/ep_remap/id_mapping/ --logging-level debug --pred-etypes "n0,access,n1" "n1,access,n0" --preserve-input True --prediction-dir /tmp/ep_remap/pred/ --rank 1 --world-size 2

--- a/tests/end2end-tests/data_process/test.sh
+++ b/tests/end2end-tests/data_process/test.sh
@@ -75,6 +75,15 @@ python3 $GS_HOME/tests/end2end-tests/data_process/test_data.py --graph-format Di
 echo "********* Test the remap edge predictions *********"
 python3 $GS_HOME/tests/end2end-tests/data_process/gen_edge_predict_remap_test.py --output /tmp/ep_remap/
 
+# Test customize mask name
+echo "********* Test the DistDGL graph format with customize mask ********"
+python3 -m graphstorm.gconstruct.construct_graph --conf-file /tmp/test_data/test_data_transform_custom_mask.conf --num-processes 2 --output-dir /tmp/test_partition3 --graph-name test --output-conf-file /tmp/test_data/test_data_transform_custom_mask_new.conf
+
+error_and_exit $?
+
+python3 $GS_HOME/tests/end2end-tests/data_process/test_custom_mask_data.py --graph-format DistDGL --graph_dir /tmp/test_partition3 --conf_file /tmp/test_data/test_data_transform_custom_mask_new.conf
+
+
 # Test remap edge prediction results
 python3 -m graphstorm.gconstruct.remap_result --num-processes 16 --node-id-mapping /tmp/ep_remap/id_mapping/ --logging-level debug --pred-etypes "n0,access,n1" "n1,access,n0" --preserve-input True --prediction-dir /tmp/ep_remap/pred/ --rank 1 --world-size 2
 error_and_exit $?

--- a/tests/end2end-tests/data_process/test_custom_mask_data.py
+++ b/tests/end2end-tests/data_process/test_custom_mask_data.py
@@ -1,0 +1,112 @@
+"""
+    Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+    Licensed under the Apache License, Version 2.0 (the "License").
+    You may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+    Test constructed graph data with customized mask
+"""
+import os
+import json
+import dgl
+import pyarrow.parquet as pq
+import numpy as np
+import torch as th
+import argparse
+
+from test_data import read_data_parquet
+
+argparser = argparse.ArgumentParser("Preprocess graphs")
+argparser.add_argument("--graph-format", type=str, required=True,
+                       help="The constructed graph format.")
+argparser.add_argument("--graph_dir", type=str, required=True,
+                       help="The path of the constructed graph.")
+argparser.add_argument("--conf_file", type=str, required=True,
+                       help="The configuration file.")
+args = argparser.parse_args()
+out_dir = args.graph_dir
+with open(args.conf_file, 'r') as f:
+    conf = json.load(f)
+
+# only test DistDGL graph now
+if args.graph_format == "DistDGL":
+    from dgl.distributed.graph_partition_book import _etype_str_to_tuple
+    g, node_feats, edge_feats, gpb, graph_name, ntypes_list, etypes_list = \
+            dgl.distributed.load_partition(os.path.join(out_dir, 'test.json'), 0)
+    g = dgl.to_heterogeneous(g, ntypes_list, [etype[1] for etype in etypes_list])
+    for key, val in node_feats.items():
+        ntype, name = key.split('/')
+        g.nodes[ntype].data[name] = val
+    for key, val in edge_feats.items():
+        etype, name = key.split('/')
+        etype = _etype_str_to_tuple(etype)
+        g.edges[etype].data[name] = val
+else:
+    raise ValueError('Invalid graph format: {}'.format(args.graph_format))
+
+node1_map = read_data_parquet(os.path.join(out_dir, "raw_id_mappings", "node1"))
+reverse_node1_map = {val: key for key, val in zip(node1_map['orig'], node1_map['new'])}
+# Test the first node data
+assert g.nodes['node1'].data['feat'].dtype is th.float32
+assert g.nodes['node1'].data['feat1'].dtype is th.float32
+label = g.nodes['node1'].data['label'].numpy()
+assert label.dtype == np.int32
+data = g.nodes['node1'].data['feat'].numpy()
+data1 = g.nodes['node1'].data['feat1'].numpy()
+orig_ids = np.array([reverse_node1_map[new_id] for new_id in range(g.number_of_nodes('node1'))])
+np.testing.assert_allclose(data, orig_ids.reshape(-1, 1))
+np.testing.assert_allclose(data1, orig_ids.reshape(-1, 1))
+assert np.all(label == orig_ids % 100)
+assert 'train_mask' not in g.nodes['node1'].data
+assert 'val_mask' not in g.nodes['node1'].data
+assert 'test_mask' not in g.nodes['node1'].data
+assert np.all(np.nonzero(g.nodes['node1'].data['train_m'].numpy()) == np.arange(100))
+assert np.all(np.nonzero(g.nodes['node1'].data['val_m'].numpy()) == np.arange(100, 200))
+assert th.sum(g.nodes['node1'].data['test_m']) == 0
+
+# Test the edge data of edge type 1
+src_ids, dst_ids = g.edges(etype=('node1', 'relation1', 'node2'))
+assert 'label' in g.edges[('node1', 'relation1', 'node2')].data
+label = g.edges[('node1', 'relation1', 'node2')].data['label'].numpy()
+assert label.dtype == np.int32
+src_ids = np.array([reverse_node1_map[src_id] for src_id in src_ids.numpy()])
+dst_ids = dst_ids.numpy()
+assert np.all((src_ids + dst_ids) % 100 == label)
+assert 'train_mask' not in g.edges[('node1', 'relation1', 'node2')].data
+assert 'val_mask' not in g.nodesedges[('node1', 'relation1', 'node2')].data
+assert 'test_mask' not in g.nodesedges[('node1', 'relation1', 'node2')].data
+assert th.sum(g.edges[('node1', 'relation1', 'node2')].data['train_m']) \
+        == int(g.number_of_edges(('node1', 'relation1', 'node2')) * 0.8)
+assert th.sum(g.edges[('node1', 'relation1', 'node2')].data['val_m']) \
+        == int(g.number_of_edges(('node1', 'relation1', 'node2')) * 0.2)
+assert th.sum(g.edges[('node1', 'relation1', 'node2')].data['test_m']) == 0
+#test data type
+data = g.edges[('node1', 'relation1', 'node2')].data['feat1']
+assert data.dtype is th.float32
+data = g.edges[('node1', 'relation1', 'node2')].data['max_min_norm']
+assert data.dtype is th.float32
+assert th.max(data) <= 1.0
+assert th.min(data) >= 0
+
+# Test customized link prediction data split
+src_ids, dst_ids = g.edges(etype=('node1', 'relation_custom', 'node2'))
+src_ids = np.array([reverse_node1_map[src_id] for src_id in src_ids.numpy()])
+dst_ids = dst_ids.numpy()
+assert np.all((src_ids + dst_ids) % 100 == label)
+assert 'train_mask' not in g.edges[('node1', 'relation_custom', 'node2')].data
+assert 'val_mask' not in g.nodesedges[('node1', 'relation_custom', 'node2')].data
+assert 'test_mask' not in g.nodesedges[('node1', 'relation_custom', 'node2')].data
+assert th.sum(g.edges[('node1', 'relation_custom', 'node2')].data['train_m']) \
+        == 100
+assert th.sum(g.edges[('node1', 'relation_custom', 'node2')].data['val_m']) \
+        == 20
+assert th.sum(g.edges[('node1', 'relation_custom', 'node2')].data['test_m']) == 20

--- a/tests/end2end-tests/data_process/test_custom_mask_data.py
+++ b/tests/end2end-tests/data_process/test_custom_mask_data.py
@@ -82,8 +82,8 @@ src_ids = np.array([reverse_node1_map[src_id] for src_id in src_ids.numpy()])
 dst_ids = dst_ids.numpy()
 assert np.all((src_ids + dst_ids) % 100 == label)
 assert 'train_mask' not in g.edges[('node1', 'relation1', 'node2')].data
-assert 'val_mask' not in g.nodesedges[('node1', 'relation1', 'node2')].data
-assert 'test_mask' not in g.nodesedges[('node1', 'relation1', 'node2')].data
+assert 'val_mask' not in g.edges[('node1', 'relation1', 'node2')].data
+assert 'test_mask' not in g.edges[('node1', 'relation1', 'node2')].data
 assert th.sum(g.edges[('node1', 'relation1', 'node2')].data['train_m']) \
         == int(g.number_of_edges(('node1', 'relation1', 'node2')) * 0.8)
 assert th.sum(g.edges[('node1', 'relation1', 'node2')].data['val_m']) \

--- a/tests/end2end-tests/data_process/test_custom_mask_data.py
+++ b/tests/end2end-tests/data_process/test_custom_mask_data.py
@@ -103,8 +103,8 @@ src_ids = np.array([reverse_node1_map[src_id] for src_id in src_ids.numpy()])
 dst_ids = dst_ids.numpy()
 assert np.all((src_ids + dst_ids) % 100 == label)
 assert 'train_mask' not in g.edges[('node1', 'relation_custom', 'node2')].data
-assert 'val_mask' not in g.nodesedges[('node1', 'relation_custom', 'node2')].data
-assert 'test_mask' not in g.nodesedges[('node1', 'relation_custom', 'node2')].data
+assert 'val_mask' not in g.edges[('node1', 'relation_custom', 'node2')].data
+assert 'test_mask' not in g.edges[('node1', 'relation_custom', 'node2')].data
 assert th.sum(g.edges[('node1', 'relation_custom', 'node2')].data['train_m']) \
         == 100
 assert th.sum(g.edges[('node1', 'relation_custom', 'node2')].data['val_m']) \

--- a/tests/end2end-tests/data_process/test_custom_mask_data.py
+++ b/tests/end2end-tests/data_process/test_custom_mask_data.py
@@ -23,7 +23,10 @@ import numpy as np
 import torch as th
 import argparse
 
-from test_data import read_data_parquet
+def read_data_parquet(data_file):
+    table = pq.read_table(data_file)
+    pd = table.to_pandas()
+    return {key: np.array(pd[key]) for key in pd}
 
 argparser = argparse.ArgumentParser("Preprocess graphs")
 argparser.add_argument("--graph-format", type=str, required=True,

--- a/tests/unit-tests/gconstruct/test_construct_graph.py
+++ b/tests/unit-tests/gconstruct/test_construct_graph.py
@@ -923,10 +923,10 @@ def test_label():
     check_classification_no_split(res, mask_field_names)
 
     # Check regression
-    def check_regression(res):
-        check_split(res)
-    def check_regression_no_split(res):
-        check_no_split(res)
+    def check_regression(res, mask_field_names=[("train_mask", "val_mask", "test_mask")]):
+        check_split(res, mask_field_names[0][0], mask_field_names[0][1], mask_field_names[0][2])
+    def check_regression_no_split(res, mask_field_names=[("train_mask", "val_mask", "test_mask")]):
+        check_no_split(res, mask_field_names[0][0], mask_field_names[0][1], mask_field_names[0][2])
 
     conf = {
             "labels": [
@@ -940,19 +940,19 @@ def test_label():
     }
     ops, mask_field_names = parse_label_ops(conf, True)
     assert len(mask_field_names) == 1
-    assert mask_field_names[0][0] == "train_mask"
-    assert mask_field_names[0][1] == "val_mask"
-    assert mask_field_names[0][2] == "test_mask"
+    assert mask_field_names[0][0] == "train_mask_l"
+    assert mask_field_names[0][1] == "val_mask_l"
+    assert mask_field_names[0][2] == "test_mask_l"
     data = {'label' : np.random.uniform(size=10) * 10}
     res = process_labels(data, ops)
-    check_regression(res)
+    check_regression(res, mask_field_names)
     ops, mask_field_names = parse_label_ops(conf, False)
     assert len(mask_field_names) == 1
-    assert mask_field_names[0][0] == "train_mask"
-    assert mask_field_names[0][1] == "val_mask"
-    assert mask_field_names[0][2] == "test_mask"
+    assert mask_field_names[0][0] == "train_mask_l"
+    assert mask_field_names[0][1] == "val_mask_l"
+    assert mask_field_names[0][2] == "test_mask_l"
     res = process_labels(data, ops)
-    check_regression(res)
+    check_regression(res, mask_field_names)
 
     # Check regression with customized mask names
     conf = {
@@ -981,6 +981,26 @@ def test_label():
     res = process_labels(data, ops)
     check_regression(res, mask_field_names)
 
+    conf = {
+            "labels": [
+                {'task_type': 'regression',
+                 'label_col': 'label',
+                 'split_pct': [0.8, 0.1, 0.1]
+                }
+            ]
+    }
+    ops, mask_field_names = parse_label_ops(conf, True)
+    assert len(mask_field_names) == 1
+    assert mask_field_names[0][0] == "train_mask"
+    assert mask_field_names[0][1] == "val_mask"
+    assert mask_field_names[0][2] == "test_mask"
+    data = {'label' : np.random.uniform(size=10) * 10}
+    res = process_labels(data, ops)
+    check_regression(res, mask_field_names)
+    ops, _ = parse_label_ops(conf, False)
+    res = process_labels(data, ops)
+    check_regression(res)
+
     # Check regression with invalid labels.
     data = {'label' : np.random.uniform(size=13) * 10}
     data['label'][[0, 3, 4]] = np.NAN
@@ -989,7 +1009,7 @@ def test_label():
     check_regression(res)
 
     # Check custom data split for regression.
-    data, _ = {
+    data = {
             "id": np.arange(10),
             'label' : np.random.uniform(size=10) * 10
     }

--- a/tests/unit-tests/gconstruct/test_construct_graph.py
+++ b/tests/unit-tests/gconstruct/test_construct_graph.py
@@ -1727,6 +1727,48 @@ def test_parse_edge_data():
         assert "val_mask" in feat_data
         assert "test_mask" in feat_data
 
+        # Test with customized mask names.
+        try:
+            label_ops = [
+            LinkPredictionProcessor(None, None, [0.7,0.1,0.2], None,
+                                    mask_field_names="train_mask")]
+            assert False, \
+                "Should raise an exception as mask_field_names is in the wrong format."
+        except:
+            pass
+
+        try:
+            label_ops = [
+            LinkPredictionProcessor(None, None, [0.7,0.1,0.2], None,
+                                    mask_field_names=("tm", "vm"))]
+            assert False, \
+                "Should raise an exception as mask_field_names is in the wrong format."
+        except:
+            pass
+
+        label_ops = [
+            LinkPredictionProcessor(None, None, [0.7,0.1,0.2], None,
+                                    mask_field_names=("tm", "vm", "tsm"))]
+
+        conf = {
+            "source_id_col": "src_id",
+            "dest_id_col": "dst_id",
+            "relation": ("src", "rel", "dst")
+        }
+        keys = ["src_id", "dst_id", "feat"]
+        src_ids, dst_ids, feat_data = \
+            parse_edge_data(data_file, feat_ops, label_ops, node_id_map,
+                            partial(read_data_parquet, data_fields=keys),
+                            conf, skip_nonexist_edges=True)
+        for _, val in feat_data.items():
+            assert len(src_ids) == len(val)
+            assert len(dst_ids) == len(val)
+
+        assert "feat" in feat_data
+        assert "tm" in feat_data
+        assert "vm" in feat_data
+        assert "tsm" in feat_data
+
 @pytest.mark.parametrize("ext_mem_path", [None, "/tmp/"])
 def test_multicolumn(ext_mem_path):
     # Just get the features without transformation.

--- a/tests/unit-tests/gconstruct/test_construct_graph.py
+++ b/tests/unit-tests/gconstruct/test_construct_graph.py
@@ -643,26 +643,24 @@ def test_label():
                  'split_pct': [0.8, 0.1, 0.1]}
             ]
     }
-    ops, mask_field_names = parse_label_ops(conf, True)
+    ops = parse_label_ops(conf, True)
     data = {'label' : np.random.uniform(size=10) * 10}
-    assert len(mask_field_names) == 1
-    assert mask_field_names[0][0] == "train_mask"
-    assert mask_field_names[0][1] == "val_mask"
-    assert mask_field_names[0][2] == "test_mask"
+    assert ops[0].train_mask_name == "train_mask"
+    assert ops[0].val_mask_name == "val_mask"
+    assert ops[0].test_mask_name == "test_mask"
     res = process_labels(data, ops)
-    check_classification(res, mask_field_names)
-    ops, mask_field_names = parse_label_ops(conf, False)
-    assert len(mask_field_names) == 1
-    assert mask_field_names[0][0] == "train_mask"
-    assert mask_field_names[0][1] == "val_mask"
-    assert mask_field_names[0][2] == "test_mask"
+    check_classification(res)
+    ops = parse_label_ops(conf, False)
+    assert ops[0].train_mask_name == "train_mask"
+    assert ops[0].val_mask_name == "val_mask"
+    assert ops[0].test_mask_name == "test_mask"
     res = process_labels(data, ops)
     check_classification(res)
 
     # Check classification with invalid labels.
     data = {'label' : np.random.uniform(size=13) * 10}
     data['label'][[0, 3, 4]] = np.NAN
-    ops, _ = parse_label_ops(conf, True)
+    ops = parse_label_ops(conf, True)
     res = process_labels(data, ops)
     check_classification(res)
 
@@ -670,13 +668,13 @@ def test_label():
     data = {'label' : np.random.randint(2, size=(15,5)).astype(np.float32)}
     data['label'][[0,3,4]] = np.NAN
     data['label'][[1,2], [3,4]] = np.NAN
-    ops, _ = parse_label_ops(conf, True)
+    ops = parse_label_ops(conf, True)
     res = process_labels(data, ops)
     check_classification(res)
 
     # Check classification with integer labels.
     data = {'label' : np.random.randint(10, size=10)}
-    ops, _ = parse_label_ops(conf, True)
+    ops = parse_label_ops(conf, True)
     res = process_labels(data, ops)
     check_classification(res)
 
@@ -689,7 +687,7 @@ def test_label():
                  'split_pct': [0.4, 0.05, 0.05]}
             ]
     }
-    ops, _ = parse_label_ops(conf, True)
+    ops = parse_label_ops(conf, True)
     data = {'label' : np.random.randint(3, size=20)}
     res = process_labels(data, ops)
     check_classification(res)
@@ -705,14 +703,13 @@ def test_label():
                                       'test_mask_c']}
             ]
     }
-    ops, mask_field_names = parse_label_ops(conf, True)
-    assert len(mask_field_names) == 1
-    assert mask_field_names[0][0] == "train_mask_c"
-    assert mask_field_names[0][1] == "val_mask_c"
-    assert mask_field_names[0][2] == "test_mask_c"
+    ops = parse_label_ops(conf, True)
+    assert ops[0].train_mask_name == "train_mask_c"
+    assert ops[0].val_mask_name == "val_mask_c"
+    assert ops[0].test_mask_name == "test_mask_c"
     data = {'label' : np.random.randint(3, size=20)}
     res = process_labels(data, ops)
-    check_classification(res, mask_field_names)
+    check_classification(res, [("train_mask_c", "val_mask_c", "test_mask_c")])
 
     # split_pct is not specified.
     conf = {
@@ -721,7 +718,7 @@ def test_label():
                  'label_col': 'label'}
             ]
     }
-    ops, _ = parse_label_ops(conf, True)
+    ops = parse_label_ops(conf, True)
     data = {'label' : np.random.randint(3, size=10)}
     res = process_labels(data, ops)
     assert np.sum(res['train_mask']) == 8
@@ -738,11 +735,10 @@ def test_label():
                                       'test_mask_c']}
             ]
     }
-    ops, mask_field_names = parse_label_ops(conf, True)
-    assert len(mask_field_names) == 1
-    assert mask_field_names[0][0] == "train_mask_c"
-    assert mask_field_names[0][1] == "val_mask_c"
-    assert mask_field_names[0][2] == "test_mask_c"
+    ops = parse_label_ops(conf, True)
+    assert ops[0].train_mask_name == "train_mask_c"
+    assert ops[0].val_mask_name == "val_mask_c"
+    assert ops[0].test_mask_name == "test_mask_c"
     data = {'label' : np.random.randint(3, size=10)}
     res = process_labels(data, ops)
     assert np.sum(res['train_mask_c']) == 8
@@ -767,7 +763,7 @@ def test_label():
                                             "test": "/tmp/test_idx.json"}}
             ]
     }
-    ops, _ = parse_label_ops(conf, True)
+    ops = parse_label_ops(conf, True)
     res = process_labels(data, ops)
     check_classification(res)
 
@@ -785,13 +781,12 @@ def test_label():
                                       'test_mask_c']}
             ]
     }
-    ops, mask_field_names = parse_label_ops(conf, True)
-    assert len(mask_field_names) == 1
-    assert mask_field_names[0][0] == "train_mask_c"
-    assert mask_field_names[0][1] == "val_mask_c"
-    assert mask_field_names[0][2] == "test_mask_c"
+    ops = parse_label_ops(conf, True)
+    assert ops[0].train_mask_name == "train_mask_c"
+    assert ops[0].val_mask_name == "val_mask_c"
+    assert ops[0].test_mask_name == "test_mask_c"
     res = process_labels(data, ops)
-    check_classification(res, mask_field_names)
+    check_classification(res, [("train_mask_c", "val_mask_c", "test_mask_c")])
 
     # Check custom data split for classification on edge.
     data = {
@@ -814,7 +809,7 @@ def test_label():
                                             "test": "/tmp/test_idx.json"}}
             ]
     }
-    ops, _ = parse_label_ops(conf, False)
+    ops = parse_label_ops(conf, False)
     res = process_labels(data, ops)
     check_classification(res)
 
@@ -833,13 +828,12 @@ def test_label():
                                       'test_mask_ec']}
             ]
     }
-    ops, mask_field_names = parse_label_ops(conf, False)
-    assert len(mask_field_names) == 1
-    assert mask_field_names[0][0] == "train_mask_ec"
-    assert mask_field_names[0][1] == "val_mask_ec"
-    assert mask_field_names[0][2] == "test_mask_ec"
+    ops = parse_label_ops(conf, False)
+    assert ops[0].train_mask_name == "train_mask_ec"
+    assert ops[0].val_mask_name == "val_mask_ec"
+    assert ops[0].test_mask_name == "test_mask_ec"
     res = process_labels(data, ops)
-    check_classification(res, mask_field_names)
+    check_classification(res, [("train_mask_ec", "val_mask_ec", "test_mask_ec")])
 
     # Check custom data split with only training set.
     data = {
@@ -855,7 +849,7 @@ def test_label():
                  'custom_split_filenames': {"train": "/tmp/train_idx.json"} }
             ]
     }
-    ops, _ = parse_label_ops(conf, True)
+    ops = parse_label_ops(conf, True)
     res = process_labels(data, ops)
     assert "train_mask" in res
     assert np.sum(res["train_mask"]) == 8
@@ -876,11 +870,10 @@ def test_label():
                                       'test_mask_c'] }
             ]
     }
-    ops, mask_field_names = parse_label_ops(conf, True)
-    assert len(mask_field_names) == 1
-    assert mask_field_names[0][0] == "train_mask_c"
-    assert mask_field_names[0][1] == "val_mask_c"
-    assert mask_field_names[0][2] == "test_mask_c"
+    ops = parse_label_ops(conf, True)
+    assert ops[0].train_mask_name == "train_mask_c"
+    assert ops[0].val_mask_name == "val_mask_c"
+    assert ops[0].test_mask_name == "test_mask_c"
     res = process_labels(data, ops)
     assert "train_mask_c" in res
     assert np.sum(res["train_mask_c"]) == 8
@@ -897,7 +890,7 @@ def test_label():
                  'split_pct': [0, 0, 0]}
             ]
     }
-    ops, _ = parse_label_ops(conf, True)
+    ops = parse_label_ops(conf, True)
     data = {'label' : np.random.uniform(size=10) * 10}
     res = process_labels(data, ops)
     check_classification_no_split(res)
@@ -913,14 +906,13 @@ def test_label():
                                       'test_mask_c']}
             ]
     }
-    ops, mask_field_names = parse_label_ops(conf, True)
-    assert len(mask_field_names) == 1
-    assert mask_field_names[0][0] == "train_mask_c"
-    assert mask_field_names[0][1] == "val_mask_c"
-    assert mask_field_names[0][2] == "test_mask_c"
+    ops = parse_label_ops(conf, True)
+    assert ops[0].train_mask_name == "train_mask_c"
+    assert ops[0].val_mask_name == "val_mask_c"
+    assert ops[0].test_mask_name == "test_mask_c"
     data = {'label' : np.random.uniform(size=10) * 10}
     res = process_labels(data, ops)
-    check_classification_no_split(res, mask_field_names)
+    check_classification_no_split(res, [("train_mask_c", "val_mask_c", "test_mask_c")])
 
     # Check regression
     def check_regression(res, mask_field_names=[("train_mask", "val_mask", "test_mask")]):
@@ -938,21 +930,19 @@ def test_label():
                                       'test_mask_l']}
             ]
     }
-    ops, mask_field_names = parse_label_ops(conf, True)
-    assert len(mask_field_names) == 1
-    assert mask_field_names[0][0] == "train_mask_l"
-    assert mask_field_names[0][1] == "val_mask_l"
-    assert mask_field_names[0][2] == "test_mask_l"
+    ops = parse_label_ops(conf, True)
+    assert ops[0].train_mask_name == "train_mask_l"
+    assert ops[0].val_mask_name == "val_mask_l"
+    assert ops[0].test_mask_name == "test_mask_l"
     data = {'label' : np.random.uniform(size=10) * 10}
     res = process_labels(data, ops)
-    check_regression(res, mask_field_names)
-    ops, mask_field_names = parse_label_ops(conf, False)
-    assert len(mask_field_names) == 1
-    assert mask_field_names[0][0] == "train_mask_l"
-    assert mask_field_names[0][1] == "val_mask_l"
-    assert mask_field_names[0][2] == "test_mask_l"
+    check_regression(res, [("train_mask_l", "val_mask_l", "test_mask_l")])
+    ops = parse_label_ops(conf, False)
+    assert ops[0].train_mask_name == "train_mask_l"
+    assert ops[0].val_mask_name == "val_mask_l"
+    assert ops[0].test_mask_name == "test_mask_l"
     res = process_labels(data, ops)
-    check_regression(res, mask_field_names)
+    check_regression(res, [("train_mask_l", "val_mask_l", "test_mask_l")])
 
     # Check regression with customized mask names
     conf = {
@@ -965,21 +955,19 @@ def test_label():
                                       'test_mask_r']}
             ]
     }
-    ops, mask_field_names = parse_label_ops(conf, True)
-    assert len(mask_field_names) == 1
-    assert mask_field_names[0][0] == "train_mask_r"
-    assert mask_field_names[0][1] == "val_mask_r"
-    assert mask_field_names[0][2] == "test_mask_r"
+    ops = parse_label_ops(conf, True)
+    assert ops[0].train_mask_name == "train_mask_r"
+    assert ops[0].val_mask_name == "val_mask_r"
+    assert ops[0].test_mask_name == "test_mask_r"
     data = {'label' : np.random.uniform(size=10) * 10}
     res = process_labels(data, ops)
-    check_regression(res, mask_field_names)
-    ops, mask_field_names = parse_label_ops(conf, False)
-    assert len(mask_field_names) == 1
-    assert mask_field_names[0][0] == "train_mask_r"
-    assert mask_field_names[0][1] == "val_mask_r"
-    assert mask_field_names[0][2] == "test_mask_r"
+    check_regression(res, [("train_mask_r", "val_mask_r", "test_mask_r")])
+    ops = parse_label_ops(conf, False)
+    assert ops[0].train_mask_name == "train_mask_r"
+    assert ops[0].val_mask_name == "val_mask_r"
+    assert ops[0].test_mask_name == "test_mask_r"
     res = process_labels(data, ops)
-    check_regression(res, mask_field_names)
+    check_regression(res, [("train_mask_r", "val_mask_r", "test_mask_r")])
 
     conf = {
             "labels": [
@@ -989,22 +977,21 @@ def test_label():
                 }
             ]
     }
-    ops, mask_field_names = parse_label_ops(conf, True)
-    assert len(mask_field_names) == 1
-    assert mask_field_names[0][0] == "train_mask"
-    assert mask_field_names[0][1] == "val_mask"
-    assert mask_field_names[0][2] == "test_mask"
+    ops = parse_label_ops(conf, True)
+    assert ops[0].train_mask_name == "train_mask"
+    assert ops[0].val_mask_name == "val_mask"
+    assert ops[0].test_mask_name == "test_mask"
     data = {'label' : np.random.uniform(size=10) * 10}
     res = process_labels(data, ops)
-    check_regression(res, mask_field_names)
-    ops, _ = parse_label_ops(conf, False)
+    check_regression(res)
+    ops = parse_label_ops(conf, False)
     res = process_labels(data, ops)
     check_regression(res)
 
     # Check regression with invalid labels.
     data = {'label' : np.random.uniform(size=13) * 10}
     data['label'][[0, 3, 4]] = np.NAN
-    ops, _ = parse_label_ops(conf, True)
+    ops = parse_label_ops(conf, True)
     res = process_labels(data, ops)
     check_regression(res)
 
@@ -1026,7 +1013,7 @@ def test_label():
                                             "test": "/tmp/test_idx.json"} }
             ]
     }
-    ops, _ = parse_label_ops(conf, True)
+    ops = parse_label_ops(conf, True)
     res = process_labels(data, ops)
     check_regression(res)
 
@@ -1039,7 +1026,7 @@ def test_label():
             ]
     }
     data = {'label' : np.random.uniform(size=10) * 10}
-    ops, _ = parse_label_ops(conf, True)
+    ops = parse_label_ops(conf, True)
     res = process_labels(data, ops)
     check_regression_no_split(res)
 
@@ -1050,11 +1037,10 @@ def test_label():
                  'split_pct': [0.8, 0.1, 0.1]}
             ]
     }
-    ops, mask_field_names = parse_label_ops(conf, False)
-    assert len(mask_field_names) == 1
-    assert mask_field_names[0][0] == "train_mask"
-    assert mask_field_names[0][1] == "val_mask"
-    assert mask_field_names[0][2] == "test_mask"
+    ops = parse_label_ops(conf, False)
+    assert ops[0].train_mask_name == "train_mask"
+    assert ops[0].val_mask_name == "val_mask"
+    assert ops[0].test_mask_name == "test_mask"
     data = {'label' : np.random.uniform(size=10) * 10}
     res = process_labels(data, ops)
     assert len(res) == 3
@@ -1075,11 +1061,10 @@ def test_label():
                                       'test_mask_l']}
             ]
     }
-    ops, mask_field_names = parse_label_ops(conf, False)
-    assert len(mask_field_names) == 1
-    assert mask_field_names[0][0] == "train_mask_l"
-    assert mask_field_names[0][1] == "val_mask_l"
-    assert mask_field_names[0][2] == "test_mask_l"
+    ops = parse_label_ops(conf, False)
+    assert ops[0].train_mask_name == "train_mask_l"
+    assert ops[0].val_mask_name == "val_mask_l"
+    assert ops[0].test_mask_name == "test_mask_l"
     data = {'label' : np.random.uniform(size=10) * 10}
     res = process_labels(data, ops)
     assert len(res) == 3
@@ -1097,7 +1082,7 @@ def test_label():
                  'split_pct': [0, 0, 0]}
             ]
     }
-    ops, _ = parse_label_ops(conf, False)
+    ops = parse_label_ops(conf, False)
     data = {'label' : np.random.uniform(size=10) * 10}
     res = process_labels(data, ops)
     assert len(res) == 0
@@ -1128,11 +1113,10 @@ def check_link_prediction_custom_label():
                  }
             ]
     }
-    ops, mask_field_names = parse_label_ops(conf, False)
-    assert len(mask_field_names) == 1
-    assert mask_field_names[0][0] == "train_mask"
-    assert mask_field_names[0][1] == "val_mask"
-    assert mask_field_names[0][2] == "test_mask"
+    ops = parse_label_ops(conf, False)
+    assert ops[0].train_mask_name == "train_mask"
+    assert ops[0].val_mask_name == "val_mask"
+    assert ops[0].test_mask_name == "test_mask"
     res = process_labels(data, ops)
     assert len(res) == 3
     assert 'train_mask' in res
@@ -1157,11 +1141,10 @@ def check_link_prediction_custom_label():
                  }
             ]
     }
-    ops, mask_field_names = parse_label_ops(conf, False)
-    assert len(mask_field_names) == 1
-    assert mask_field_names[0][0] == "train_mask_l"
-    assert mask_field_names[0][1] == "val_mask_l"
-    assert mask_field_names[0][2] == "test_mask_l"
+    ops = parse_label_ops(conf, False)
+    assert ops[0].train_mask_name == "train_mask_l"
+    assert ops[0].val_mask_name == "val_mask_l"
+    assert ops[0].test_mask_name == "test_mask_l"
     res = process_labels(data, ops)
     assert len(res) == 3
     assert 'train_mask_l' in res
@@ -1617,7 +1600,7 @@ def test_multiprocessing_checks():
     }
     in_files = ["/tmp/test1", "/tmp/test2"]
     (feat_ops, _, _, _) = parse_feat_ops(conf['features'])
-    label_ops, _ = parse_label_ops(conf, is_node=True)
+    label_ops = parse_label_ops(conf, is_node=True)
     multiprocessing = do_multiprocess_transform(conf, feat_ops, label_ops, in_files)
     assert multiprocessing == True
 
@@ -1634,7 +1617,7 @@ def test_multiprocessing_checks():
     }
     in_files = ["/tmp/test1", "/tmp/test2"]
     feat_ops = None
-    label_ops, _ = parse_label_ops(conf, is_node=True)
+    label_ops = parse_label_ops(conf, is_node=True)
     multiprocessing = do_multiprocess_transform(conf, feat_ops, label_ops, in_files)
     assert multiprocessing == True
 

--- a/tests/unit-tests/gconstruct/test_construct_graph.py
+++ b/tests/unit-tests/gconstruct/test_construct_graph.py
@@ -625,13 +625,13 @@ def test_label():
         assert np.all(np.logical_and(label[test_idx] >= 0, label[test_idx] <= 10))
 
     # Check classification
-    def check_classification(res, mask_field_names=("train_mask", "val_mask", "test_mask")):
+    def check_classification(res, mask_field_names=[("train_mask", "val_mask", "test_mask")]):
         # default masks are train_mask, val_mask and test_mask
         check_split(res, mask_field_names[0][0], mask_field_names[0][1], mask_field_names[0][2])
         assert np.issubdtype(res['label'].dtype, np.integer)
         check_integer(res['label'], res, mask_field_names[0][0], mask_field_names[0][1], mask_field_names[0][2])
 
-    def check_classification_no_split(res, mask_field_names=("train_mask", "val_mask", "test_mask")):
+    def check_classification_no_split(res, mask_field_names=[("train_mask", "val_mask", "test_mask")]):
         # default masks are train_mask, val_mask and test_mask
         check_no_split(res, mask_field_names[0][0], mask_field_names[0][1], mask_field_names[0][2])
         assert np.issubdtype(res['label'].dtype, np.integer)

--- a/tests/unit-tests/gconstruct/test_transform.py
+++ b/tests/unit-tests/gconstruct/test_transform.py
@@ -634,6 +634,12 @@ def test_custom_node_label_processor():
     assert_equal(np.squeeze(np.nonzero(split["tsm"])), test_idx)
 
     # there is no label
+    clp = CustomLabelProcessor(col_name="test_label", label_name="test", id_col="id",
+                            task_type="classification",
+                            train_idx=train_idx,
+                            val_idx=val_idx,
+                            test_idx=test_idx,
+                            stats_type=None)
     input_data = {
         "feat": np.random.rand(24),
         "id": np.arange(24),
@@ -742,7 +748,7 @@ def test_custom_edge_label_processor():
                                 test_idx=test_idx,
                                 stats_type=None,
                                 mask_field_names=("tm", "vm", "tsm"))
-    split = clp.data_split(np.arange(20))
+    split = clp.data_split(data)
     assert "tm" in split
     assert "vm" in split
     assert "tsm" in split
@@ -757,6 +763,10 @@ def test_custom_edge_label_processor():
 
     # test generating labels on classification
     # there labels and _stats_type is frequency count
+    clp = CustomLabelProcessor(col_name="test_label", label_name="test", id_col="id",
+                               task_type="link_prediction",
+                               train_idx=train_idx, val_idx=val_idx, test_idx=test_idx,
+                               stats_type=None)
     input_data = {
         "test_label": np.random.randint(0, 5, (361,)),
         "id": data,


### PR DESCRIPTION
*Issue #, if available:*
#789 

*Description of changes:*
This is the first PR to implement #789. We need to allow use to define train, validation and test mask names themselves.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
