### PR TITLE
[Refactor] Regression, LP, and PerEtypeLP evaluators

### DIFF
--- a/docs/source/api/graphstorm.eval.rst
+++ b/docs/source/api/graphstorm.eval.rst
@@ -23,7 +23,7 @@ Base Evaluators
 
     GSgnnBaseEvaluator
     GSgnnPredictionEvalInterface
-    GSgnnLPMrrEvalInterface
+    GSgnnLPRankingEvalInterface
 
 Evaluators
 -----------
@@ -35,5 +35,5 @@ Evaluators
 
     GSgnnClassificationEvaluator
     GSgnnRegressionEvaluator
-    GSgnnLPEvaluator
+    GSgnnMrrLPEvaluator
     GSgnnPerEtypeMrrLPEvaluator

--- a/docs/source/api/graphstorm.eval.rst
+++ b/docs/source/api/graphstorm.eval.rst
@@ -7,8 +7,9 @@ graphstorm.eval
     Learning (GML) tasks.
 
     If users want to implement customized evaluators or evaluation methods, a best practice is to
-    extend base evaluators, i.e., the ``GSgnnInstanceEvaluator`` class for node or edge prediction
-    tasks, and ``GSgnnLPEvaluator`` for link prediction tasks, and then implement the abstract methods.
+    extend the base evaluator, i.e., the ``GSgnnBaseEvaluator``, and the corresponding evaluation
+    interfaces, e.g., ``GSgnnPredictionEvalInterface``` for prediction tasks, and
+    ``GSgnnLPMrrEvalInterface`` for link prediction tasks, and then implement the abstract methods.
 
 .. currentmodule:: graphstorm.eval
 
@@ -20,8 +21,9 @@ Base Evaluators
     :nosignatures:
     :template: evaltemplate.rst
 
-    GSgnnInstanceEvaluator
-    GSgnnLPEvaluator
+    GSgnnBaseEvaluator
+    GSgnnPredictionEvalInterface
+    GSgnnLPMrrEvalInterface
 
 Evaluators
 -----------
@@ -31,8 +33,7 @@ Evaluators
     :nosignatures:
     :template: evaltemplate.rst
 
-    GSgnnLPEvaluator
-    GSgnnMrrLPEvaluator
-    GSgnnPerEtypeMrrLPEvaluator
     GSgnnClassificationEvaluator
     GSgnnRegressionEvaluator
+    GSgnnLPEvaluator
+    GSgnnPerEtypeMrrLPEvaluator

--- a/docs/source/api/graphstorm.eval.rst
+++ b/docs/source/api/graphstorm.eval.rst
@@ -9,7 +9,7 @@ graphstorm.eval
     If users want to implement customized evaluators or evaluation methods, a best practice is to
     extend the base evaluator, i.e., the ``GSgnnBaseEvaluator``, and the corresponding evaluation
     interfaces, e.g., ``GSgnnPredictionEvalInterface``` for prediction tasks, and
-    ``GSgnnLPMrrEvalInterface`` for link prediction tasks, and then implement the abstract methods.
+    ``GSgnnLPRankingEvalInterface`` for link prediction tasks, and then implement the abstract methods.
 
 .. currentmodule:: graphstorm.eval
 

--- a/examples/peft_llm_gnn/main_lp.py
+++ b/examples/peft_llm_gnn/main_lp.py
@@ -4,7 +4,7 @@ import graphstorm as gs
 from graphstorm.config import get_argument_parser
 from graphstorm.config import GSConfig
 from graphstorm.dataloading import GSgnnLinkPredictionDataLoader, GSgnnLinkPredictionTestDataLoader
-from graphstorm.eval import GSgnnMrrLPEvaluator
+from graphstorm.eval import GSgnnLPEvaluator
 from graphstorm.dataloading import GSgnnLPTrainData
 from graphstorm.utils import get_device
 from graphstorm.inference import GSgnnLinkPredictionInferrer
@@ -54,14 +54,12 @@ def main(config_args):
     trainer.setup_device(device=get_device())
 
     # set evaluator
