### PR TITLE
[Docker] Move local image to CUDA 12.1. Add option for CPU local image.

### DIFF
--- a/docker/Dockerfile.local
+++ b/docker/Dockerfile.local
@@ -1,64 +1,74 @@
 ARG DEVICE=gpu
+ARG SOURCE
 
-FROM nvidia/cuda:12.1.0-runtime-ubuntu20.04 as branch-gpu
-ENV dev_type=GPU
+FROM ${SOURCE} as base
 
-RUN apt update && apt install -y --no-install-recommends \
-    python3-dev \
-    python3-pip \
-    && rm -rf /var/lib/apt/lists/*
-
-# Install DGL and Pytorch for GPU
-RUN pip3 install torch==2.1.2 \
-    && rm -rf /root/.cache
-
-RUN pip3 install networkx==3.1 pydantic dgl==2.1.0+cu121 \
-    -f https://data.dgl.ai/wheels/cu121/repo.html && rm -rf /root/.cache
-
-FROM public.ecr.aws/ubuntu/ubuntu:22.04_stable as branch-cpu
-
-# Install DGL and Pytorch for CPU
-ENV dev_type=CPU
-
-RUN apt update && apt install -y --no-install-recommends \
-    python3-dev \
-    python3-pip \
-    && rm -rf /var/lib/apt/lists/*
-
-RUN pip3 install torch==2.1.2 --index-url https://download.pytorch.org/whl/cpu
-
-RUN pip3 install networkx==3.1 pydantic dgl==2.1.0 \
-    -f https://data.dgl.ai/wheels-internal/repo.html && rm -rf /root/.cache
-
-FROM branch-${DEVICE} as runtime
-
-ENV PYTHONPATH="/root/dgl/tools/:${PYTHONPATH}"
 ENV DEBIAN_FRONTEND=noninteractive
 ENV HOME=/root
 
+ARG DGL_VERSION=1.1.3
+ARG OGB_VERSION=1.3.6
+ARG TORCH_VERSION=2.1.2
+ARG TRANSFORMERS_VERSION=4.28.1
+
 RUN apt update && apt install -y --no-install-recommends \
-    build-essential \
-    cmake \
-    cython3 \
-    g++ \
     git \
     libicu-dev \
-    make \
-    net-tools \
     openssh-client \
     openssh-server \
-    psmisc \
-    unzip \
-    wget \
+    python3.9 \
+    python3.9-distutils \
+    python3.9-venv \
     && rm -rf /var/lib/apt/lists/*
 
+# Create and activate a Python venv
+RUN python3.9 -m venv /opt/gs-venv
+ENV PATH="/opt/gs-venv/bin:$PATH"
 
 # Install GraphStorm dependencies
-RUN pip3 install ogb==1.3.6 scipy pyarrow boto3 scikit-learn transformers h5py psutil \
+RUN pip install \
+    boto3==1.34.89 \
+    botocore==1.34.89 \
+    h5py==3.11.0 \
+    networkx==3.1 \
+    psutil==5.9.8 \
+    pyarrow==14.0.0 \
+    pydantic==2.7.0 \
+    scikit-learn==1.4.2 \
+    scipy==1.13.0 \
     && rm -rf /root/.cache
 
+FROM base as base-cpu
+
+# Install torch, DGL, and GSF deps that require torch
+RUN pip install \
+    torch==${TORCH_VERSION} \
+    --index-url https://download.pytorch.org/whl/cpu \
+    && rm -rf /root/.cache
+
+RUN pip install \
+    dgl==${DGL_VERSION} \
+    ogb==${OGB_VERSION} \
+    transformers==${TRANSFORMERS_VERSION} \
+    -f https://data.dgl.ai/wheels-internal/repo.html && rm -rf /root/.cache
+
+FROM base as base-gpu
+
+# Install torch, DGL, and GSF deps that require torch
+RUN pip install \
+    dgl==${DGL_VERSION}+cu121 \
+    ogb==${OGB_VERSION} \
+    torch==${TORCH_VERSION} \
+    transformers==${TRANSFORMERS_VERSION} \
+    -f https://data.dgl.ai/wheels/cu121/repo.html \
+    && rm -rf /root/.cache
+
+FROM base-${DEVICE} as runtime
+
+ENV PYTHONPATH="/root/dgl/tools/:${PYTHONPATH}"
+
 # Download DGL source code
-RUN cd /root; git clone --recursive https://github.com/dmlc/dgl.git
+RUN cd /root; git clone --single-branch https://github.com/dmlc/dgl.git
 
 # Copy GraphStorm source and add to PYTHONPATH
 RUN mkdir -p /graphstorm

--- a/docker/Dockerfile.local
+++ b/docker/Dockerfile.local
@@ -1,34 +1,66 @@
-FROM nvidia/cuda:11.3.1-devel-ubuntu20.04
+ARG DEVICE=gpu
+
+FROM nvidia/cuda:12.1.0-runtime-ubuntu20.04 as branch-gpu
+ENV dev_type=GPU
+
+RUN apt update && apt install -y --no-install-recommends \
+    python3-dev \
+    python3-pip \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install DGL and Pytorch for GPU
+RUN pip3 install torch==2.1.2 \
+    && rm -rf /root/.cache
+
+RUN pip3 install networkx==3.1 pydantic dgl==2.1.0+cu121 \
+    -f https://data.dgl.ai/wheels/cu121/repo.html && rm -rf /root/.cache
+
+FROM public.ecr.aws/ubuntu/ubuntu:22.04_stable as branch-cpu
+
+# Install DGL and Pytorch for CPU
+ENV dev_type=CPU
+
+RUN apt update && apt install -y --no-install-recommends \
+    python3-dev \
+    python3-pip \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN pip3 install torch==2.1.2 --index-url https://download.pytorch.org/whl/cpu
+
+RUN pip3 install networkx==3.1 pydantic dgl==2.1.0 \
+    -f https://data.dgl.ai/wheels-internal/repo.html && rm -rf /root/.cache
+
+FROM branch-${DEVICE} as runtime
+
+ENV PYTHONPATH="/root/dgl/tools/:${PYTHONPATH}"
 ENV DEBIAN_FRONTEND=noninteractive
 ENV HOME=/root
 
-RUN apt-get update
-RUN apt-get install -y --no-install-recommends build-essential python3-dev make g++ vim net-tools
+RUN apt update && apt install -y --no-install-recommends \
+    build-essential \
+    cmake \
+    cython3 \
+    g++ \
+    git \
+    libicu-dev \
+    make \
+    net-tools \
+    openssh-client \
+    openssh-server \
+    psmisc \
+    unzip \
+    wget \
+    && rm -rf /var/lib/apt/lists/*
 
-RUN apt-get install -y python3-pip git wget psmisc
-RUN apt-get install -y cmake
 
-# Install Pytorch
-RUN pip3 install networkx==3.1 pydantic
-RUN pip3 install torch==2.1.0+cu118 --extra-index-url https://download.pytorch.org/whl/cu118
-
-# Install DGL
-RUN pip3 install dgl==1.0.4+cu117 -f https://data.dgl.ai/wheels/cu117/repo.html
-ENV PYTHONPATH="/root/dgl/tools/:${PYTHONPATH}"
-
-# Install related Python packages
-RUN pip3 install ogb==1.3.6 scipy pyarrow boto3 scikit-learn transformers
-
-# Install other dependencies
-RUN apt-get install -y cython3 libicu-dev
-RUN pip3 install h5py psutil
-
-RUN apt-get install -y unzip
+# Install GraphStorm dependencies
+RUN pip3 install ogb==1.3.6 scipy pyarrow boto3 scikit-learn transformers h5py psutil \
+    && rm -rf /root/.cache
 
 # Download DGL source code
 RUN cd /root; git clone --recursive https://github.com/dmlc/dgl.git
 
-# Install GraphStorm from source code
+# Copy GraphStorm source and add to PYTHONPATH
 RUN mkdir -p /graphstorm
 COPY code/python/graphstorm /graphstorm/python/graphstorm
 ENV PYTHONPATH="/graphstorm/python/:${PYTHONPATH}"
@@ -39,16 +71,17 @@ COPY code/inference_scripts /graphstorm/inference_scripts
 COPY code/tools /graphstorm/tools
 COPY code/training_scripts /graphstorm/training_scripts
 
-# Set up SSH
-RUN apt-get install -y openssh-client openssh-server
+# Set up SSH access
 ENV SSH_PORT=2222
+
 RUN cat /etc/ssh/sshd_config > /tmp/sshd_config && \
     sed "0,/^#Port 22/s//Port ${SSH_PORT}/" /tmp/sshd_config > /etc/ssh/sshd_config
 ENV SSHDIR $HOME/.ssh
-RUN mkdir -p ${SSHDIR}
-RUN ssh-keygen -t rsa -f ${SSHDIR}/id_rsa -N ''
-RUN cp ${SSHDIR}/id_rsa.pub ${SSHDIR}/authorized_keys
+RUN mkdir -p ${SSHDIR} \
+    && ssh-keygen -t rsa -f ${SSHDIR}/id_rsa -N '' \
+    && cp ${SSHDIR}/id_rsa.pub ${SSHDIR}/authorized_keys \
+    && mkdir /run/sshd
 
-EXPOSE 2222
-RUN mkdir /run/sshd
+EXPOSE ${SSH_PORT}
+
 CMD ["/usr/sbin/sshd", "-D"]

--- a/docker/build_docker_oss4local.sh
+++ b/docker/build_docker_oss4local.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -eox pipefail
 
 # process argument 1: graphstorm home folder
 if [ -z "$1" ]; then
@@ -23,6 +24,13 @@ else
     TAG="$3"
 fi
 
+# process argument 4: docker image type, default is GPU
+if [ -z "$4" ]; then
+    IMAGE_TYPE="gpu"
+else
+    IMAGE_TYPE="$4"
+fi
+
 # Copy scripts and tools codes to the docker folder
 mkdir -p $GSF_HOME"/docker/code"
 cp -r $GSF_HOME"/python" $GSF_HOME"/docker/code/python"
@@ -31,11 +39,25 @@ cp -r $GSF_HOME"/inference_scripts" $GSF_HOME"/docker/code/inference_scripts"
 cp -r $GSF_HOME"/tools" $GSF_HOME"/docker/code/tools"
 cp -r $GSF_HOME"/training_scripts" $GSF_HOME"/docker/code/training_scripts"
 
+aws ecr-public get-login-password --region us-east-1 | \
+    docker login --username AWS --password-stdin public.ecr.aws
+
 # Build OSS docker for EC2 instances that an pull ECR docker images
-DOCKER_FULLNAME="${IMAGE_NAME}:${TAG}"
+DOCKER_FULLNAME="${IMAGE_NAME}:${TAG}-${IMAGE_TYPE}"
 
 echo "Build a local docker image ${DOCKER_FULLNAME}"
 docker build --no-cache -f $GSF_HOME"/docker/Dockerfile.local" . -t $DOCKER_FULLNAME
+
+if [ $IMAGE_TYPE = "gpu" ] || [ $IMAGE_TYPE = "cpu" ]; then
+    # Use Buildkit to avoid pulling both CPU and GPU images
+    DOCKER_BUILDKIT=1 docker build --build-arg DEVICE=$IMAGE_TYPE \
+        -f "${GSF_HOME}/docker/Dockerfile.local" . -t $DOCKER_FULLNAME
+else
+    echo "Image type can only be \"gpu\" or \"cpu\", but got \""$IMAGE_TYPE"\""
+    # remove the temporary code folder
+    rm -rf code
+    exit 1
+fi
 
 # remove the temporary code folder
 rm -rf $GSF_HOME"/docker/code"

--- a/docker/build_docker_oss4local.sh
+++ b/docker/build_docker_oss4local.sh
@@ -3,8 +3,8 @@ set -eox pipefail
 
 # process argument 1: graphstorm home folder
 if [ -z "$1" ]; then
-    echo "Please provide the graphstorm home folder that the graphstorm codes are cloned to."
-    echo "For example, ./build_docker_oss4local.sh /graph-storm/"
+    echo "Please provide a path to the root directory of the GraphStorm repository."
+    echo "For example, ./build_docker_oss4local.sh ../ graphstorm local gpu"
     exit 1
 else
     GSF_HOME="$1"

--- a/docker/build_docker_oss4local.sh
+++ b/docker/build_docker_oss4local.sh
@@ -26,9 +26,9 @@ fi
 
 # process argument 4: docker image type, default is GPU
 if [ -z "$4" ]; then
-    IMAGE_TYPE="gpu"
+    DEVICE_TYPE="gpu"
 else
-    IMAGE_TYPE="$4"
+    DEVICE_TYPE="$4"
 fi
 
 # Copy scripts and tools codes to the docker folder
@@ -43,16 +43,16 @@ aws ecr-public get-login-password --region us-east-1 | \
     docker login --username AWS --password-stdin public.ecr.aws
 
 # Build OSS docker for EC2 instances that an pull ECR docker images
-DOCKER_FULLNAME="${IMAGE_NAME}:${TAG}-${IMAGE_TYPE}"
+DOCKER_FULLNAME="${IMAGE_NAME}:${TAG}-${DEVICE_TYPE}"
 
 echo "Build a local docker image ${DOCKER_FULLNAME}"
 
-if [[ $IMAGE_TYPE = "gpu" ]]; then
+if [[ $DEVICE_TYPE = "gpu" ]]; then
     SOURCE_IMAGE="nvidia/cuda:12.1.0-runtime-ubuntu20.04"
-elif [[ $IMAGE_TYPE = "cpu" ]]; then
+elif [[ $DEVICE_TYPE = "cpu" ]]; then
     SOURCE_IMAGE="public.ecr.aws/ubuntu/ubuntu:20.04_stable"
 else
-    echo >&2 -e "Image type can only be \"gpu\" or \"cpu\", but got \""$IMAGE_TYPE"\""
+    echo >&2 -e "Image type can only be \"gpu\" or \"cpu\", but got \""$DEVICE_TYPE"\""
     # remove the temporary code folder
     rm -rf code
     exit 1
@@ -60,7 +60,7 @@ fi
 
 # Use Buildkit to avoid pulling both CPU and GPU images
 DOCKER_BUILDKIT=1 docker build \
-    --build-arg DEVICE=$IMAGE_TYPE \
+    --build-arg DEVICE=$DEVICE_TYPE \
     --build-arg SOURCE=${SOURCE_IMAGE} \
     -f "${GSF_HOME}/docker/Dockerfile.local" . -t $DOCKER_FULLNAME
 

--- a/docker/build_docker_sagemaker.sh
+++ b/docker/build_docker_sagemaker.sh
@@ -12,9 +12,9 @@ fi
 
 # process argument 2: docker image type, default is GPU
 if [ -z "$2" ]; then
-    IMAGE_TYPE="gpu"
+    DEVICE_TYPE="gpu"
 else
-    IMAGE_TYPE="$2"
+    DEVICE_TYPE="$2"
 fi
 
 # process argument 3: docker image name, default is graphstorm
@@ -39,7 +39,7 @@ cp -r "${GSF_HOME}/sagemaker" code/graphstorm/sagemaker
 cp -r "${GSF_HOME}/docker/sagemaker/build_artifacts" build_artifacts
 
 # Build OSS docker for EC2 instances that an pull ECR docker images
-DOCKER_FULLNAME="${IMAGE_NAME}:${TAG}-${IMAGE_TYPE}"
+DOCKER_FULLNAME="${IMAGE_NAME}:${TAG}-${DEVICE_TYPE}"
 
 echo "Build a sagemaker docker image ${DOCKER_FULLNAME}"
 
@@ -47,12 +47,12 @@ echo "Build a sagemaker docker image ${DOCKER_FULLNAME}"
 aws ecr get-login-password --region us-east-1 \
         | docker login --username AWS --password-stdin 763104351884.dkr.ecr.us-east-1.amazonaws.com
 
-if [ $IMAGE_TYPE = "gpu" ] || [ $IMAGE_TYPE = "cpu" ]; then
+if [ $DEVICE_TYPE = "gpu" ] || [ $DEVICE_TYPE = "cpu" ]; then
     # Use Buildkit to avoid pulling both CPU and GPU images
-    DOCKER_BUILDKIT=1 docker build --build-arg DEVICE=$IMAGE_TYPE \
+    DOCKER_BUILDKIT=1 docker build --build-arg DEVICE=$DEVICE_TYPE \
         -f "${GSF_HOME}/docker/sagemaker/Dockerfile.sm" . -t $DOCKER_FULLNAME
 else
-    echo "Image type can only be \"gpu\" or \"cpu\", but got \""$IMAGE_TYPE"\""
+    echo "Device type can only be \"gpu\" or \"cpu\", but got \""$DEVICE_TYPE"\""
     # remove the temporary code folder
     rm -rf code
     exit 1

--- a/docker/build_docker_sagemaker.sh
+++ b/docker/build_docker_sagemaker.sh
@@ -39,7 +39,7 @@ cp -r "${GSF_HOME}/sagemaker" code/graphstorm/sagemaker
 cp -r "${GSF_HOME}/docker/sagemaker/build_artifacts" build_artifacts
 
 # Build OSS docker for EC2 instances that an pull ECR docker images
-DOCKER_FULLNAME="${IMAGE_NAME}:${TAG}"
+DOCKER_FULLNAME="${IMAGE_NAME}:${TAG}-${IMAGE_TYPE}"
 
 echo "Build a sagemaker docker image ${DOCKER_FULLNAME}"
 

--- a/docs/source/install/env-setup.rst
+++ b/docs/source/install/env-setup.rst
@@ -128,7 +128,7 @@ There are four positional arguments for ``build_docker_oss4local.sh``:
 1. **path-to-graphstorm** (**required**), is the absolute path of the "graphstorm" folder, where you cloned the GraphStorm source code. For example, the path could be ``/code/graphstorm``.
 2. **docker-name** (optional), is the assigned name of the to be built Docker image. Default is ``graphstorm``.
 3. **docker-tag** (optional), is the assigned tag name of the to be built docker image. Default is ``local-<device>``.
-3. **device** (optional), is the intended device for the docker image. Default is ``gpu``, can also build a ``cpu`` image.
+4. **device** (optional), is the intended device for the docker image. Default is ``gpu``, can also build a ``cpu`` image.
 
 If Docker requires you to run it as a root user and you don't want to preface all docker commands with sudo, you can check the solution available `here <https://docs.docker.com/engine/install/linux-postinstall/#manage-docker-as-a-non-root-user>`_.
 

--- a/docs/source/install/env-setup.rst
+++ b/docs/source/install/env-setup.rst
@@ -121,13 +121,14 @@ Please use the following command to build a Docker image from source:
 
     cd /path-to-graphstorm/docker/
 
-    bash /path-to-graphstorm/docker/build_docker_oss4local.sh /path-to-graphstorm/ docker-name docker-tag
+    bash /path-to-graphstorm/docker/build_docker_oss4local.sh /path-to-graphstorm/ docker-name docker-tag device
 
-There are three arguments of the ``build_docker_oss4local.sh``:
+There are four positional arguments for ``build_docker_oss4local.sh``:
 
 1. **path-to-graphstorm** (**required**), is the absolute path of the "graphstorm" folder, where you cloned the GraphStorm source code. For example, the path could be ``/code/graphstorm``.
 2. **docker-name** (optional), is the assigned name of the to be built Docker image. Default is ``graphstorm``.
-3. **docker-tag** (optional), is the assigned tag name of the to be built docker image. Default is ``local``.
+3. **docker-tag** (optional), is the assigned tag name of the to be built docker image. Default is ``local-<device>``.
+3. **device** (optional), is the intended device for the docker image. Default is ``gpu``, can also build a ``cpu`` image.
 
 If Docker requires you to run it as a root user and you don't want to preface all docker commands with sudo, you can check the solution available `here <https://docs.docker.com/engine/install/linux-postinstall/#manage-docker-as-a-non-root-user>`_.
 
@@ -137,7 +138,7 @@ You can use the below command to check if the new Docker image is created succes
 
     docker image ls
 
-If the build succeeds, there should be a new Docker image, named *<docker-name>:<docker-tag>*, e.g., ``graphstorm:local``.
+If the build succeeds, there should be a new Docker image, named *<docker-name>:<docker-tag>*, e.g., ``graphstorm:local-gpu``.
 
 Create a GraphStorm Container
 ..............................
@@ -148,7 +149,7 @@ Run the following command:
 
 .. code:: bash
 
-    nvidia-docker run --network=host -v /dev/shm:/dev/shm/ -d --name test graphstorm:local
+    nvidia-docker run --network=host -v /dev/shm:/dev/shm/ -d --name test graphstorm:local-gpu
 
 This command will create a GraphStorm container, named ``test`` and run the container as a daemon.
 

--- a/docs/source/scale/distributed.rst
+++ b/docs/source/scale/distributed.rst
@@ -20,7 +20,7 @@ Setup the instance of a cluster
 .......................................
 A cluster contains several instances each of which can run GraphStorm Docker container.
 
-To create such a cluster, in one instance, please follow the :ref:`Environment Setup <setup_docker>` description to setup GraphStorm Docker container environment, and use a Docker management system, e.g., AWS ECR, to upload the Docker image built in the instance to a Docker repository and pull it to the rest of the instances in the cluster. 
+To create such a cluster, in one instance, please follow the :ref:`Environment Setup <setup_docker>` description to setup GraphStorm Docker container environment, and use a Docker management system, e.g., AWS ECR, to upload the Docker image built in the instance to a Docker repository and pull it to the rest of the instances in the cluster.
 
 If there is no such Docker manangement system available in your environment, in **each** instance of the cluster, follow the :ref:`Environment Setup <setup_docker>` description to build a GraphStorm Docker image, and start the image as a container. Then exchange the ssh key from inside of one GraphStorm Docker containers to the rest containers in the cluster, i.e., copy the keys from the ``/root/.ssh/id_rsa.pub`` from one container to ``/root/.ssh/authorized_keys`` in containers on all other containers.
 
@@ -43,7 +43,7 @@ In each instance, use the following command to start a GraphStorm Docker contain
     nvidia-docker run -v /path_to_data/:/data \
                       -v /dev/shm:/dev/shm \
                       --network=host \
-                      -d --name test graphstorm:local
+                      -d --name test graphstorm:local-gpu
 
 This command mount the shared ``/path_to_data/`` folder to each container's ``/data/`` folder by which GraphStorm codes can access graph data and save training and inference outcomes.
 
@@ -57,14 +57,14 @@ The GraphStorm Docker containers use SSH on port ``2222`` to communicate with ea
     :align: center
 
 .. note:: If possible, use **private IP addresses**, insteand of public IP addresses. Public IP addresses may have additional port constraints, which cause communication issues.
-    
+
 Put this file into container's ``/data/`` folder.
 
 Check port
 ................
 The GraphStorm Docker container uses port ``2222`` to **ssh** to containers running on other machines without passwords. Please make sure all host instances do not use this port.
 
-Users also need to make sure the port ``2222`` is open for **ssh** commands. 
+Users also need to make sure the port ``2222`` is open for **ssh** commands.
 
 Pick one instance and run the following command to connect to the GraphStorm Docker container.
 
@@ -78,9 +78,9 @@ In the container environment, users can check the connectivity with the command 
 
     ssh 172.38.12.143 -o StrictHostKeyChecking=no -p 2222
 
-If succeeds, you should login to the container in the ``<ip-in-the-cluster>`` instance. 
+If succeeds, you should login to the container in the ``<ip-in-the-cluster>`` instance.
 
-If not, please make sure there is no restriction of exposing port 2222. 
+If not, please make sure there is no restriction of exposing port 2222.
 
 For distributed training, users also need to make sure ports under 65536 is open for DistDGL to use.
 
@@ -117,9 +117,9 @@ After this command completes successfully, the partitioned OGBN-MAG graph is sto
 .. code-block:: bash
 
     /data/ogbn_mag_lp_3p
-    ogbn-mag.json 
+    ogbn-mag.json
     node_mapping.pt
-    edge_mapping.pt 
+    edge_mapping.pt
     |- part0
         edge_feat.dgl
         graph.dgl
@@ -137,7 +137,7 @@ After this command completes successfully, the partitioned OGBN-MAG graph is sto
 
 Launch Training on One Container
 ---------------------------------
-When graph partition data is ready, it is easy to launch a distributed training job. Pick a GraphStorm container, e.g. the container with IP address ``172.37.11.221``, and run the following command. 
+When graph partition data is ready, it is easy to launch a distributed training job. Pick a GraphStorm container, e.g. the container with IP address ``172.37.11.221``, and run the following command.
 
 .. code-block:: bash
 
@@ -168,7 +168,7 @@ In addition to the three GraphStorm instance created in the OGBN-MAG tutorial, t
     docker run -v /path_to_data/:/data \
                -v /dev/shm:/dev/shm \
                --network=host \
-               -d --name test graphstorm:local
+               -d --name test graphstorm:local-gpu
 
 .. note::
     - Use the "**docker**", instead of "nvidia-docker" command to create the GraphStorm container because the new r6a.32xlarge instance does not have GPUs installed.
@@ -176,7 +176,7 @@ In addition to the three GraphStorm instance created in the OGBN-MAG tutorial, t
 
 Process and Partition a Graph
 ..............................
-Run the below command to download and partition the OGBN-Papers100M data for a node classification task, which will predict the category of a paper. Because the ogbn-papers100M is one of GraphStorm's built-in datasets, we do not specify some arguments, such as ``target-ntype``, ``nlabel-field``, and ``ntask-type``, which have been automatically handled by GraphStorm's `ogbn_datasets.py <https://github.com/awslabs/graphstorm/blob/main/python/graphstorm/data/ogbn_datasets.py>`_. 
+Run the below command to download and partition the OGBN-Papers100M data for a node classification task, which will predict the category of a paper. Because the ogbn-papers100M is one of GraphStorm's built-in datasets, we do not specify some arguments, such as ``target-ntype``, ``nlabel-field``, and ``ntask-type``, which have been automatically handled by GraphStorm's `ogbn_datasets.py <https://github.com/awslabs/graphstorm/blob/main/python/graphstorm/data/ogbn_datasets.py>`_.
 
 .. code-block:: bash
 
@@ -188,7 +188,7 @@ Run the below command to download and partition the OGBN-Papers100M data for a n
                                                 --balance-edges \
                                                 --output /data/ogbn_papers100M_3p \
 
-Given the size of OGBN-Papers100M, the download and partition process could run more than 5 hours and consume around 700GB memory in peak. After the command completes, the partitioned OGBN-Papers100M graphs are stored in the ``/data/ogbn_papers100M_3p`` folder whose structure is the same as the OGBN-MAG's. 
+Given the size of OGBN-Papers100M, the download and partition process could run more than 5 hours and consume around 700GB memory in peak. After the command completes, the partitioned OGBN-Papers100M graphs are stored in the ``/data/ogbn_papers100M_3p`` folder whose structure is the same as the OGBN-MAG's.
 
 Distribute Partitioned Graphs and Configurations to all Instances
 ...................................................................

--- a/docs/source/scale/sagemaker.rst
+++ b/docs/source/scale/sagemaker.rst
@@ -54,9 +54,9 @@ The ``build_docker_sagemaker.sh`` script takes four arguments:
 .. warning::
     In order to upload the GraphStorm SageMaker Docker image to Amazon ECR, users need to define the <DOCKER_NAME> to include the ECR URI string, **<AWS_ACCOUNT_ID>.dkr.ecr.<REGION>.amazonaws.com/**, e.g., ``888888888888.dkr.ecr.us-east-1.amazonaws.com/graphstorm``.
 
-4. **DOCKER_TAG** (optional), is the assigned tag name of the to-be built Docker image. Default is ``sm``.
+4. **DOCKER_TAG** (optional), is the assigned tag name of the to-be built Docker image. Default is ``sm-<cpu/gpu>``.
 
-Once the ``build_docker_sagemaker.sh`` command completes successfully, there will be a Docker image, named ``<DOCKER_NAME>:<DOCKER_TAG>``, such as ``888888888888.dkr.ecr.us-east-1.amazonaws.com/graphstorm:sm``, in the local repository, which could be listed by running:
+Once the ``build_docker_sagemaker.sh`` command completes successfully, there will be a Docker image, named ``<DOCKER_NAME>:<DOCKER_TAG>``, such as ``888888888888.dkr.ecr.us-east-1.amazonaws.com/graphstorm:sm-gpu``, in the local repository, which could be listed by running:
 
 .. code-block:: bash
 
@@ -84,7 +84,7 @@ And then use the below command to push the built GraphStorm Docker image to user
 
     docker push <DOCKER_NAME>:<DOCKER_TAG>
 
-Please replace the `<DOCKER_NAME>` and `<DOCKER_TAG>` with the actual Docker image name and tag, e.g., ``888888888888.dkr.ecr.us-east-1.amazonaws.com/graphstorm:sm``.
+Please replace the `<DOCKER_NAME>` and `<DOCKER_TAG>` with the actual Docker image name and tag, e.g., ``888888888888.dkr.ecr.us-east-1.amazonaws.com/graphstorm:sm-gpu``.
 
 Run GraphStorm on SageMaker
 ----------------------------

--- a/docs/source/scale/sagemaker.rst
+++ b/docs/source/scale/sagemaker.rst
@@ -43,20 +43,22 @@ Then, clone GraphStorm source code, and build a GraphStorm SageMaker compatible 
 
     cd /path-to-graphstorm/docker/
 
-    bash /path-to-graphstorm/docker/build_docker_sagemaker.sh /path-to-graphstorm/ <DOCKER_TYPE> <DOCKER_NAME> <DOCKER_TAG>
+    bash /path-to-graphstorm/docker/build_docker_sagemaker.sh /path-to-graphstorm/ <DEVICE_TYPE> <IMAGE_NAME> <IMAGE_TAG>
 
 The ``build_docker_sagemaker.sh`` script takes four arguments:
 
 1. **path-to-graphstorm** (**required**), is the absolute path of the ``graphstorm`` folder, where you cloned the GraphStorm source code. For example, the path could be ``/code/graphstorm``.
-2. **DOCKER_TYPE** (optional), is the docker type of the to-be built Docker image. There are two options: ``cpu`` for building CPU-compatible images, and ``gpu`` for building Nvidia GPU-compatible images. Default is ``gpu``.
-3. **DOCKER_NAME** (optional), is the assigned name of the to-be built Docker image. Default is ``graphstorm``.
+2. **DEVICE_TYPE** (optional), is the intended device type of the to-be built Docker image. There are two options: ``cpu`` for building CPU-compatible images, and ``gpu`` for building Nvidia GPU-compatible images. Default is ``gpu``.
+3. **IMAGE_NAME** (optional), is the assigned name of the to-be built Docker image. Default is ``graphstorm``.
 
 .. warning::
-    In order to upload the GraphStorm SageMaker Docker image to Amazon ECR, users need to define the <DOCKER_NAME> to include the ECR URI string, **<AWS_ACCOUNT_ID>.dkr.ecr.<REGION>.amazonaws.com/**, e.g., ``888888888888.dkr.ecr.us-east-1.amazonaws.com/graphstorm``.
+    In order to upload the GraphStorm SageMaker Docker image to Amazon ECR, users need to define the <IMAGE_NAME> to include the ECR URI string, **<AWS_ACCOUNT_ID>.dkr.ecr.<REGION>.amazonaws.com/**, e.g., ``888888888888.dkr.ecr.us-east-1.amazonaws.com/graphstorm``.
 
-4. **DOCKER_TAG** (optional), is the assigned tag name of the to-be built Docker image. Default is ``sm-<cpu/gpu>``.
+4. **IMAGE_TAG** (optional), is the assigned tag name of the to-be built Docker image. Default is ``sm-<DEVICE_TYPE>``,
+   that is, ``sm-gpu`` for GPU images, ``sm-cpu`` for CPU images.
 
-Once the ``build_docker_sagemaker.sh`` command completes successfully, there will be a Docker image, named ``<DOCKER_NAME>:<DOCKER_TAG>``, such as ``888888888888.dkr.ecr.us-east-1.amazonaws.com/graphstorm:sm-gpu``, in the local repository, which could be listed by running:
+Once the ``build_docker_sagemaker.sh`` command completes successfully, there will be a Docker image, named ``<IMAGE_NAME>:<IMAGE_TAG>``,
+such as ``888888888888.dkr.ecr.us-east-1.amazonaws.com/graphstorm:sm-gpu``, in the local repository, which could be listed by running:
 
 .. code-block:: bash
 
@@ -76,15 +78,15 @@ The following command will authenticate the user account to access to user's ECR
 
 Please replace the `<REGION>` and `<AWS_ACCOUNT_ID>` with your own account information and be consistent with the values used in the **Step 1**.
 
-In addition, users need to create an ECR repository at the specified `<REGION>` with the name as `<DOCKER_NAME>` **WITHOUT** the ECR URI string, e.g., ``graphstorm``.
+In addition, users need to create an ECR repository at the specified `<REGION>` with the name as `<IMAGE_NAME>` **WITHOUT** the ECR URI string, e.g., ``graphstorm``.
 
 And then use the below command to push the built GraphStorm Docker image to users' own ECR repository.
 
 .. code-block:: bash
 
-    docker push <DOCKER_NAME>:<DOCKER_TAG>
+    docker push <IMAGE_NAME>:<IMAGE_TAG>
 
-Please replace the `<DOCKER_NAME>` and `<DOCKER_TAG>` with the actual Docker image name and tag, e.g., ``888888888888.dkr.ecr.us-east-1.amazonaws.com/graphstorm:sm-gpu``.
+Please replace the `<IMAGE_NAME>` and `<IMAGE_TAG>` with the actual Docker image name and tag, e.g., ``888888888888.dkr.ecr.us-east-1.amazonaws.com/graphstorm:sm-gpu``.
 
 Run GraphStorm on SageMaker
 ----------------------------
@@ -154,7 +156,7 @@ Users can use the following commands to launch a GraphStorm Link Prediction trai
             --backend gloo \
             --batch-size 128
 
-Please replace `<AMAZON_ECR_IMAGE_URI>` with the `<DOCKER_NAME>:<DOCKER_TAG>` that are uploaded in the Step 2, e.g., ``888888888888.dkr.ecr.us-east-1.amazonaws.com/graphstorm:sm``, replace the `<REGION>` with the region where ECR image repository is located, e.g., ``us-east-1``, and replace the `<ROLE_ARN>` with your AWS account ARN that has SageMaker execution role, e.g., ``"arn:aws:iam::<ACCOUNT_ID>:role/service-role/AmazonSageMaker-ExecutionRole-20220627T143571"``.
+Please replace `<AMAZON_ECR_IMAGE_URI>` with the `<IMAGE_NAME>:<IMAGE_TAG>` that are uploaded in the Step 2, e.g., ``888888888888.dkr.ecr.us-east-1.amazonaws.com/graphstorm:sm``, replace the `<REGION>` with the region where ECR image repository is located, e.g., ``us-east-1``, and replace the `<ROLE_ARN>` with your AWS account ARN that has SageMaker execution role, e.g., ``"arn:aws:iam::<ACCOUNT_ID>:role/service-role/AmazonSageMaker-ExecutionRole-20220627T143571"``.
 
 Because we are using a three-partition OGB-MAG graph, we need to set the ``--instance-count`` to 3 in this command.
 


### PR DESCRIPTION

*Issue #, if available:*

*Description of changes:*

Motivation: we want to be able to run local CPU clusters for cost-efficient partition and inference. Also the 11.7 Nvidia image will be EOL and removed by Nvidia in July 2024.

* Move local image to CUDA 12.1, ~~DGL 2.1.0~~
* Add the option to create CPU images for local clusters, allowing us to run partition/inference in CPU local clusters.
* Also changes tagging for SageMaker image to include image type as tag suffix, cpu/gpu.


### Testing

Created local CPU and GPU clusters on EC2, run example ACM job.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


