### PR TITLE
[Enhancement] Remove GSF dependency on lint check CI

### DIFF
--- a/.github/workflow_scripts/lint_check.sh
+++ b/.github/workflow_scripts/lint_check.sh
@@ -5,7 +5,6 @@ set -ex
 
 python3 -m pip install --upgrade prospector pip
 yes | pip3 install astroid==v3.0.0
-FORCE_CUDA=1 python3 -m pip install -e '.[test]'  --no-build-isolation
 pylint --rcfile=./tests/lint/pylintrc ./python/graphstorm/data/*.py
 pylint --rcfile=./tests/lint/pylintrc ./python/graphstorm/distributed/
 pylint --rcfile=./tests/lint/pylintrc ./python/graphstorm/dataloading/


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Remove the part for installing the graphstorm when running lint test.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