-    evaluator = GSgnnMrrLPEvaluator(config.eval_frequency,
-        train_data,
-        config.num_negative_edges_eval,
-        config.lp_decoder_type,
-        config.use_early_stop,
-        config.early_stop_burnin_rounds,
-        config.early_stop_rounds,
-        config.early_stop_strategy
+    evaluator = GSgnnLPEvaluator(
+        eval_frequency=config.eval_frequency,
+        use_early_stop=config.use_early_stop,
+        early_stop_burnin_rounds=config.early_stop_burnin_rounds,
+        early_stop_rounds=config.early_stop_rounds,
+        early_stop_strategy=config.early_stop_strategy
     )
     # disbale validation for efficiency
     # trainer.setup_evaluator(evaluator)

--- a/examples/peft_llm_gnn/main_lp.py
+++ b/examples/peft_llm_gnn/main_lp.py
@@ -4,7 +4,7 @@ import graphstorm as gs
 from graphstorm.config import get_argument_parser
 from graphstorm.config import GSConfig
 from graphstorm.dataloading import GSgnnLinkPredictionDataLoader, GSgnnLinkPredictionTestDataLoader
-from graphstorm.eval import GSgnnLPEvaluator
+from graphstorm.eval import GSgnnMrrLPEvaluator
 from graphstorm.dataloading import GSgnnLPTrainData
 from graphstorm.utils import get_device
 from graphstorm.inference import GSgnnLinkPredictionInferrer
@@ -54,7 +54,7 @@ def main(config_args):
     trainer.setup_device(device=get_device())
 
     # set evaluator
-    evaluator = GSgnnLPEvaluator(
+    evaluator = GSgnnMrrLPEvaluator(
         eval_frequency=config.eval_frequency,
         use_early_stop=config.use_early_stop,
         early_stop_burnin_rounds=config.early_stop_burnin_rounds,

--- a/python/graphstorm/config/argument.py
+++ b/python/graphstorm/config/argument.py
@@ -352,7 +352,7 @@ class GSConfig:
         _ = self.log_report_frequency
 
         _ = self.task_type
-        # For classification tasks.
+        # For classification/regression tasks.
         if self.task_type in [BUILTIN_TASK_NODE_CLASSIFICATION, BUILTIN_TASK_EDGE_CLASSIFICATION]:
             _ = self.label_field
             _ = self.num_classes
@@ -368,6 +368,7 @@ class GSConfig:
                               BUILTIN_TASK_LINK_PREDICTION] and is_train:
             _ = self.exclude_training_targets
             _ = self.reverse_edge_types_map
+        # For link prediction tasks.
         if self.task_type == BUILTIN_TASK_LINK_PREDICTION:
             _ = self.gamma
             _ = self.lp_decoder_type

--- a/python/graphstorm/eval/__init__.py
+++ b/python/graphstorm/eval/__init__.py
@@ -23,7 +23,7 @@ from .eval_func import SUPPORTED_CLASSIFICATION_METRICS
 from .eval_func import SUPPORTED_REGRESSION_METRICS
 from .eval_func import SUPPORTED_LINK_PREDICTION_METRICS
 
-from .evaluator import GSgnnLPEvaluator
+from .evaluator import GSgnnMrrLPEvaluator
 from .evaluator import GSgnnPerEtypeMrrLPEvaluator
 from .evaluator import GSgnnClassificationEvaluator
 from .evaluator import GSgnnRegressionEvaluator

--- a/python/graphstorm/eval/__init__.py
+++ b/python/graphstorm/eval/__init__.py
@@ -23,8 +23,7 @@ from .eval_func import SUPPORTED_CLASSIFICATION_METRICS
 from .eval_func import SUPPORTED_REGRESSION_METRICS
 from .eval_func import SUPPORTED_LINK_PREDICTION_METRICS
 
-from .evaluator import GSgnnInstanceEvaluator
 from .evaluator import GSgnnLPEvaluator
-from .evaluator import GSgnnMrrLPEvaluator, GSgnnPerEtypeMrrLPEvaluator
+from .evaluator import GSgnnPerEtypeMrrLPEvaluator
 from .evaluator import GSgnnClassificationEvaluator
 from .evaluator import GSgnnRegressionEvaluator

--- a/python/graphstorm/eval/eval_func.py
+++ b/python/graphstorm/eval/eval_func.py
@@ -141,6 +141,14 @@ class LinkPredictionMetrics:
         self.metric_comparator = {}
         self.metric_comparator["mrr"] = operator.le
 
+        # This is the operator used to measure each metric performance
+        self.metric_function = {}
+        self.metric_function["mrr"] = compute_mrr
+
+        # This is the operator used to measure each metric performance in evaluation
+        self.metric_eval_function = {}
+        self.metric_eval_function["mrr"] = compute_mrr
+
     def assert_supported_metric(self, metric):
         """ check if the given metric is supported.
         """
@@ -589,3 +597,19 @@ def compute_mae(pred, labels):
 
     diff = th.abs(pred.cpu() - labels.cpu())
     return th.mean(diff).cpu().item()
+
+def compute_mrr(ranking):
+    """ Get link prediction mrr metrics
+
+        Parameters
+        ----------
+        ranking:
+            ranking of each positive edge
+
+        Returns
+        -------
+        link prediction mrr metrics: tensor
+    """
+    logs = th.div(1.0, ranking)
+    metrics = th.tensor(th.div(th.sum(logs),len(logs)))
+    return metrics

--- a/python/graphstorm/eval/eval_func.py
+++ b/python/graphstorm/eval/eval_func.py
@@ -103,6 +103,12 @@ class RegressionMetrics:
         self.metric_function["mse"] = compute_mse
         self.metric_function["mae"] = compute_mae
 
+        # This is the operator used to measure each metric performance in evaluation
+        self.metric_eval_function = {}
+        self.metric_eval_function["rmse"] = compute_rmse
+        self.metric_eval_function["mse"] = compute_mse
+        self.metric_eval_function["mae"] = compute_mae
+
     def assert_supported_metric(self, metric):
         """ check if the given metric is supported.
         """

--- a/python/graphstorm/eval/evaluator.py
+++ b/python/graphstorm/eval/evaluator.py
@@ -26,7 +26,7 @@ from ..config.config import (EARLY_STOP_AVERAGE_INCREASE_STRATEGY,
                              EARLY_STOP_CONSECUTIVE_INCREASE_STRATEGY,
                              LINK_PREDICTION_MAJOR_EVAL_ETYPE_ALL)
 from ..utils import get_rank, get_world_size, barrier
-from .utils import gen_mrr_score
+
 
 def early_stop_avg_increase_judge(val_score, val_perf_list, comparator):
     """

--- a/python/graphstorm/eval/evaluator.py
+++ b/python/graphstorm/eval/evaluator.py
@@ -165,7 +165,7 @@ class GSgnnPredictionEvalInterface():
 
 
 class GSgnnLPRankingEvalInterface():
-    """ Interface for Link Prediction evaluation function using ranking method
+    """ Interface for Link Prediction evaluation function using ranking methods
 
     The interface set the two abstract methods for Link Prediction classes that use ranking
     method to compute evaluation metrics, such as "mrr" (Mean Reciprocal Rank).
@@ -187,9 +187,9 @@ class GSgnnLPRankingEvalInterface():
 
         Parameters
         ----------
-        val_scores: dict of tensors
+        val_rankings: dict of tensors
             The rankings of validation edges for each edge type in format of {etype: ranking}.
-        test_scores: dict of tensors
+        test_rankings: dict of tensors
             The rankings of testing edges for each edge type in format of {etype: ranking}.
         total_iters: int
             The current interation number.

--- a/python/graphstorm/eval/evaluator.py
+++ b/python/graphstorm/eval/evaluator.py
@@ -15,7 +15,7 @@
 
     Evaluator for different tasks.
 """
-import logging
+
 import abc
 from statistics import mean
 import torch as th

--- a/python/graphstorm/eval/evaluator.py
+++ b/python/graphstorm/eval/evaluator.py
@@ -164,10 +164,11 @@ class GSgnnPredictionEvalInterface():
         """
 
 
-class GSgnnLPEvalInterface():
-    """ Interface for Link Prediction evaluation functions
+class GSgnnLPMrrEvalInterface():
+    """ Interface for Link Prediction evaluation function using "mrr"
 
-    The interface set the two abstract methods for Link Prediction classes.
+    The interface set the two abstract methods for Link Prediction classes that use "mrr"
+    as the evaluation metric.
     """
 
     @abc.abstractmethod
@@ -227,7 +228,7 @@ class GSgnnBaseEvaluator():
     ----------
     eval_frequency: int
         The frequency (# of iterations) of doing evaluation.
-    eval_metric: list of string
+    eval_metric_list: list of string
         Evaluation metric used during evaluation.
     use_early_stop: bool
         Set true to use early stop.
@@ -239,7 +240,7 @@ class GSgnnBaseEvaluator():
         The early stop strategy. GraphStorm supports two strategies:
         1) consecutive_increase and 2) average_increase.
     """
-    def __init__(self, eval_frequency, eval_metric,
+    def __init__(self, eval_frequency, eval_metric_list,
                  use_early_stop=False,
                  early_stop_burnin_rounds=0,
                  early_stop_rounds=3,
@@ -253,8 +254,8 @@ class GSgnnBaseEvaluator():
         self._best_iter = None
         self.metrics_obj = None # Evaluation metrics obj
 
-        self._metric = eval_metric
-        assert len(self.metric) > 0, "At least one metric must be defined, but got 0."
+        self._metric_list = eval_metric_list
+        assert len(self.metric_list) > 0, "At least one metric must be defined, but got 0."
         self._eval_frequency = eval_frequency
         self._do_early_stop = use_early_stop
         if self._do_early_stop:
@@ -344,7 +345,7 @@ class GSgnnBaseEvaluator():
             We treat the first metric in all evaluation metrics as the major metric.
         """
         assert self.metrics_obj is not None, "Evaluation metrics object should not be None."
-        metric = self.metric[0]
+        metric = self.metric_list[0]
         return self.metrics_obj.metric_comparator[metric]
 
     def get_val_score_rank(self, val_score):
@@ -368,10 +369,10 @@ class GSgnnBaseEvaluator():
         return rank
 
     @property
-    def metric(self):
+    def metric_list(self):
         """ evaluation metrics
         """
-        return self._metric
+        return self._metric_list
 
     @property
     def best_val_score(self):
@@ -422,10 +423,11 @@ class GSgnnBaseEvaluator():
         """
         return self._val_perf_rank_list
 
+
 class GSgnnClassificationEvaluator(GSgnnBaseEvaluator, GSgnnPredictionEvalInterface):
     """Classification evaluator
 
-    GS built-in evaluator for classificatioin task. It uses "accuracy" as the default eval metric,
+    GS built-in evaluator for classification task. It uses "accuracy" as the default eval metric,
     and sets the multilabel to be False.
 
     It replacees the ``GSgnnAccEvaluator`` since v0.3.
@@ -434,7 +436,7 @@ class GSgnnClassificationEvaluator(GSgnnBaseEvaluator, GSgnnPredictionEvalInterf
     ----------
     eval_frequency: int
         The frequency (number of iterations) of doing evaluation.
-    eval_metric: list of string
+    eval_metric_list: list of string
         Evaluation metrics used during evaluation. Default: ["accuracy"].
     multilabel: bool
         If set to true, the task is a multi-label classification task. Default: False.
@@ -449,17 +451,17 @@ class GSgnnClassificationEvaluator(GSgnnBaseEvaluator, GSgnnPredictionEvalInterf
         1) consecutive_increase and 2) average_increase.
     """
     def __init__(self, eval_frequency,
-                 eval_metric=None,
+                 eval_metric_list=None,
                  multilabel=False,
                  use_early_stop=False,
                  early_stop_burnin_rounds=0,
                  early_stop_rounds=3,
                  early_stop_strategy=EARLY_STOP_AVERAGE_INCREASE_STRATEGY): # pylint: disable=unused-argument
         # set up default metric to be accuracy
-        if eval_metric is None:
-            eval_metric = ["accuracy"]
+        if eval_metric_list is None:
+            eval_metric_list = ["accuracy"]
         super(GSgnnClassificationEvaluator, self).__init__(eval_frequency,
-                                                           eval_metric,
+                                                           eval_metric_list,
                                                            use_early_stop,
                                                            early_stop_burnin_rounds,
                                                            early_stop_rounds,
@@ -470,7 +472,7 @@ class GSgnnClassificationEvaluator(GSgnnBaseEvaluator, GSgnnPredictionEvalInterf
         self._best_iter = {}
         self.metrics_obj = ClassificationMetrics(multilabel=self._multilabel)
 
-        for metric in self.metric:
+        for metric in self.metric_list:
             self.metrics_obj.assert_supported_metric(metric=metric)
             self._best_val_score[metric] = self.metrics_obj.init_best_metric(metric=metric)
             self._best_test_score[metric] = self.metrics_obj.init_best_metric(metric=metric)
@@ -512,7 +514,7 @@ class GSgnnClassificationEvaluator(GSgnnBaseEvaluator, GSgnnPredictionEvalInterf
             val_score = self.compute_score(val_pred, val_labels, train=False)
             test_score = self.compute_score(test_pred, test_labels, train=False)
 
-        for metric in self.metric:
+        for metric in self.metric_list:
             # be careful whether > or < it might change per metric.
             if self.metrics_obj.metric_comparator[metric](
                     self._best_val_score[metric], val_score[metric]):
@@ -538,16 +540,16 @@ class GSgnnClassificationEvaluator(GSgnnBaseEvaluator, GSgnnPredictionEvalInterf
             Evaluation metric values: dict
         """
         results = {}
-        for metric in self.metric:
+        for metric in self.metric_list:
             if pred is not None and labels is not None:
                 if train:
                     # training expects always a single number to be
-                    # returned and has a different (potentially) function
+                    # returned and has a different (potentially) evalution function
                     results[metric] = self.metrics_obj.metric_function[metric](pred, labels)
                 else:
                     # validation or testing may have a different
                     # evaluation function, in our case the evaluation code
-                    # may return a dictionary with the metric values for each label
+                    # may return a dictionary with the metric values for each metric
                     results[metric] = self.metrics_obj.metric_eval_function[metric](pred, labels)
             else:
                 # if the pred is None or the labels is None the metric can not me computed
@@ -560,259 +562,18 @@ class GSgnnClassificationEvaluator(GSgnnBaseEvaluator, GSgnnPredictionEvalInterf
         """
         return self._multilabel
 
-# TODO(xiangsx): combine GSgnnInstanceEvaluator and GSgnnLPEvaluator
-class GSgnnInstanceEvaluator():
-    """ Base class for user defined Classification/Regression evaluators.
 
-    Parameters
-    ----------
-    eval_frequency: int
-        The frequency (# of iterations) of doing evaluation.
-    eval_metric: list of string
-        Evaluation metric used during evaluation.
-    use_early_stop: bool
-        Set true to use early stop.
-    early_stop_burnin_rounds: int
-        Burn-in rounds before start checking for the early stop condition.
-    early_stop_rounds: int
-        The number of rounds for validation scores used to decide early stop.
-    early_stop_strategy: str
-        The early stop strategy. GraphStorm supports two strategies:
-        1) consecutive_increase and 2) average_increase.
-    """
-    def __init__(self, eval_frequency, eval_metric,
-                 use_early_stop=False,
-                 early_stop_burnin_rounds=0,
-                 early_stop_rounds=3,
-                 early_stop_strategy=EARLY_STOP_AVERAGE_INCREASE_STRATEGY):
-        # nodes whose embeddings are used during evaluation
-        # if None all nodes are used.
-        self._history = []
-        self.tracker = None
-        self._best_val_score = None
-        self._best_test_score = None
-        self._best_iter = None
-        self.metrics_obj = None # Evaluation metrics obj
+class GSgnnRegressionEvaluator(GSgnnBaseEvaluator, GSgnnPredictionEvalInterface):
+    """ Regression Evaluator.
 
-        self._metric = eval_metric
-        assert len(self.metric) > 0, \
-            "At least one metric must be defined"
-        self._eval_frequency = eval_frequency
-        self._do_early_stop = use_early_stop
-        if self._do_early_stop:
-            self._early_stop_burnin_rounds = early_stop_burnin_rounds
-            self._num_early_stop_calls = 0
-            self._early_stop_rounds = early_stop_rounds
-            self._early_stop_strategy = early_stop_strategy
-            self._val_perf_list = []
-        # add this list to store
-        self._val_perf_rank_list = []
-
-    def setup_task_tracker(self, task_tracker):
-        """ Setup evaluation tracker
-
-            Parameters
-            ----------
-            task_tracker:
-                a task tracker
-        """
-        self.tracker = task_tracker
-
-    @abc.abstractmethod
-    def evaluate(self, val_pred, test_pred, val_labels, test_labels, total_iters):
-        """
-        GSgnnLinkPredictionModel.fit() will call this function to do user defined evalution.
-
-        Parameters
-        ----------
-        val_pred : tensor
-            The tensor stores the prediction results on the validation nodes.
-        test_pred : tensor
-            The tensor stores the prediction results on the test nodes.
-        val_labels : tensor
-            The tensor stores the labels of the validation nodes.
-        test_labels : tensor
-            The tensor stores the labels of the test nodes.
-        total_iters: int
-            The current interation number.
-
-        Returns
-        -----------
-        eval_score: float
-            Validation score
-        test_score: float
-            Test score
-        """
-
-    def do_eval(self, total_iters, epoch_end=False):
-        """ Decide whether to do the evaluation in current iteration or epoch
-
-            Parameters
-            ----------
-            total_iters: int
-                The total number of iterations has been taken.
-            epoch_end: bool
-                Whether it is the end of an epoch
-
-            Returns
-            -------
-            Whether do evaluation: bool
-        """
-        if epoch_end:
-            return True
-        elif self._eval_frequency != 0 and total_iters % self._eval_frequency == 0:
-            return True
-        return False
-
-
-    @abc.abstractmethod
-    def compute_score(self, pred, labels):
-        """ Compute evaluation score
-
-            Parameters
-            ----------
-            pred:
-                Rediction result
-            labels:
-                Label
-        """
-
-    def print_history(self):
-        """ Print history eval info
-        """
-        for val_score, test_score in self._history:
-            logging.info("val %s: %.3f, test %s: %.3f",
-                         self.metric, val_score, self.metric, test_score)
-
-    def do_early_stop(self, val_score):
-        """ Decide whether to stop the training
-
-            Parameters
-            ----------
-            val_score: float
-                Evaluation score
-        """
-        if self._do_early_stop is False:
-            return False
-
-        assert len(val_score) == 1, \
-            f"valudation score should be a signle key value pair but got {val_score}"
-        self._num_early_stop_calls += 1
-        # Not enough existing validation scores
-        if self._num_early_stop_calls <= self._early_stop_burnin_rounds:
-            return False
-
-        val_score = list(val_score.values())[0]
-        # Not enough validation scores to make early stop decision
-        if len(self._val_perf_list) < self._early_stop_rounds:
-            self._val_perf_list.append(val_score)
-            return False
-
-        # early stop criteria: if the average evaluation value
-        # does not improve in the last N evaluation iterations
-        if self._early_stop_strategy == EARLY_STOP_AVERAGE_INCREASE_STRATEGY:
-            early_stop = early_stop_avg_increase_judge(val_score,
-                                                       self._val_perf_list,
-                                                       self.get_metric_comparator())
-        elif self._early_stop_strategy == EARLY_STOP_CONSECUTIVE_INCREASE_STRATEGY:
-            early_stop = early_stop_cons_increase_judge(val_score,
-                                                        self._val_perf_list,
-                                                        self.get_metric_comparator())
-        else:
-            return False
-
-        self._val_perf_list.pop(0)
-        self._val_perf_list.append(val_score)
-
-        return early_stop
-
-    def get_metric_comparator(self):
-        """ Return the comparator of the major eval metric.
-
-            We treat the first metric in all evaluation metrics as the major metric.
-        """
-        assert self.metrics_obj is not None, \
-            "Evaluation metrics object should not be None"
-        metric = self.metric[0]
-        return self.metrics_obj.metric_comparator[metric]
-
-    def get_val_score_rank(self, val_score):
-        """
-        Get the rank of the given validation score by comparing its values to the existing value
-        list.
-
-        Parameters
-        ----------
-        val_score: dict
-            A dictionary whose key is the metric and the value is a score from evaluator's
-            validation computation.
-        """
-        val_score = list(val_score.values())[0]
-
-        rank = get_val_score_rank(val_score,
-                                  self._val_perf_rank_list,
-                                  self.get_metric_comparator())
-        # after compare, append the score into existing list
-        self._val_perf_rank_list.append(val_score)
-        return rank
-
-    @property
-    def metric(self):
-        """ evaluation metrics
-        """
-        return self._metric
-
-    @property
-    def best_val_score(self):
-        """ Best validation score
-        """
-        return self._best_val_score
-
-    @property
-    def best_test_score(self):
-        """ Best test score
-        """
-        return self._best_test_score
-
-    @property
-    def best_iter_num(self):
-        """ Best iteration number
-        """
-        return self._best_iter
-
-    @property
-    def history(self):
-        """ Evaluation history
-
-            Returns
-            -------
-            A list of evaluation history in training. The detailed contents of the list rely
-            on specific Evaluators. For example, ``GSgnnRegressionEvaluator`` and
-            ``GSgnnAccEvaluator`` add a tuple of validation and testing score as one list element.
-        """
-        return self._history
-
-    @property
-    def eval_frequency(self):
-        """ Evaluation frequency
-        """
-        return self._eval_frequency
-
-    @property
-    def task_tracker(self):
-        """ Task tracker of this evaluator
-        """
-        return self.tracker
-
-class GSgnnRegressionEvaluator(GSgnnInstanceEvaluator):
-    """ The class for user defined evaluator.
+    GS built-in evaluator for regression task. It uses "rmse" as the default eval metric.
 
     Parameters
     ----------
     eval_frequency: int
         The frequency (number of iterations) of doing evaluation.
-    eval_metric: list of string
-        Evaluation metric used during evaluation.
+    eval_metric_list: list of string
+        Evaluation metric used during evaluation. Default: ["rmse"].
     use_early_stop: bool
         Set true to use early stop.
     early_stop_burnin_rounds: int
@@ -824,20 +585,23 @@ class GSgnnRegressionEvaluator(GSgnnInstanceEvaluator):
         1) consecutive_increase and 2) average_increase.
     """
     def __init__(self, eval_frequency,
-                 eval_metric,
+                 eval_metric_list=None,
                  use_early_stop=False,
                  early_stop_burnin_rounds=0,
                  early_stop_rounds=3,
                  early_stop_strategy=EARLY_STOP_AVERAGE_INCREASE_STRATEGY):
+        # set up default metric to be mse
+        if eval_metric_list is None:
+            eval_metric_list = ["rmse"]
         super(GSgnnRegressionEvaluator, self).__init__(eval_frequency,
-            eval_metric, use_early_stop, early_stop_burnin_rounds,
+            eval_metric_list, use_early_stop, early_stop_burnin_rounds,
             early_stop_rounds, early_stop_strategy)
         self._best_val_score = {}
         self._best_test_score = {}
         self._best_iter = {}
         self.metrics_obj = RegressionMetrics()
 
-        for metric in self.metric:
+        for metric in self.metric_list:
             self.metrics_obj.assert_supported_metric(metric=metric)
             self._best_val_score[metric] = self.metrics_obj.init_best_metric(metric=metric)
             self._best_test_score[metric] = self.metrics_obj.init_best_metric(metric=metric)
@@ -879,7 +643,7 @@ class GSgnnRegressionEvaluator(GSgnnInstanceEvaluator):
             val_score = self.compute_score(val_pred, val_labels)
             test_score = self.compute_score(test_pred, test_labels)
 
-        for metric in self.metric:
+        for metric in self.metric_list:
             # be careful whether > or < it might change per metric.
             if self.metrics_obj.metric_comparator[metric](self._best_val_score[metric],
                                                           val_score[metric]):
@@ -890,7 +654,7 @@ class GSgnnRegressionEvaluator(GSgnnInstanceEvaluator):
 
         return val_score, test_score
 
-    def compute_score(self, pred, labels):
+    def compute_score(self, pred, labels, train=True):
         """ Compute evaluation score
 
             Parameters
@@ -905,27 +669,46 @@ class GSgnnRegressionEvaluator(GSgnnInstanceEvaluator):
             Evaluation metric values: dict
         """
         scores = {}
-        if pred is None or labels is None:
-            for metric in self.metric:
+        for metric in self.metric_list:
+            if pred is not None and labels is not None:
+                pred = th.squeeze(pred)
+                labels = th.squeeze(labels)
+                pred = pred.to(th.float32)
+                labels = labels.to(th.float32)
+
+                if train:
+                    # training expects always a single number to be
+                    # returned and has a different (potentially) evluation function
+                    scores[metric] = self.metrics_obj.metric_function[metric](pred, labels)
+                else:
+                    # validation or testing may have a different
+                    # evaluation function, in our case the evaluation code
+                    # may return a dictionary with the metric values for each metric
+                    scores[metric] = self.metrics_obj.metric_eval_function[metric](pred, labels)
+            else:
+                # if the pred is None or the labels is None the metric can not me computed
                 scores[metric] = "N/A"
-        else: # pred is not None and labels is not None
-            pred = th.squeeze(pred)
-            labels = th.squeeze(labels)
-            pred = pred.to(th.float32)
-            labels = labels.to(th.float32)
-            for metric in self.metric:
-                scores[metric] = self.metrics_obj.metric_function[metric](pred, labels)
+
         return scores
 
-class GSgnnLPEvaluator():
-    """ Base class for user defined Link Prediction evaluator.
+
+class GSgnnLPEvaluator(GSgnnBaseEvaluator, GSgnnLPMrrEvalInterface):
+    """ Link Prediction Evaluator.
+
+    GS built-in evaluator for Link Prediction task. It uses "mrr" as the default eval metric,
+    which therefore implements the `GSgnnLPMrrEvalInterface`.
+    
+    To create a customized LP evaluator that use evaluation metric other than "mrr", users might
+    need to 1) define a new evaluation interface if the evaluation method requires different input
+    arguments; 2) inherite the new evaluation interface in a customized LP evaluator; 3) define
+    a customized LP trainer/inferrer to call the customized LP evaluator.
 
     Parameters
     ----------
     eval_frequency: int
         The frequency (number of iterations) of doing evaluation.
-    eval_metric: list of string
-        Evaluation metric used during evaluation.
+    eval_metric_list: list of string
+        Evaluation metric used during evaluation. Default: ['mrr']
     use_early_stop: bool
         Set true to use early stop.
     early_stop_burnin_rounds: int
@@ -936,255 +719,70 @@ class GSgnnLPEvaluator():
         The early stop strategy. GraphStorm supports two strategies:
         1) consecutive_increase and 2) average_increase.
     """
-    def __init__(self, eval_frequency, eval_metric,
+    def __init__(self, eval_frequency,
+                 eval_metric_list=None,
                  use_early_stop=False,
                  early_stop_burnin_rounds=0,
                  early_stop_rounds=3,
                  early_stop_strategy=EARLY_STOP_AVERAGE_INCREASE_STRATEGY):
-        # nodes whose embeddings are used during evaluation
-        # if None all nodes are used.
-        self._target_nidx = None
-        self.tracker = None
-        self._best_val_score = None
-        self._best_test_score = None
-        self._best_iter = None
-        self.metrics_obj = None # Evaluation metrics obj
-
-        self._metric = eval_metric
-        assert len(self.metric) > 0, "At least one metric must be defined"
-        self._eval_frequency = eval_frequency
-        self._do_early_stop = use_early_stop
-        if self._do_early_stop:
-            self._early_stop_burnin_rounds = early_stop_burnin_rounds
-            self._num_early_stop_calls = 0
-            self._early_stop_rounds = early_stop_rounds
-            self._early_stop_strategy = early_stop_strategy
-            self._val_perf_list = []
-        # add this list to store all of the performance rank of validation scores for pick top k
-        self._val_perf_rank_list = []
-
-    def setup_task_tracker(self, task_tracker):
-        """ Setup evaluation tracker
-
-            Parameters
-            ----------
-            task_tracker:
-                a task tracker
-        """
-        self.tracker = task_tracker
-
-    @abc.abstractmethod
-    def evaluate(self, val_scores, test_scores, total_iters):
-        """
-        GSgnnLinkPredictionModel.fit() will call this function to do user defined evalution.
-
-        Note: Make sure each trainer will get the same validation scores.
-        The early stop and model saving progress rely on certain scores.
-
-        Parameters
-        ----------
-        val_scores: dict of tensors
-            The rankings of validation edges for each edge type.
-        test_scores: dict of tensors
-            The rankings of testing edges for each edge type.
-        total_iters: int
-            The current interation number.
-
-        Returns
-        -----------
-        eval_score: float
-            Validation score
-        test_score: float
-            Test score
-        """
-
-    def do_eval(self, total_iters, epoch_end=False):
-        """ Decide whether to do the evaluation in current iteration or epoch
-
-            Parameters
-            ----------
-            epoch: int
-                The epoch number
-            total_iters: int
-                The total number of iterations has been taken.
-            epoch_end: bool
-                Whether it is the end of an epoch
-
-            Returns
-            -------
-            Whether do evaluation: bool
-        """
-        if epoch_end:
-            return True
-        elif self._eval_frequency != 0 and \
-            total_iters % self._eval_frequency == 0:
-            return True
-        return False
-
-    def do_early_stop(self, val_score):
-        """ Decide whether to stop the training
-
-            Parameters
-            ----------
-            val_score: float
-                Evaluation score
-        """
-        if self._do_early_stop is False:
-            return False
-
-        assert len(val_score) == 1, \
-            f"valudation score should be a signle key value pair but got {val_score}"
-        self._num_early_stop_calls += 1
-        # Not enough existing validation scores
-        if self._num_early_stop_calls <= self._early_stop_burnin_rounds:
-            return False
-
-        val_score = list(val_score.values())[0]
-        # Not enough validation scores to make early stop decision
-        if len(self._val_perf_list) < self._early_stop_rounds:
-            self._val_perf_list.append(val_score)
-            return False
-
-        # early stop criteria: if the average evaluation value
-        # does not improve in the last N evaluation iterations
-        if self._early_stop_strategy == EARLY_STOP_AVERAGE_INCREASE_STRATEGY:
-            early_stop = early_stop_avg_increase_judge(val_score,
-                self._val_perf_list, self.get_metric_comparator())
-        elif self._early_stop_strategy == EARLY_STOP_CONSECUTIVE_INCREASE_STRATEGY:
-            early_stop = early_stop_cons_increase_judge(val_score,
-                self._val_perf_list, self.get_metric_comparator())
-
-        self._val_perf_list.pop(0)
-        self._val_perf_list.append(val_score)
-
-        return early_stop
-
-    def get_metric_comparator(self):
-        """ Return the comparator of the major eval metric.
-
-            We treat the first metric in all evaluation metrics as the major metric.
-        """
-
-        assert self.metrics_obj is not None, \
-            "Evaluation metrics object should not be None"
-        metric = self.metric[0]
-        return self.metrics_obj.metric_comparator[metric]
-
-    def get_val_score_rank(self, val_score):
-        """
-        Get the rank of the given val score by comparing its values to the existing value list.
-
-        Parameters
-        ----------
-        val_score: dict
-            A dictionary whose key is the metric and the value is a score from evaluator's
-            validation computation.
-        """
-        val_score = list(val_score.values())[0]
-
-        rank = get_val_score_rank(val_score,
-                                  self._val_perf_rank_list,
-                                  self.get_metric_comparator())
-        # after compare, append the score into existing list
-        self._val_perf_rank_list.append(val_score)
-        return rank
-
-    @property
-    def target_nidx(self):
-        """ target_nidx
-        """
-        return self._target_nidx
-
-    @property
-    def metric(self):
-        """ evaluation metrics
-        """
-        return self._metric
-
-    @property
-    def best_val_score(self):
-        """ Best validation score
-        """
-        return self._best_val_score
-
-    @property
-    def best_test_score(self):
-        """ Best test score
-        """
-        return self._best_test_score
-
-    @property
-    def best_iter_num(self):
-        """ Best iteration number
-        """
-        return self._best_iter
-
-    @property
-    def val_perf_rank_list(self):
-        """ validation performance rank list
-        """
-        return self._val_perf_rank_list
-
-    @property
-    def eval_frequency(self):
-        """ Evaluation frequency.
-        """
-        return self._eval_frequency
-
-    @property
-    def task_tracker(self):
-        """ Task tracker of this evaluator
-        """
-        return self.tracker
-
-class GSgnnMrrLPEvaluator(GSgnnLPEvaluator):
-    """ The class for link prediction evaluation using Mrr metric.
-
-    Parameters
-    ----------
-    eval_frequency: int
-        The frequency (# of iterations) of doing evaluation.
-    data: GSgnnEdgeData
-        The processed dataset
-    num_negative_edges_eval: int
-        Number of negative edges sampled for each positive edge in evalation.
-    lp_decoder_type: str
-        Link prediction decoder type.
-    use_early_stop: bool
-        Set true to use early stop.
-    early_stop_burnin_rounds: int
-        Burn-in rounds before start checking for the early stop condition.
-    early_stop_rounds: int
-        The number of rounds for validation scores used to decide early stop.
-    early_stop_strategy: str
-        The early stop strategy. GraphStorm supports two strategies:
-        1) consecutive_increase and 2) average_increase.
-    """
-    def __init__(self, eval_frequency, data,
-                 num_negative_edges_eval, lp_decoder_type,
-                 use_early_stop=False,
-                 early_stop_burnin_rounds=0,
-                 early_stop_rounds=3,
-                 early_stop_strategy=EARLY_STOP_AVERAGE_INCREASE_STRATEGY):
-        eval_metric = ["mrr"]
-        super(GSgnnMrrLPEvaluator, self).__init__(eval_frequency,
-            eval_metric, use_early_stop, early_stop_burnin_rounds,
+        if eval_metric_list is None:
+            eval_metric_list = ["mrr"]
+        super(GSgnnLPEvaluator, self).__init__(eval_frequency,
+            eval_metric_list, use_early_stop, early_stop_burnin_rounds,
             early_stop_rounds, early_stop_strategy)
-        self.train_idxs = data.train_idxs
-        self.val_idxs = data.val_idxs
-        self.test_idxs = data.test_idxs
-        self.num_negative_edges_eval = num_negative_edges_eval
-        self.lp_decoder_type = lp_decoder_type
-
         self.metrics_obj = LinkPredictionMetrics()
 
         self._best_val_score = {}
         self._best_test_score = {}
         self._best_iter = {}
-        for metric in self.metric:
+        for metric in self.metric_list:
             self._best_val_score[metric] = self.metrics_obj.init_best_metric(metric=metric)
             self._best_test_score[metric] = self.metrics_obj.init_best_metric(metric=metric)
             self._best_iter[metric] = 0
+
+    def evaluate(self, val_scores, test_scores, total_iters):
+        """ `GSgnnLinkPredictionTrainer` and `GSgnnLinkPredictionInferrer` will call this function
+        to compute validation and test mrr scores.
+
+        Parameters
+        ----------
+        val_scores: dict of tensors
+            Rankings of positive scores of validation edges for each edge type.
+        test_scores: dict of tensors
+            Rankings of positive scores of test edges for each edge type..
+        total_iters: int
+            The current interation number.
+
+        Returns
+        -----------
+        val_mrr: float
+            Validation mrr score
+        test_mrr: float
+            Test mrr score
+        """
+        with th.no_grad():
+            if test_scores is not None:
+                test_score = self.compute_score(test_scores)
+            else:
+                for metric in self.metric_list:
+                    test_score = {metric: "N/A"} # Dummy
+
+            if val_scores is not None:
+                val_score = self.compute_score(val_scores)
+
+                if get_rank() == 0:
+                    for metric in self.metric_list:
+                        # be careful whether > or < it might change per metric.
+                        if self.metrics_obj.metric_comparator[metric](
+                            self._best_val_score[metric], val_score[metric]):
+                            self._best_val_score[metric] = val_score[metric]
+                            self._best_test_score[metric] = test_score[metric]
+                            self._best_iter[metric] = total_iters
+            else:
+                for metric in self.metric_list:
+                    val_score = {metric: "N/A"} # Dummy
+
+        return val_score, test_score
 
     def compute_score(self, rankings, train=False): # pylint:disable=unused-argument
         """ Compute evaluation score
@@ -1222,49 +820,8 @@ class GSgnnMrrLPEvaluator(GSgnnLPEvaluator):
             return_metrics[metric] = return_metric.item()
         return return_metrics
 
-    def evaluate(self, val_scores, test_scores, total_iters):
-        """ GSgnnLinkPredictionModel.fit() will call this function to do user defined evalution.
 
-        Parameters
-        ----------
-        val_scores: dict of tensors
-            Rankings of positive scores of validation edges for each edge type.
-        test_scores: dict of tensors
-            Rankings of positive scores of test edges for each edge type..
-        total_iters: int
-            The current interation number.
-
-        Returns
-        -----------
-        val_mrr: float
-            Validation mrr
-        test_mrr: float
-            Test mrr
-        """
-        with th.no_grad():
-            if test_scores is not None:
-                test_score = self.compute_score(test_scores)
-            else:
-                test_score = {"mrr": "N/A"} # Dummy
-
-            if val_scores is not None:
-                val_score = self.compute_score(val_scores)
-
-                if get_rank() == 0:
-                    for metric in self.metric:
-                        # be careful whether > or < it might change per metric.
-                        if self.metrics_obj.metric_comparator[metric](
-                            self._best_val_score[metric], val_score[metric]):
-                            self._best_val_score[metric] = val_score[metric]
-                            self._best_test_score[metric] = test_score[metric]
-                            self._best_iter[metric] = total_iters
-            else:
-                val_score = {"mrr": "N/A"} # Dummy
-
-        return val_score, test_score
-
-
-class GSgnnPerEtypeMrrLPEvaluator(GSgnnMrrLPEvaluator):
+class GSgnnPerEtypeMrrLPEvaluator(GSgnnBaseEvaluator, GSgnnLPMrrEvalInterface):
     """ The class for link prediction evaluation using Mrr metric and
         return a Per etype mrr score.
 
@@ -1272,12 +829,8 @@ class GSgnnPerEtypeMrrLPEvaluator(GSgnnMrrLPEvaluator):
     ----------
     eval_frequency: int
         The frequency (# of iterations) of doing evaluation.
-    data: GSgnnEdgeData
-        The processed dataset
-    num_negative_edges_eval: int
-        Number of negative edges sampled for each positive edge in evalation.
-    lp_decoder_type: str
-        Link prediction decoder type.
+    eval_metric_list: list of string
+        Evaluation metric used during evaluation. Default: ['mrr']
     major_etype: tuple
         Canonical etype used for selecting the best model. If None, use the general mrr.
     use_early_stop: bool
@@ -1290,19 +843,31 @@ class GSgnnPerEtypeMrrLPEvaluator(GSgnnMrrLPEvaluator):
         The early stop strategy. GraphStorm supports two strategies:
         1) consecutive_increase and 2) average_increase.
     """
-    def __init__(self, eval_frequency, data,
-                 num_negative_edges_eval, lp_decoder_type,
+    def __init__(self, eval_frequency,
+                 eval_metric_list=None,
                  major_etype = LINK_PREDICTION_MAJOR_EVAL_ETYPE_ALL,
                  use_early_stop=False,
                  early_stop_burnin_rounds=0,
                  early_stop_rounds=3,
                  early_stop_strategy=EARLY_STOP_AVERAGE_INCREASE_STRATEGY):
-        self.major_etype = major_etype
+        if eval_metric_list is None:
+            eval_metric_list = ["mrr"]
         super(GSgnnPerEtypeMrrLPEvaluator, self).__init__(eval_frequency,
-            data, num_negative_edges_eval, lp_decoder_type,
-            use_early_stop, early_stop_burnin_rounds,
-            early_stop_rounds, early_stop_strategy)
+                                                          eval_metric_list,
+                                                          use_early_stop,
+                                                          early_stop_burnin_rounds,
+                                                          early_stop_rounds,
+                                                          early_stop_strategy)
+        self.major_etype = major_etype
+        self.metrics_obj = LinkPredictionMetrics()
 
+        self._best_val_score = {}
+        self._best_test_score = {}
+        self._best_iter = {}
+        for metric in self.metric_list:
+            self._best_val_score[metric] = self.metrics_obj.init_best_metric(metric=metric)
+            self._best_test_score[metric] = self.metrics_obj.init_best_metric(metric=metric)
+            self._best_iter[metric] = 0
 
     def compute_score(self, rankings, train=False): # pylint:disable=unused-argument
         """ Compute evaluation score
@@ -1353,7 +918,8 @@ class GSgnnPerEtypeMrrLPEvaluator(GSgnnMrrLPEvaluator):
         return major_score
 
     def evaluate(self, val_scores, test_scores, total_iters):
-        """ GSgnnLinkPredictionModel.fit() will call this function to do user defined evalution.
+        """ `GSgnnLinkPredictionTrainer` and `GSgnnLinkPredictionInferrer` will call this function
+        to compute validation and test mrr scores.
 
         Parameters
         ----------
@@ -1381,7 +947,7 @@ class GSgnnPerEtypeMrrLPEvaluator(GSgnnMrrLPEvaluator):
                 val_score = self.compute_score(val_scores)
 
                 if get_rank() == 0:
-                    for metric in self.metric:
+                    for metric in self.metric_list:
                         # be careful whether > or < it might change per metric.
                         major_val_score = self._get_major_score(val_score[metric])
                         major_test_score = self._get_major_score(test_score[metric])

--- a/python/graphstorm/eval/evaluator.py
+++ b/python/graphstorm/eval/evaluator.py
@@ -928,9 +928,9 @@ class GSgnnPerEtypeMrrLPEvaluator(GSgnnBaseEvaluator, GSgnnLPRankingEvalInterfac
 
         Parameters
         ----------
-        val_scores: dict of tensors
+        val_rankings: dict of tensors
             Rankings of positive scores of validation edges for each edge type.
-        test_scores: dict of tensors
+        test_rankings: dict of tensors
             Rankings of positive scores of test edges for each edge type..
         total_iters: int
             The current interation number.

--- a/python/graphstorm/eval/evaluator.py
+++ b/python/graphstorm/eval/evaluator.py
@@ -759,9 +759,9 @@ class GSgnnMrrLPEvaluator(GSgnnBaseEvaluator, GSgnnLPRankingEvalInterface):
 
         Parameters
         ----------
-        val_scores: dict of tensors
+        val_rankings: dict of tensors
             Rankings of positive scores of validation edges for each edge type.
-        test_scores: dict of tensors
+        test_rankings: dict of tensors
             Rankings of positive scores of test edges for each edge type..
         total_iters: int
             The current interation number.

--- a/python/graphstorm/eval/evaluator.py
+++ b/python/graphstorm/eval/evaluator.py
@@ -462,12 +462,15 @@ class GSgnnClassificationEvaluator(GSgnnBaseEvaluator, GSgnnPredictionEvalInterf
         1) consecutive_increase and 2) average_increase.
     """
     def __init__(self, eval_frequency,
-                 eval_metric_list=["accuracy"],
+                 eval_metric_list=None,
                  multilabel=False,
                  use_early_stop=False,
                  early_stop_burnin_rounds=0,
                  early_stop_rounds=3,
-                 early_stop_strategy=EARLY_STOP_AVERAGE_INCREASE_STRATEGY): # pylint: disable=unused-argument
+                 early_stop_strategy=EARLY_STOP_AVERAGE_INCREASE_STRATEGY):
+        # set default metric list
+        if eval_metric_list is None:
+            eval_metric_list = ["accuracy"]
         super(GSgnnClassificationEvaluator, self).__init__(eval_frequency,
                                                            eval_metric_list,
                                                            use_early_stop,
@@ -595,11 +598,14 @@ class GSgnnRegressionEvaluator(GSgnnBaseEvaluator, GSgnnPredictionEvalInterface)
         1) consecutive_increase and 2) average_increase.
     """
     def __init__(self, eval_frequency,
-                 eval_metric_list=["rmse"],
+                 eval_metric_list=None,
                  use_early_stop=False,
                  early_stop_burnin_rounds=0,
                  early_stop_rounds=3,
                  early_stop_strategy=EARLY_STOP_AVERAGE_INCREASE_STRATEGY):
+        # set default metric list
+        if eval_metric_list is None:
+            eval_metric_list = ["rmse"]
         super(GSgnnRegressionEvaluator, self).__init__(eval_frequency,
             eval_metric_list, use_early_stop, early_stop_burnin_rounds,
             early_stop_rounds, early_stop_strategy)
@@ -729,11 +735,14 @@ class GSgnnMrrLPEvaluator(GSgnnBaseEvaluator, GSgnnLPRankingEvalInterface):
         1) consecutive_increase and 2) average_increase.
     """
     def __init__(self, eval_frequency,
-                 eval_metric_list=["mrr"],
+                 eval_metric_list=None,
                  use_early_stop=False,
                  early_stop_burnin_rounds=0,
                  early_stop_rounds=3,
                  early_stop_strategy=EARLY_STOP_AVERAGE_INCREASE_STRATEGY):
+        # set default metric list
+        if eval_metric_list is None:
+            eval_metric_list = ["mrr"]
         super(GSgnnMrrLPEvaluator, self).__init__(eval_frequency,
             eval_metric_list, use_early_stop, early_stop_burnin_rounds,
             early_stop_rounds, early_stop_strategy)
@@ -861,12 +870,15 @@ class GSgnnPerEtypeMrrLPEvaluator(GSgnnBaseEvaluator, GSgnnLPRankingEvalInterfac
         1) consecutive_increase and 2) average_increase.
     """
     def __init__(self, eval_frequency,
-                 eval_metric_list=["mrr"],
+                 eval_metric_list=None,
                  major_etype = LINK_PREDICTION_MAJOR_EVAL_ETYPE_ALL,
                  use_early_stop=False,
                  early_stop_burnin_rounds=0,
                  early_stop_rounds=3,
                  early_stop_strategy=EARLY_STOP_AVERAGE_INCREASE_STRATEGY):
+        # set default metric list
+        if eval_metric_list is None:
+            eval_metric_list = ["mrr"]
         super(GSgnnPerEtypeMrrLPEvaluator, self).__init__(eval_frequency,
                                                           eval_metric_list,
                                                           use_early_stop,

--- a/python/graphstorm/eval/evaluator.py
+++ b/python/graphstorm/eval/evaluator.py
@@ -157,6 +157,8 @@ class GSgnnPredictionEvalInterface():
             Rediction result
         labels:
             Label
+        train: boolean
+            If in model training.
 
         Returns
         -------
@@ -541,6 +543,8 @@ class GSgnnClassificationEvaluator(GSgnnBaseEvaluator, GSgnnPredictionEvalInterf
                 Rediction result
             labels:
                 Label
+            train: boolean
+                If in model training.
 
             Returns
             -------
@@ -670,6 +674,8 @@ class GSgnnRegressionEvaluator(GSgnnBaseEvaluator, GSgnnPredictionEvalInterface)
                 Rediction result
             labels:
                 Label
+            train: boolean
+                If in model training.
 
             Returns
             -------

--- a/python/graphstorm/inference/graphstorm_infer.py
+++ b/python/graphstorm/inference/graphstorm_infer.py
@@ -93,7 +93,7 @@ class GSInferrer():
         best_val_score = self.evaluator.best_val_score
         best_test_score = self.evaluator.best_test_score
         best_iter_num = self.evaluator.best_iter_num
-        self.task_tracker.log_iter_metrics(self.evaluator.metric,
+        self.task_tracker.log_iter_metrics(self.evaluator.metric_list,
                                            train_score=train_score,
                                            val_score=val_score,
                                            test_score=test_score,

--- a/python/graphstorm/run/gsgnn_lp/gsgnn_lm_lp.py
+++ b/python/graphstorm/run/gsgnn_lp/gsgnn_lm_lp.py
@@ -40,7 +40,7 @@ from graphstorm.dataloading import (BUILTIN_LP_UNIFORM_NEG_SAMPLER,
                                     BUILTIN_LP_LOCALJOINT_NEG_SAMPLER)
 from graphstorm.dataloading import BUILTIN_LP_ALL_ETYPE_UNIFORM_NEG_SAMPLER
 from graphstorm.dataloading import BUILTIN_LP_ALL_ETYPE_JOINT_NEG_SAMPLER
-from graphstorm.eval import GSgnnMrrLPEvaluator, GSgnnPerEtypeMrrLPEvaluator
+from graphstorm.eval import GSgnnLPEvaluator, GSgnnPerEtypeMrrLPEvaluator
 from graphstorm.model.utils import save_full_node_embeddings
 from graphstorm.model import do_full_graph_inference
 from graphstorm.utils import rt_profiler, sys_tracker, get_device
@@ -58,24 +58,18 @@ def get_evaluator(config, train_data):
     assert len(config.eval_metric) == 1, \
         "GraphStorm doees not support computing multiple metrics at the same time."
     if config.report_eval_per_type:
-        return GSgnnPerEtypeMrrLPEvaluator(config.eval_frequency,
-                                           train_data,
-                                           config.num_negative_edges_eval,
-                                           config.lp_decoder_type,
-                                           config.model_select_etype,
-                                           config.use_early_stop,
-                                           config.early_stop_burnin_rounds,
-                                           config.early_stop_rounds,
-                                           config.early_stop_strategy)
+        return GSgnnPerEtypeMrrLPEvaluator(eval_frequency=config.eval_frequency,
+                                           major_etype=config.model_select_etype,
+                                           use_early_stop=config.use_early_stop,
+                                           early_stop_burnin_rounds=config.early_stop_burnin_rounds,
+                                           early_stop_rounds=config.early_stop_rounds,
+                                           early_stop_strategy=config.early_stop_strategy)
     else:
-        return GSgnnMrrLPEvaluator(config.eval_frequency,
-                                   train_data,
-                                   config.num_negative_edges_eval,
-                                   config.lp_decoder_type,
-                                   config.use_early_stop,
-                                   config.early_stop_burnin_rounds,
-                                   config.early_stop_rounds,
-                                   config.early_stop_strategy)
+        return GSgnnLPEvaluator(eval_frequency=config.eval_frequency,
+                                use_early_stop=config.use_early_stop,
+                                early_stop_burnin_rounds=config.early_stop_burnin_rounds,
+                                early_stop_rounds=config.early_stop_rounds,
+                                early_stop_strategy=config.early_stop_strategy)
 
 def main(config_args):
     """ main function

--- a/python/graphstorm/run/gsgnn_lp/gsgnn_lm_lp.py
+++ b/python/graphstorm/run/gsgnn_lp/gsgnn_lm_lp.py
@@ -94,7 +94,7 @@ def main(config_args):
     if not config.no_validation:
         # TODO(zhengda) we need to refactor the evaluator.
         # Currently, we only support mrr
-        evaluator = get_evaluator(config, train_data)
+        evaluator = get_evaluator(config)
         trainer.setup_evaluator(evaluator)
         assert len(train_data.val_idxs) > 0, "The training data do not have validation set."
         # TODO(zhengda) we need to compute the size of the entire validation set to make sure

--- a/python/graphstorm/run/gsgnn_lp/gsgnn_lm_lp.py
+++ b/python/graphstorm/run/gsgnn_lp/gsgnn_lm_lp.py
@@ -40,7 +40,7 @@ from graphstorm.dataloading import (BUILTIN_LP_UNIFORM_NEG_SAMPLER,
                                     BUILTIN_LP_LOCALJOINT_NEG_SAMPLER)
 from graphstorm.dataloading import BUILTIN_LP_ALL_ETYPE_UNIFORM_NEG_SAMPLER
 from graphstorm.dataloading import BUILTIN_LP_ALL_ETYPE_JOINT_NEG_SAMPLER
-from graphstorm.eval import GSgnnLPEvaluator, GSgnnPerEtypeMrrLPEvaluator
+from graphstorm.eval import GSgnnMrrLPEvaluator, GSgnnPerEtypeMrrLPEvaluator
 from graphstorm.model.utils import save_full_node_embeddings
 from graphstorm.model import do_full_graph_inference
 from graphstorm.utils import rt_profiler, sys_tracker, get_device
@@ -63,7 +63,7 @@ def get_evaluator(config):
                                            early_stop_rounds=config.early_stop_rounds,
                                            early_stop_strategy=config.early_stop_strategy)
     else:
-        return GSgnnLPEvaluator(eval_frequency=config.eval_frequency,
+        return GSgnnMrrLPEvaluator(eval_frequency=config.eval_frequency,
                                 use_early_stop=config.use_early_stop,
                                 early_stop_burnin_rounds=config.early_stop_burnin_rounds,
                                 early_stop_rounds=config.early_stop_rounds,

--- a/python/graphstorm/run/gsgnn_lp/gsgnn_lm_lp.py
+++ b/python/graphstorm/run/gsgnn_lp/gsgnn_lm_lp.py
@@ -45,15 +45,13 @@ from graphstorm.model.utils import save_full_node_embeddings
 from graphstorm.model import do_full_graph_inference
 from graphstorm.utils import rt_profiler, sys_tracker, get_device
 
-def get_evaluator(config, train_data):
+def get_evaluator(config):
     """ Get evaluator according to config
 
         Parameters
         ----------
         config: GSConfig
             Configuration
-        train_data: GSgnnEdgeData
-            Training data
     """
     assert len(config.eval_metric) == 1, \
         "GraphStorm doees not support computing multiple metrics at the same time."

--- a/python/graphstorm/run/gsgnn_lp/gsgnn_lp.py
+++ b/python/graphstorm/run/gsgnn_lp/gsgnn_lp.py
@@ -111,7 +111,7 @@ def main(config_args):
     if not config.no_validation:
         # TODO(zhengda) we need to refactor the evaluator.
         # Currently, we only support mrr
-        evaluator = get_evaluator(config, train_data)
+        evaluator = get_evaluator(config)
         trainer.setup_evaluator(evaluator)
         assert len(train_data.val_idxs) > 0, "The training data do not have validation set."
         # TODO(zhengda) we need to compute the size of the entire validation set to make sure

--- a/python/graphstorm/run/gsgnn_lp/gsgnn_lp.py
+++ b/python/graphstorm/run/gsgnn_lp/gsgnn_lp.py
@@ -48,7 +48,7 @@ from graphstorm.dataloading import (FastGSgnnLinkPredictionDataLoader,
                                     FastGSgnnLPJointNegDataLoader,
                                     FastGSgnnLPLocalUniformNegDataLoader,
                                     FastGSgnnLPLocalJointNegDataLoader)
-from graphstorm.eval import GSgnnMrrLPEvaluator, GSgnnPerEtypeMrrLPEvaluator
+from graphstorm.eval import GSgnnLPEvaluator, GSgnnPerEtypeMrrLPEvaluator
 from graphstorm.model.utils import save_full_node_embeddings
 from graphstorm.model import do_full_graph_inference
 from graphstorm.utils import (
@@ -72,24 +72,18 @@ def get_evaluator(config, train_data):
     assert len(config.eval_metric) == 1, \
         "GraphStorm doees not support computing multiple metrics at the same time."
     if config.report_eval_per_type:
-        return GSgnnPerEtypeMrrLPEvaluator(config.eval_frequency,
-                                           train_data,
-                                           config.num_negative_edges_eval,
-                                           config.lp_decoder_type,
-                                           config.model_select_etype,
-                                           config.use_early_stop,
-                                           config.early_stop_burnin_rounds,
-                                           config.early_stop_rounds,
-                                           config.early_stop_strategy)
+        return GSgnnPerEtypeMrrLPEvaluator(eval_frequency=config.eval_frequency,
+                                           major_etype=config.model_select_etype,
+                                           use_early_stop=config.use_early_stop,
+                                           early_stop_burnin_rounds=config.early_stop_burnin_rounds,
+                                           early_stop_rounds=config.early_stop_rounds,
+                                           early_stop_strategy=config.early_stop_strategy)
     else:
-        return GSgnnMrrLPEvaluator(config.eval_frequency,
-                                   train_data,
-                                   config.num_negative_edges_eval,
-                                   config.lp_decoder_type,
-                                   config.use_early_stop,
-                                   config.early_stop_burnin_rounds,
-                                   config.early_stop_rounds,
-                                   config.early_stop_strategy)
+        return GSgnnLPEvaluator(eval_frequency=config.eval_frequency,
+                                use_early_stop=config.use_early_stop,
+                                early_stop_burnin_rounds=config.early_stop_burnin_rounds,
+                                early_stop_rounds=config.early_stop_rounds,
+                                early_stop_strategy=config.early_stop_strategy)
 
 def main(config_args):
     """ main function

--- a/python/graphstorm/run/gsgnn_lp/gsgnn_lp.py
+++ b/python/graphstorm/run/gsgnn_lp/gsgnn_lp.py
@@ -59,15 +59,13 @@ from graphstorm.utils import (
 )
 from graphstorm.utils import get_lm_ntypes
 
-def get_evaluator(config, train_data):
+def get_evaluator(config):
     """ Get evaluator according to config
 
         Parameters
         ----------
         config: GSConfig
             Configuration
-        train_data: GSgnnEdgeData
-            Training data
     """
     assert len(config.eval_metric) == 1, \
         "GraphStorm doees not support computing multiple metrics at the same time."

--- a/python/graphstorm/run/gsgnn_lp/gsgnn_lp.py
+++ b/python/graphstorm/run/gsgnn_lp/gsgnn_lp.py
@@ -48,7 +48,7 @@ from graphstorm.dataloading import (FastGSgnnLinkPredictionDataLoader,
                                     FastGSgnnLPJointNegDataLoader,
                                     FastGSgnnLPLocalUniformNegDataLoader,
                                     FastGSgnnLPLocalJointNegDataLoader)
-from graphstorm.eval import GSgnnLPEvaluator, GSgnnPerEtypeMrrLPEvaluator
+from graphstorm.eval import GSgnnMrrLPEvaluator, GSgnnPerEtypeMrrLPEvaluator
 from graphstorm.model.utils import save_full_node_embeddings
 from graphstorm.model import do_full_graph_inference
 from graphstorm.utils import (
@@ -77,7 +77,7 @@ def get_evaluator(config):
                                            early_stop_rounds=config.early_stop_rounds,
                                            early_stop_strategy=config.early_stop_strategy)
     else:
-        return GSgnnLPEvaluator(eval_frequency=config.eval_frequency,
+        return GSgnnMrrLPEvaluator(eval_frequency=config.eval_frequency,
                                 use_early_stop=config.use_early_stop,
                                 early_stop_burnin_rounds=config.early_stop_burnin_rounds,
                                 early_stop_rounds=config.early_stop_rounds,

--- a/python/graphstorm/run/gsgnn_lp/lp_infer_gnn.py
+++ b/python/graphstorm/run/gsgnn_lp/lp_infer_gnn.py
@@ -20,7 +20,7 @@ import graphstorm as gs
 from graphstorm.config import get_argument_parser
 from graphstorm.config import GSConfig
 from graphstorm.inference import GSgnnLinkPredictionInferrer
-from graphstorm.eval import GSgnnLPEvaluator
+from graphstorm.eval import GSgnnMrrLPEvaluator
 from graphstorm.dataloading import GSgnnEdgeInferData
 from graphstorm.dataloading import (GSgnnLinkPredictionTestDataLoader,
                                     GSgnnLinkPredictionJointTestDataLoader,
@@ -57,7 +57,7 @@ def main(config_args):
     infer.setup_device(device=get_device())
     if not config.no_validation:
         infer.setup_evaluator(
-            GSgnnLPEvaluator(config.eval_frequency))
+            GSgnnMrrLPEvaluator(config.eval_frequency))
         assert len(infer_data.test_idxs) > 0, "There is not test data for evaluation."
     tracker = gs.create_builtin_task_tracker(config)
     infer.setup_task_tracker(tracker)

--- a/python/graphstorm/run/gsgnn_lp/lp_infer_gnn.py
+++ b/python/graphstorm/run/gsgnn_lp/lp_infer_gnn.py
@@ -20,7 +20,7 @@ import graphstorm as gs
 from graphstorm.config import get_argument_parser
 from graphstorm.config import GSConfig
 from graphstorm.inference import GSgnnLinkPredictionInferrer
-from graphstorm.eval import GSgnnMrrLPEvaluator
+from graphstorm.eval import GSgnnLPEvaluator
 from graphstorm.dataloading import GSgnnEdgeInferData
 from graphstorm.dataloading import (GSgnnLinkPredictionTestDataLoader,
                                     GSgnnLinkPredictionJointTestDataLoader,
@@ -57,10 +57,7 @@ def main(config_args):
     infer.setup_device(device=get_device())
     if not config.no_validation:
         infer.setup_evaluator(
-            GSgnnMrrLPEvaluator(config.eval_frequency,
-                                infer_data,
-                                config.num_negative_edges_eval,
-                                config.lp_decoder_type))
+            GSgnnLPEvaluator(config.eval_frequency))
         assert len(infer_data.test_idxs) > 0, "There is not test data for evaluation."
     tracker = gs.create_builtin_task_tracker(config)
     infer.setup_task_tracker(tracker)

--- a/python/graphstorm/run/gsgnn_lp/lp_infer_lm.py
+++ b/python/graphstorm/run/gsgnn_lp/lp_infer_lm.py
@@ -21,7 +21,7 @@ import graphstorm as gs
 from graphstorm.config import get_argument_parser
 from graphstorm.config import GSConfig
 from graphstorm.inference import GSgnnLinkPredictionInferrer
-from graphstorm.eval import GSgnnLPEvaluator
+from graphstorm.eval import GSgnnMrrLPEvaluator
 from graphstorm.dataloading import GSgnnEdgeInferData
 from graphstorm.dataloading import (GSgnnLinkPredictionTestDataLoader,
                                     GSgnnLinkPredictionJointTestDataLoader,
@@ -51,7 +51,7 @@ def main(config_args):
     infer.setup_device(device=get_device())
     if not config.no_validation:
         infer.setup_evaluator(
-            GSgnnLPEvaluator(config.eval_frequency))
+            GSgnnMrrLPEvaluator(config.eval_frequency))
         assert len(infer_data.test_idxs) > 0, "There is not test data for evaluation."
     tracker = gs.create_builtin_task_tracker(config)
     infer.setup_task_tracker(tracker)

--- a/python/graphstorm/run/gsgnn_lp/lp_infer_lm.py
+++ b/python/graphstorm/run/gsgnn_lp/lp_infer_lm.py
@@ -21,7 +21,7 @@ import graphstorm as gs
 from graphstorm.config import get_argument_parser
 from graphstorm.config import GSConfig
 from graphstorm.inference import GSgnnLinkPredictionInferrer
-from graphstorm.eval import GSgnnMrrLPEvaluator
+from graphstorm.eval import GSgnnLPEvaluator
 from graphstorm.dataloading import GSgnnEdgeInferData
 from graphstorm.dataloading import (GSgnnLinkPredictionTestDataLoader,
                                     GSgnnLinkPredictionJointTestDataLoader,
@@ -51,10 +51,7 @@ def main(config_args):
     infer.setup_device(device=get_device())
     if not config.no_validation:
         infer.setup_evaluator(
-            GSgnnMrrLPEvaluator(config.eval_frequency,
-                                infer_data,
-                                config.num_negative_edges_eval,
-                                config.lp_decoder_type))
+            GSgnnLPEvaluator(config.eval_frequency))
         assert len(infer_data.test_idxs) > 0, "There is not test data for evaluation."
     tracker = gs.create_builtin_task_tracker(config)
     infer.setup_task_tracker(tracker)

--- a/python/graphstorm/trainer/ep_trainer.py
+++ b/python/graphstorm/trainer/ep_trainer.py
@@ -283,7 +283,7 @@ class GSgnnEdgePredictionTrainer(GSgnnTrainer):
                        'peak_RAM_mem_alloc_MB': \
                            resource.getrusage(resource.RUSAGE_SELF).ru_maxrss / 1024,
                        'best validation iteration': \
-                           self.evaluator.best_iter_num[self.evaluator.metric[0]],
+                           self.evaluator.best_iter_num[self.evaluator.metric_list[0]],
                        'best model path': \
                            self.get_best_model_path() if save_model_path is not None else \
                                "No model is saved, please set save_model_path"}
@@ -319,7 +319,7 @@ class GSgnnEdgePredictionTrainer(GSgnnTrainer):
         test_start = time.time()
         sys_tracker.check('start prediction')
 
-        metric = set(self.evaluator.metric)
+        metric = set(self.evaluator.metric_list)
         need_proba = metric.intersection({'roc_auc', 'per_class_roc_auc', 'precision_recall'})
         need_label_pred = metric.intersection({'accuracy', 'f1_score', 'per_class_f1_score'})
         assert len(need_proba) == 0 or len(need_label_pred) == 0, \

--- a/python/graphstorm/trainer/gsgnn_trainer.py
+++ b/python/graphstorm/trainer/gsgnn_trainer.py
@@ -186,7 +186,7 @@ class GSgnnTrainer():
         best_val_score = self.evaluator.best_val_score
         best_test_score = self.evaluator.best_test_score
         best_iter_num = self.evaluator.best_iter_num
-        self.task_tracker.log_iter_metrics(self.evaluator.metric,
+        self.task_tracker.log_iter_metrics(self.evaluator.metric_list,
                 train_score=train_score, val_score=val_score,
                 test_score=test_score, best_val_score=best_val_score,
                 best_test_score=best_test_score, best_iter_num=best_iter_num,

--- a/python/graphstorm/trainer/lp_trainer.py
+++ b/python/graphstorm/trainer/lp_trainer.py
@@ -323,16 +323,16 @@ class GSgnnLinkPredictionTrainer(GSgnnTrainer):
                                           edge_mask=edge_mask_for_gnn_embeddings,
                                           task_tracker=self.task_tracker)
         sys_tracker.check('compute embeddings')
-        val_scores = lp_mini_batch_predict(model, emb, val_loader, self.device) \
+        val_rankings = lp_mini_batch_predict(model, emb, val_loader, self.device) \
             if val_loader is not None else None
         sys_tracker.check('after_val_score')
         if test_loader is not None:
-            test_scores = lp_mini_batch_predict(model, emb, test_loader, self.device)
+            test_rankings = lp_mini_batch_predict(model, emb, test_loader, self.device)
         else:
-            test_scores = None
+            test_rankings = None
         sys_tracker.check('after_test_score')
         val_score, test_score = self.evaluator.evaluate(
-            val_scores, test_scores, total_steps)
+            val_rankings, test_rankings, total_steps)
         sys_tracker.check('evaluate validation/test')
         model.train()
 

--- a/python/graphstorm/trainer/lp_trainer.py
+++ b/python/graphstorm/trainer/lp_trainer.py
@@ -323,16 +323,16 @@ class GSgnnLinkPredictionTrainer(GSgnnTrainer):
                                           edge_mask=edge_mask_for_gnn_embeddings,
                                           task_tracker=self.task_tracker)
         sys_tracker.check('compute embeddings')
-        val_rankings = lp_mini_batch_predict(model, emb, val_loader, self.device) \
+        val_scores = lp_mini_batch_predict(model, emb, val_loader, self.device) \
             if val_loader is not None else None
         sys_tracker.check('after_val_score')
         if test_loader is not None:
-            test_rankings = lp_mini_batch_predict(model, emb, test_loader, self.device)
+            test_scores = lp_mini_batch_predict(model, emb, test_loader, self.device)
         else:
-            test_rankings = None
+            test_scores = None
         sys_tracker.check('after_test_score')
         val_score, test_score = self.evaluator.evaluate(
-            val_rankings, test_rankings, total_steps)
+            val_scores, test_scores, total_steps)
         sys_tracker.check('evaluate validation/test')
         model.train()
 

--- a/python/graphstorm/trainer/lp_trainer.py
+++ b/python/graphstorm/trainer/lp_trainer.py
@@ -275,7 +275,7 @@ class GSgnnLinkPredictionTrainer(GSgnnTrainer):
                        'peak_RAM_mem_alloc_MB': \
                            resource.getrusage(resource.RUSAGE_SELF).ru_maxrss / 1024,
                        'best validation iteration': \
-                           self.evaluator.best_iter_num[self.evaluator.metric[0]],
+                           self.evaluator.best_iter_num[self.evaluator.metric_list[0]],
                        'best model path': \
                            self.get_best_model_path() if save_model_path is not None else None}
             self.log_params(output)

--- a/python/graphstorm/trainer/np_trainer.py
+++ b/python/graphstorm/trainer/np_trainer.py
@@ -262,7 +262,7 @@ class GSgnnNodePredictionTrainer(GSgnnTrainer):
                        'peak_RAM_mem_alloc_MB': \
                            resource.getrusage(resource.RUSAGE_SELF).ru_maxrss / 1024,
                        'best validation iteration': \
-                           self.evaluator.best_iter_num[self.evaluator.metric[0]],
+                           self.evaluator.best_iter_num[self.evaluator.metric_list[0]],
                        'best model path': \
                            self.get_best_model_path() if save_model_path is not None else None}
             self.log_params(output)
@@ -297,7 +297,7 @@ class GSgnnNodePredictionTrainer(GSgnnTrainer):
         teval = time.time()
         sys_tracker.check('before prediction')
 
-        metric = set(self.evaluator.metric)
+        metric = set(self.evaluator.metric_list)
         need_proba = metric.intersection({'roc_auc', 'per_class_roc_auc', 'precision_recall'})
         need_label_pred = metric.intersection({'accuracy', 'f1_score', 'per_class_f1_score'})
         assert len(need_proba) == 0 or len(need_label_pred) == 0, \

--- a/tests/unit-tests/test_dist_eval.py
+++ b/tests/unit-tests/test_dist_eval.py
@@ -32,7 +32,7 @@ import numpy as np
 
 from graphstorm.eval import GSgnnClassificationEvaluator
 from graphstorm.eval import GSgnnRegressionEvaluator
-from graphstorm.eval import GSgnnLPEvaluator
+from graphstorm.eval import GSgnnMrrLPEvaluator
 from graphstorm.utils import setup_device
 
 from graphstorm.config import BUILTIN_LP_DOT_DECODER
@@ -49,8 +49,8 @@ def run_dist_lp_eval_worker(worker_rank, config, val_scores, test_scores, conn):
                                       world_size=2,
                                       rank=worker_rank)
 
-    lp_eval = GSgnnLPEvaluator(config.eval_frequency,
-                               use_early_stop=config.use_early_stop)
+    lp_eval = GSgnnMrrLPEvaluator(config.eval_frequency,
+                                  use_early_stop=config.use_early_stop)
     val_sc, test_sc = lp_eval.evaluate(val_scores, test_scores, 0)
 
     if worker_rank == 0:
@@ -101,8 +101,8 @@ def run_local_lp_eval_worker(config, val_scores, test_scores, conn):
                                       world_size=1,
                                       rank=0)
 
-    lp_eval = GSgnnLPEvaluator(config.eval_frequency,
-                               use_early_stop=config.use_early_stop)
+    lp_eval = GSgnnMrrLPEvaluator(config.eval_frequency,
+                                  use_early_stop=config.use_early_stop)
     val_sc, test_sc = lp_eval.evaluate(val_scores, test_scores, 0)
     conn.send((val_sc, test_sc))
     th.distributed.destroy_process_group()

--- a/tests/unit-tests/test_dist_eval.py
+++ b/tests/unit-tests/test_dist_eval.py
@@ -343,7 +343,7 @@ def test_nc_dist_eval(metric, seed, backend):
     val_labels2[:160] = val_pred[:160]
 
     config = Dummy({
-        "eval_metric": metric,
+        "eval_metric_list": metric,
         "no_validation": False,
         "multilabel": False,
         "eval_frequency": 100,
@@ -420,21 +420,18 @@ def test_nc_dist_eval_multilabel(seed, backend):
     test_logits = softmax(test_logits)
 
     config = Dummy({
-        "eval_metric": ["accuracy"],
+        "eval_metric_list": ["accuracy"],
         "no_validation": False,
         "multilabel": True,
         "eval_frequency": 100,
         "use_early_stop": False,
     })
-    train_data = Dummy({
-        "do_validation": True
-    })
 
     # do evaluation with single worker
-    metrics_local = run_local_nc_eval((config, train_data), ["accuracy"], val_logits, test_logits,
+    metrics_local = run_local_nc_eval(config, ["accuracy"], val_logits, test_logits,
         val_labels0, val_labels1, val_labels2, test_labels0)
     # do evaluation with two workers
-    metrics_dist = run_dist_nc_eval((config, train_data), ["accuracy"], val_logits, test_logits,
+    metrics_dist = run_dist_nc_eval(config, ["accuracy"], val_logits, test_logits,
         val_labels0, val_labels1, val_labels2, test_labels0, backend)
 
     metrics_keys = list(metrics_local.keys())
@@ -463,18 +460,15 @@ def test_nc_dist_regression_eval(metric, seed, backend):
     test_labels[100:170] = test_pred[100:170]
 
     config = Dummy({
-        "eval_metric": metric,
+        "eval_metric_list": metric,
         "no_validation": False,
         "eval_frequency": 100,
         "use_early_stop": False,
     })
-    train_data = Dummy({
-        "do_validation": True
-    })
 
-    metrics_local = run_local_nc_eval((config, train_data), metric, val_pred, test_pred,
+    metrics_local = run_local_nc_eval(config, metric, val_pred, test_pred,
         val_labels0, val_labels1, val_labels2, test_labels)
-    metrics_dist = run_dist_nc_eval((config, train_data), metric, val_pred, test_pred,
+    metrics_dist = run_dist_nc_eval(config, metric, val_pred, test_pred,
         val_labels0, val_labels1, val_labels2, test_labels, backend)
 
     metrics_keys = list(metrics_local.keys())

--- a/tests/unit-tests/test_dist_eval.py
+++ b/tests/unit-tests/test_dist_eval.py
@@ -180,7 +180,7 @@ def run_dist_nc_eval_worker(eval_config, worker_rank, metric, val_pred, test_pre
     device = setup_device(worker_rank)
     config = eval_config
 
-    if config.eval_metric[0] in ["rmse", "mse"]:
+    if config.eval_metric_list[0] in ["rmse", "mse"]:
         evaluator = GSgnnRegressionEvaluator(config.eval_frequency,
                                              config.eval_metric_list,
                                              config.use_early_stop)
@@ -273,7 +273,7 @@ def run_local_nc_eval_worker(eval_config, metric, val_pred, test_pred,
                                       rank=0)
     config = eval_config
 
-    if config.eval_metric[0] in ["rmse", "mse"]:
+    if config.eval_metric_list[0] in ["rmse", "mse"]:
         evaluator = GSgnnRegressionEvaluator(config.eval_frequency,
                                              config.eval_metric_list,
                                              config.use_early_stop)

--- a/tests/unit-tests/test_dist_eval.py
+++ b/tests/unit-tests/test_dist_eval.py
@@ -207,7 +207,7 @@ def run_dist_nc_eval_worker(eval_config, worker_rank, metric, val_pred, test_pre
         test_labels.to(device), 300)
 
     if worker_rank == 0:
-        assert evaluator.metric == metric
+        assert evaluator.metric_list == metric
         assert evaluator.best_iter_num[metric[0]] == 200
         assert evaluator.best_val_score == val_score1
         assert evaluator.best_test_score == test_score1
@@ -290,7 +290,7 @@ def run_local_nc_eval_worker(eval_config, metric, val_pred, test_pred,
     assert val_score0 != val_score2
     assert test_score0 == test_score1
 
-    assert evaluator.metric == metric
+    assert evaluator.metric_list == metric
     assert evaluator.best_iter_num[metric[0]] == 200
     assert evaluator.best_val_score == val_score1
     assert evaluator.best_test_score == test_score1

--- a/tests/unit-tests/test_evaluator.py
+++ b/tests/unit-tests/test_evaluator.py
@@ -21,7 +21,7 @@ import numpy as np
 from numpy.testing import assert_equal, assert_almost_equal
 import dgl
 
-from graphstorm.eval import GSgnnLPEvaluator, GSgnnPerEtypeMrrLPEvaluator
+from graphstorm.eval import GSgnnMrrLPEvaluator, GSgnnPerEtypeMrrLPEvaluator
 from graphstorm.eval import GSgnnClassificationEvaluator
 from graphstorm.eval import GSgnnRegressionEvaluator
 from graphstorm.eval.evaluator import early_stop_avg_increase_judge
@@ -184,7 +184,7 @@ def test_lp_evaluator():
     val_pos_scores, val_neg_scores = val_scores
     test_pos_scores, test_neg_scores = test_scores
 
-    lp = GSgnnLPEvaluator(config.eval_frequency, use_early_stop=config.use_early_stop)
+    lp = GSgnnMrrLPEvaluator(config.eval_frequency, use_early_stop=config.use_early_stop)
     
     # checke default metric list
     assert lp.metric_list == ['mrr']
@@ -244,10 +244,10 @@ def test_lp_evaluator():
     assert_equal(test_sc['mrr'], "N/A")
 
     # test evaluate
-    @patch.object(GSgnnLPEvaluator, 'compute_score')
+    @patch.object(GSgnnMrrLPEvaluator, 'compute_score')
     def check_evaluate(mock_compute_score):
-        lp = GSgnnLPEvaluator(config.eval_frequency,
-                              use_early_stop=config.use_early_stop)
+        lp = GSgnnMrrLPEvaluator(config.eval_frequency,
+                                 use_early_stop=config.use_early_stop)
 
         mock_compute_score.side_effect = [
             {"mrr": 0.6},
@@ -275,13 +275,13 @@ def test_lp_evaluator():
         assert lp.best_test_score["mrr"] == 0.65
         assert lp.best_iter_num["mrr"] == 200
 
-    # check GSgnnLPEvaluator.evaluate()
+    # check GSgnnMrrLPEvaluator.evaluate()
     check_evaluate()
 
     # test evaluate
-    @patch.object(GSgnnLPEvaluator, 'compute_score')
+    @patch.object(GSgnnMrrLPEvaluator, 'compute_score')
     def check_evaluate_infer(mock_compute_score):
-        lp = GSgnnLPEvaluator(config.eval_frequency,
+        lp = GSgnnMrrLPEvaluator(config.eval_frequency,
                               use_early_stop=config.use_early_stop)
 
         mock_compute_score.side_effect = [
@@ -300,14 +300,14 @@ def test_lp_evaluator():
         assert lp.best_test_score["mrr"] == 0 # Still initial value 0
         assert lp.best_iter_num["mrr"] == 0 # Still initial value 0
 
-    # check GSgnnLPEvaluator.evaluate()
+    # check GSgnnMrrLPEvaluator.evaluate()
     check_evaluate_infer()
 
-    # check GSgnnLPEvaluator.do_eval()
+    # check GSgnnMrrLPEvaluator.do_eval()
     # train_data.do_validation True
     # config.no_validation False
-    lp = GSgnnLPEvaluator(config.eval_frequency,
-                          use_early_stop=config.use_early_stop)
+    lp = GSgnnMrrLPEvaluator(config.eval_frequency,
+                             use_early_stop=config.use_early_stop)
     assert lp.do_eval(120, epoch_end=True) is True
     assert lp.do_eval(200) is True
     assert lp.do_eval(0) is True
@@ -321,7 +321,7 @@ def test_lp_evaluator():
     # train_data.do_validation True
     # config.no_validation False
     # eval_frequency is 0
-    lp = GSgnnLPEvaluator(config3.eval_frequency,
+    lp = GSgnnMrrLPEvaluator(config3.eval_frequency,
                           use_early_stop=config3.use_early_stop)
     assert lp.do_eval(120, epoch_end=True) is True
     assert lp.do_eval(200) is False
@@ -705,8 +705,8 @@ def test_early_stop_lp_evaluator():
             "eval_frequency": 100,
             "use_early_stop": False,
         })
-    evaluator = GSgnnLPEvaluator(config.eval_frequency,
-                                 use_early_stop=config.use_early_stop)
+    evaluator = GSgnnMrrLPEvaluator(config.eval_frequency,
+                                    use_early_stop=config.use_early_stop)
     for _ in range(10):
         # always return false
         assert evaluator.do_early_stop({"mrr": 0.5}) is False
@@ -718,11 +718,11 @@ def test_early_stop_lp_evaluator():
             "early_stop_rounds": 3,
             "early_stop_strategy": EARLY_STOP_CONSECUTIVE_INCREASE_STRATEGY,
         })
-    evaluator = GSgnnLPEvaluator(config.eval_frequency,
-                                 use_early_stop=config.use_early_stop,
-                                 early_stop_burnin_rounds=config.early_stop_burnin_rounds,
-                                 early_stop_rounds=config.early_stop_rounds,
-                                 early_stop_strategy=config.early_stop_strategy)
+    evaluator = GSgnnMrrLPEvaluator(config.eval_frequency,
+                                    use_early_stop=config.use_early_stop,
+                                    early_stop_burnin_rounds=config.early_stop_burnin_rounds,
+                                    early_stop_rounds=config.early_stop_rounds,
+                                    early_stop_strategy=config.early_stop_strategy)
     for _ in range(5):
         # always return false
         assert evaluator.do_early_stop({"mrr": 0.5}) is False
@@ -743,11 +743,11 @@ def test_early_stop_lp_evaluator():
             "early_stop_rounds": 3,
             "early_stop_strategy": EARLY_STOP_AVERAGE_INCREASE_STRATEGY,
         })
-    evaluator = GSgnnLPEvaluator(config.eval_frequency,
-                                 use_early_stop=config.use_early_stop,
-                                 early_stop_burnin_rounds=config.early_stop_burnin_rounds,
-                                 early_stop_rounds=config.early_stop_rounds,
-                                 early_stop_strategy=config.early_stop_strategy)
+    evaluator = GSgnnMrrLPEvaluator(config.eval_frequency,
+                                    use_early_stop=config.use_early_stop,
+                                    early_stop_burnin_rounds=config.early_stop_burnin_rounds,
+                                    early_stop_rounds=config.early_stop_rounds,
+                                    early_stop_strategy=config.early_stop_strategy)
     for _ in range(5):
         # always return false
         assert evaluator.do_early_stop({"accuracy": 0.5}) is False
@@ -832,7 +832,7 @@ def test_get_val_score_rank():
             "use_early_stop": False,
         })
 
-    evaluator = GSgnnLPEvaluator(config.eval_frequency,
+    evaluator = GSgnnMrrLPEvaluator(config.eval_frequency,
                                  use_early_stop=config.use_early_stop)
 
     # For MRR, the bigger the better

--- a/tests/unit-tests/test_evaluator.py
+++ b/tests/unit-tests/test_evaluator.py
@@ -21,7 +21,7 @@ import numpy as np
 from numpy.testing import assert_equal, assert_almost_equal
 import dgl
 
-from graphstorm.eval import GSgnnMrrLPEvaluator, GSgnnPerEtypeMrrLPEvaluator
+from graphstorm.eval import GSgnnLPEvaluator, GSgnnPerEtypeMrrLPEvaluator
 from graphstorm.eval import GSgnnClassificationEvaluator
 from graphstorm.eval import GSgnnRegressionEvaluator
 from graphstorm.eval.evaluator import early_stop_avg_increase_judge
@@ -49,17 +49,7 @@ def gen_hg():
     return hg
 
 def gen_mrr_lp_eval_data():
-    # common Dummy objects
-    train_data = Dummy({
-            "train_idxs": th.randint(10, (10,)),
-            "val_idxs": th.randint(10, (10,)),
-            "test_idxs": th.randint(10, (10,)),
-            "do_validation": True
-        })
-
     config = Dummy({
-            "num_negative_edges_eval": 10,
-            "lp_decoder_type": BUILTIN_LP_DOT_DECODER,
             "eval_frequency": 100,
             "use_early_stop": False,
         })
@@ -71,7 +61,7 @@ def gen_mrr_lp_eval_data():
     test_pos_scores = th.rand((10,1))
     test_neg_scores = th.rand((10,10))
 
-    return train_data, config, etypes, (val_pos_scores, val_neg_scores), (test_pos_scores, test_neg_scores)
+    return config, etypes, (val_pos_scores, val_neg_scores), (test_pos_scores, test_neg_scores)
 
 def test_mrr_per_etype_lp_evaluation():
     # system heavily depends on th distributed
@@ -81,7 +71,7 @@ def test_mrr_per_etype_lp_evaluation():
                                       init_method=dist_init_method,
                                       world_size=1,
                                       rank=0)
-    train_data, config, etypes, val_scores, test_scores = gen_mrr_lp_eval_data()
+    config, etypes, val_scores, test_scores = gen_mrr_lp_eval_data()
 
     score = {
         ("a", "r1", "b"): 0.9,
@@ -89,22 +79,14 @@ def test_mrr_per_etype_lp_evaluation():
     }
 
     # Test get_major_score
-    lp = GSgnnPerEtypeMrrLPEvaluator(10,
-        train_data,
-        num_negative_edges_eval=4,
-        lp_decoder_type=BUILTIN_LP_DOT_DECODER,
-        use_early_stop=False)
+    lp = GSgnnPerEtypeMrrLPEvaluator(10, use_early_stop=False)
     assert lp.major_etype == LINK_PREDICTION_MAJOR_EVAL_ETYPE_ALL
 
     m_score = lp._get_major_score(score)
     assert m_score == sum(score.values()) / 2
 
     # Test get_major_score
-    lp = GSgnnPerEtypeMrrLPEvaluator(config.eval_frequency,
-        train_data,
-        major_etype=("a", "r2", "b"),
-        num_negative_edges_eval=config.num_negative_edges_eval,
-        lp_decoder_type=config.lp_decoder_type,
+    lp = GSgnnPerEtypeMrrLPEvaluator(config.eval_frequency, major_etype=("a", "r2", "b"),
         use_early_stop=config.use_early_stop)
     assert lp.major_etype == ("a", "r2", "b")
 
@@ -114,11 +96,7 @@ def test_mrr_per_etype_lp_evaluation():
     val_pos_scores, val_neg_scores = val_scores
     test_pos_scores, test_neg_scores = test_scores
 
-    lp = GSgnnPerEtypeMrrLPEvaluator(config.eval_frequency,
-        train_data,
-        num_negative_edges_eval=config.num_negative_edges_eval,
-        lp_decoder_type=config.lp_decoder_type,
-        use_early_stop=config.use_early_stop)
+    lp = GSgnnPerEtypeMrrLPEvaluator(config.eval_frequency, use_early_stop=config.use_early_stop)
 
     rank0 = []
     rank1 = []
@@ -180,11 +158,8 @@ def test_mrr_per_etype_lp_evaluation():
     assert_almost_equal(np.array([test_s_mrr]), lp.best_test_score['mrr'])
 
     lp = GSgnnPerEtypeMrrLPEvaluator(config.eval_frequency,
-        train_data,
-        major_etype=etypes[1],
-        num_negative_edges_eval=config.num_negative_edges_eval,
-        lp_decoder_type=config.lp_decoder_type,
-        use_early_stop=config.use_early_stop)
+                                     major_etype=etypes[1],
+                                     use_early_stop=config.use_early_stop)
 
     val_sc, test_sc = lp.evaluate(val_ranks, test_ranks, 0)
     assert_equal(val_s['mrr'][etypes[0]], val_sc['mrr'][etypes[0]])
@@ -197,7 +172,7 @@ def test_mrr_per_etype_lp_evaluation():
 
     th.distributed.destroy_process_group()
 
-def test_mrr_lp_evaluator():
+def test_lp_evaluator():
     # system heavily depends on th distributed
     dist_init_method = 'tcp://{master_ip}:{master_port}'.format(
         master_ip='127.0.0.1', master_port='12346')
@@ -205,15 +180,14 @@ def test_mrr_lp_evaluator():
                                       init_method=dist_init_method,
                                       world_size=1,
                                       rank=0)
-    train_data, config, etypes, val_scores, test_scores = gen_mrr_lp_eval_data()
+    config, etypes, val_scores, test_scores = gen_mrr_lp_eval_data()
     val_pos_scores, val_neg_scores = val_scores
     test_pos_scores, test_neg_scores = test_scores
 
-    lp = GSgnnMrrLPEvaluator(config.eval_frequency,
-                             train_data,
-                             num_negative_edges_eval=config.num_negative_edges_eval,
-                             lp_decoder_type=config.lp_decoder_type,
-                             use_early_stop=config.use_early_stop)
+    lp = GSgnnLPEvaluator(config.eval_frequency, use_early_stop=config.use_early_stop)
+    
+    # checke default metric list
+    assert lp.metric_list == ['mrr']
 
     rank = []
     for i in range(len(val_pos_scores)):
@@ -270,13 +244,10 @@ def test_mrr_lp_evaluator():
     assert_equal(test_sc['mrr'], "N/A")
 
     # test evaluate
-    @patch.object(GSgnnMrrLPEvaluator, 'compute_score')
+    @patch.object(GSgnnLPEvaluator, 'compute_score')
     def check_evaluate(mock_compute_score):
-        lp = GSgnnMrrLPEvaluator(config.eval_frequency,
-                                 train_data,
-                                 num_negative_edges_eval=config. num_negative_edges_eval,
-                                 lp_decoder_type=config.lp_decoder_type,
-                                 use_early_stop=config.use_early_stop)
+        lp = GSgnnLPEvaluator(config.eval_frequency,
+                              use_early_stop=config.use_early_stop)
 
         mock_compute_score.side_effect = [
             {"mrr": 0.6},
@@ -304,24 +275,14 @@ def test_mrr_lp_evaluator():
         assert lp.best_test_score["mrr"] == 0.65
         assert lp.best_iter_num["mrr"] == 200
 
-    # check GSgnnMrrLPEvaluator.evaluate()
+    # check GSgnnLPEvaluator.evaluate()
     check_evaluate()
 
-    # common Dummy objects
-    train_data = Dummy({
-            "train_idxs": None,
-            "val_idxs": None,
-            "test_idxs": th.randint(10, (10,)),
-            "do_validation": True
-        })
     # test evaluate
-    @patch.object(GSgnnMrrLPEvaluator, 'compute_score')
+    @patch.object(GSgnnLPEvaluator, 'compute_score')
     def check_evaluate_infer(mock_compute_score):
-        lp = GSgnnMrrLPEvaluator(config.eval_frequency,
-                                 train_data,
-                                 num_negative_edges_eval=config.num_negative_edges_eval,
-                                 lp_decoder_type=config.lp_decoder_type,
-                                 use_early_stop=config.use_early_stop)
+        lp = GSgnnLPEvaluator(config.eval_frequency,
+                              use_early_stop=config.use_early_stop)
 
         mock_compute_score.side_effect = [
             {"mrr": 0.6},
@@ -339,25 +300,20 @@ def test_mrr_lp_evaluator():
         assert lp.best_test_score["mrr"] == 0 # Still initial value 0
         assert lp.best_iter_num["mrr"] == 0 # Still initial value 0
 
-    # check GSgnnMrrLPEvaluator.evaluate()
+    # check GSgnnLPEvaluator.evaluate()
     check_evaluate_infer()
 
-    # check GSgnnMrrLPEvaluator.do_eval()
+    # check GSgnnLPEvaluator.do_eval()
     # train_data.do_validation True
     # config.no_validation False
-    lp = GSgnnMrrLPEvaluator(config.eval_frequency,
-                             train_data,
-                             num_negative_edges_eval=config.num_negative_edges_eval,
-                             lp_decoder_type=config.lp_decoder_type,
-                             use_early_stop=config.use_early_stop)
+    lp = GSgnnLPEvaluator(config.eval_frequency,
+                          use_early_stop=config.use_early_stop)
     assert lp.do_eval(120, epoch_end=True) is True
     assert lp.do_eval(200) is True
     assert lp.do_eval(0) is True
     assert lp.do_eval(1) is False
 
     config3 = Dummy({
-            "num_negative_edges_eval": 10,
-            "lp_decoder_type": BUILTIN_LP_DOT_DECODER,
             "eval_frequency": 0,
             "use_early_stop": False,
         })
@@ -365,11 +321,8 @@ def test_mrr_lp_evaluator():
     # train_data.do_validation True
     # config.no_validation False
     # eval_frequency is 0
-    lp = GSgnnMrrLPEvaluator(config3.eval_frequency,
-                             train_data,
-                             num_negative_edges_eval=config3.num_negative_edges_eval,
-                             lp_decoder_type=config3.lp_decoder_type,
-                             use_early_stop=config3.use_early_stop)
+    lp = GSgnnLPEvaluator(config3.eval_frequency,
+                          use_early_stop=config3.use_early_stop)
     assert lp.do_eval(120, epoch_end=True) is True
     assert lp.do_eval(200) is False
 
@@ -386,20 +339,20 @@ def test_classification_evaluator():
 
     # test default settings
     cl_eval = GSgnnClassificationEvaluator(eval_frequency=100)
-    assert cl_eval.metric == ["accuracy"]
+    assert cl_eval.metric_list == ["accuracy"]
     assert cl_eval.multilabel is False
 
     # test given settings
     config = Dummy({
             "multilabel": False,
             "eval_frequency": 100,
-            "eval_metric": ["accuracy"],
+            "eval_metric_list": ["accuracy"],
             "use_early_stop": False,
         })
 
     # Test compute_score
     cl_eval = GSgnnClassificationEvaluator(config.eval_frequency,
-                                          config.eval_metric,
+                                          config.eval_metric_list,
                                           config.multilabel,
                                           config.use_early_stop)
     pred = th.randint(10, (100,))
@@ -415,7 +368,7 @@ def test_classification_evaluator():
     @patch.object(GSgnnClassificationEvaluator, 'compute_score')
     def check_evaluate(mock_compute_score):
         cl_eval = GSgnnClassificationEvaluator(config.eval_frequency,
-                                               config.eval_metric,
+                                               config.eval_metric_list,
                                                config.multilabel,
                                                config.use_early_stop)
         mock_compute_score.side_effect = [
@@ -451,7 +404,7 @@ def test_classification_evaluator():
     @patch.object(GSgnnClassificationEvaluator, 'compute_score')
     def check_evaluate_no_test(mock_compute_score):
         cl_eval = GSgnnClassificationEvaluator(config.eval_frequency,
-                                               config.eval_metric,
+                                               config.eval_metric_list,
                                                config.multilabel,
                                                config.use_early_stop)
         mock_compute_score.side_effect = [
@@ -487,7 +440,7 @@ def test_classification_evaluator():
     # train_data.do_validation True
     # config.no_validation False
     cl_eval = GSgnnClassificationEvaluator(config.eval_frequency,
-                                           config.eval_metric,
+                                           config.eval_metric_list,
                                            config.multilabel,
                                            config.use_early_stop)
     assert cl_eval.do_eval(120, epoch_end=True) is True
@@ -498,7 +451,7 @@ def test_classification_evaluator():
     config3 = Dummy({
             "multilabel": False,
             "eval_frequency": 0,
-            "eval_metric": ["accuracy"],
+            "eval_metric_list": ["accuracy"],
             "use_early_stop": False,
         })
 
@@ -506,7 +459,7 @@ def test_classification_evaluator():
     # config.no_validation False
     # eval_frequency is 0
     cl_eval = GSgnnClassificationEvaluator(config3.eval_frequency,
-                                      config3.eval_metric,
+                                      config3.eval_metric_list,
                                       config3.multilabel,
                                       config3.use_early_stop)
     assert cl_eval.do_eval(120, epoch_end=True) is True
@@ -522,16 +475,18 @@ def test_regression_evaluator():
                                       world_size=1,
                                       rank=0)
 
+    # test default settings
+    nr_eval = GSgnnRegressionEvaluator(eval_frequency=100)
+    assert nr_eval.metric_list == ["rmse"]
+
     config = Dummy({
             "eval_frequency": 100,
-            "eval_metric": ["rmse"],
             "use_early_stop": False,
         })
 
     # Test compute_score
     nr = GSgnnRegressionEvaluator(config.eval_frequency,
-                                  config.eval_metric,
-                                  config.use_early_stop)
+                                  use_early_stop=config.use_early_stop)
     pred = th.rand(100)
     labels = th.rand(100)
     result = nr.compute_score(pred, labels)
@@ -546,8 +501,7 @@ def test_regression_evaluator():
     @patch.object(GSgnnRegressionEvaluator, 'compute_score')
     def check_evaluate(mock_compute_score):
         nr = GSgnnRegressionEvaluator(config.eval_frequency,
-                                      config.eval_metric,
-                                      config.use_early_stop)
+                                      use_early_stop=config.use_early_stop)
         mock_compute_score.side_effect = [
             {"rmse": 0.7},
             {"rmse": 0.8},
@@ -582,8 +536,7 @@ def test_regression_evaluator():
     @patch.object(GSgnnRegressionEvaluator, 'compute_score')
     def check_evaluate_no_test(mock_compute_score):
         nr = GSgnnRegressionEvaluator(config.eval_frequency,
-                                      config.eval_metric,
-                                      config.use_early_stop)
+                                      use_early_stop=config.use_early_stop)
         mock_compute_score.side_effect = [
             {"rmse": 0.7},
             {"rmse": "N/A"},
@@ -617,8 +570,7 @@ def test_regression_evaluator():
     # check GSgnnRegressionEvaluator.do_eval()
     # train_data.do_validation True
     nr = GSgnnRegressionEvaluator(config.eval_frequency,
-                                  config.eval_metric,
-                                  config.use_early_stop)
+                                  use_early_stop=config.use_early_stop)
     assert nr.do_eval(120, epoch_end=True) is True
     assert nr.do_eval(200) is True
     assert nr.do_eval(0) is True
@@ -627,15 +579,13 @@ def test_regression_evaluator():
     config3 = Dummy({
             "eval_frequency": 0,
             "no_validation": False,
-            "eval_metric": ["rmse"],
             "use_early_stop": False,
         })
 
     # train_data.do_validation True
     # eval_frequency is 0
     nr = GSgnnRegressionEvaluator(config3.eval_frequency,
-                                  config3.eval_metric,
-                                  config3.use_early_stop)
+                                  use_early_stop=config3.use_early_stop)
     assert nr.do_eval(120, epoch_end=True) is True
     assert nr.do_eval(200) is False
     th.distributed.destroy_process_group()
@@ -751,45 +701,28 @@ def test_early_stop_evaluator():
 
 def test_early_stop_lp_evaluator():
     # common Dummy objects
-    train_data = Dummy({
-            "train_idxs": th.randint(10, (10,)),
-            "val_idxs": th.randint(10, (10,)),
-            "test_idxs": th.randint(10, (10,)),
-            "do_validation": True
-        })
-
     config = Dummy({
-            "num_negative_edges_eval": 10,
-            "lp_decoder_type": BUILTIN_LP_DOT_DECODER,
             "eval_frequency": 100,
             "use_early_stop": False,
         })
-    evaluator = GSgnnMrrLPEvaluator(config.eval_frequency,
-                                    train_data,
-                                    num_negative_edges_eval=config.num_negative_edges_eval,
-                                    lp_decoder_type=config.lp_decoder_type,
-                                    use_early_stop=config.use_early_stop)
+    evaluator = GSgnnLPEvaluator(config.eval_frequency,
+                                 use_early_stop=config.use_early_stop)
     for _ in range(10):
         # always return false
         assert evaluator.do_early_stop({"mrr": 0.5}) is False
 
     config = Dummy({
-            "num_negative_edges_eval": 10,
-            "lp_decoder_type": BUILTIN_LP_DOT_DECODER,
             "eval_frequency": 100,
             "use_early_stop": True,
             "early_stop_burnin_rounds": 5,
             "early_stop_rounds": 3,
             "early_stop_strategy": EARLY_STOP_CONSECUTIVE_INCREASE_STRATEGY,
         })
-    evaluator = GSgnnMrrLPEvaluator(config.eval_frequency,
-                                    train_data,
-                                    num_negative_edges_eval=config.num_negative_edges_eval,
-                                    lp_decoder_type=config.lp_decoder_type,
-                                    use_early_stop=config.use_early_stop,
-                                    early_stop_burnin_rounds=config.early_stop_burnin_rounds,
-                                    early_stop_rounds=config.early_stop_rounds,
-                                    early_stop_strategy=config.early_stop_strategy)
+    evaluator = GSgnnLPEvaluator(config.eval_frequency,
+                                 use_early_stop=config.use_early_stop,
+                                 early_stop_burnin_rounds=config.early_stop_burnin_rounds,
+                                 early_stop_rounds=config.early_stop_rounds,
+                                 early_stop_strategy=config.early_stop_strategy)
     for _ in range(5):
         # always return false
         assert evaluator.do_early_stop({"mrr": 0.5}) is False
@@ -804,22 +737,17 @@ def test_early_stop_lp_evaluator():
     assert evaluator.do_early_stop({"mrr": 0.45}) # early stop
 
     config = Dummy({
-            "num_negative_edges_eval": 10,
-            "lp_decoder_type": BUILTIN_LP_DOT_DECODER,
             "eval_frequency": 100,
             "use_early_stop": True,
             "early_stop_burnin_rounds": 5,
             "early_stop_rounds": 3,
             "early_stop_strategy": EARLY_STOP_AVERAGE_INCREASE_STRATEGY,
         })
-    evaluator = GSgnnMrrLPEvaluator(config.eval_frequency,
-                                    train_data,
-                                    num_negative_edges_eval=config.num_negative_edges_eval,
-                                    lp_decoder_type=config.lp_decoder_type,
-                                    use_early_stop=config.use_early_stop,
-                                    early_stop_burnin_rounds=config.early_stop_burnin_rounds,
-                                    early_stop_rounds=config.early_stop_rounds,
-                                    early_stop_strategy=config.early_stop_strategy)
+    evaluator = GSgnnLPEvaluator(config.eval_frequency,
+                                 use_early_stop=config.use_early_stop,
+                                 early_stop_burnin_rounds=config.early_stop_burnin_rounds,
+                                 early_stop_rounds=config.early_stop_rounds,
+                                 early_stop_strategy=config.early_stop_strategy)
     for _ in range(5):
         # always return false
         assert evaluator.do_early_stop({"accuracy": 0.5}) is False
@@ -899,25 +827,13 @@ def test_get_val_score_rank():
 
     # ------------------- test LPEvaluator -------------------
     # common Dummy objects
-    train_data = Dummy({
-            "train_idxs": th.randint(10, (10,)),
-            "val_idxs": th.randint(10, (10,)),
-            "test_idxs": th.randint(10, (10,)),
-        })
-
     config = Dummy({
-            "num_negative_edges_eval": 10,
-            "lp_decoder_type": BUILTIN_LP_DOT_DECODER,
             "eval_frequency": 100,
             "use_early_stop": False,
-            "eval_metric": ["mrr"]
         })
 
-    evaluator = GSgnnMrrLPEvaluator(config.eval_frequency,
-                                    train_data,
-                                    num_negative_edges_eval=config.num_negative_edges_eval,
-                                    lp_decoder_type=config.lp_decoder_type,
-                                    use_early_stop=config.use_early_stop)
+    evaluator = GSgnnLPEvaluator(config.eval_frequency,
+                                 use_early_stop=config.use_early_stop)
 
     # For MRR, the bigger the better
     val_score = {"mrr": 0.47}
@@ -936,7 +852,7 @@ def test_get_val_score_rank():
 if __name__ == '__main__':
     # test evaluators
     test_mrr_per_etype_lp_evaluation()
-    test_mrr_lp_evaluator()
+    test_lp_evaluator()
     test_regression_evaluator()
     test_early_stop_avg_increase_judge()
     test_early_stop_cons_increase_judge()

--- a/tests/unit-tests/test_evaluator.py
+++ b/tests/unit-tests/test_evaluator.py
@@ -172,7 +172,7 @@ def test_mrr_per_etype_lp_evaluation():
 
     th.distributed.destroy_process_group()
 
-def test_lp_evaluator():
+def test_mrr_lp_evaluator():
     # system heavily depends on th distributed
     dist_init_method = 'tcp://{master_ip}:{master_port}'.format(
         master_ip='127.0.0.1', master_port='12346')
@@ -852,7 +852,7 @@ def test_get_val_score_rank():
 if __name__ == '__main__':
     # test evaluators
     test_mrr_per_etype_lp_evaluation()
-    test_lp_evaluator()
+    test_mrr_lp_evaluator()
     test_regression_evaluator()
     test_early_stop_avg_increase_judge()
     test_early_stop_cons_increase_judge()


### PR DESCRIPTION
*Issue #757, if available:*

*Description of changes:*
This is the 2nd PR of the Evaluator refactor work, which adds `GSgnnRegressionEvaluator`, `GSgnnLPEvaluator`, and `GSgnnPerEtypeLPEvaluator`. In addition, this PR also change the name of `GSgnnLPEvalInterface` to `GSgnnMrrLPEvalInterface`, making the meaning of the interface more clear.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
