### PR TITLE
Refactor dataloading

### DIFF
--- a/docs/source/advanced/own-models.rst
+++ b/docs/source/advanced/own-models.rst
@@ -198,37 +198,50 @@ the ``ip_config`` argument specifies a ip configuration file, which contains the
 
 Replace DGL DataLoader with the GraphStorm's dataset and dataloader
 `````````````````````````````````````````````````````````````````````
-Because the GraphStorm uses distributed graphs, we need to first load the partitioned graph, which is created in the :ref:`Step 1 <step-1>`, with the `GSgnnNodeTrainData <https://github.com/awslabs/graphstorm/blob/main/python/graphstorm/dataloading/dataset.py#L469>`_ class (for edge tasks, GraphStorm also provides `GSgnnEdgeTrainData <https://github.com/awslabs/graphstorm/blob/main/python/graphstorm/dataloading/dataset.py#L216>`_). The ``GSgnnNodeTrainData`` could be created as shown in the code below.
+Because the GraphStorm uses distributed graphs, we need to first load the partitioned graph, which is created in the :ref:`Step 1 <step-1>`, with the `GSgnnData <https://github.com/awslabs/graphstorm/blob/main/python/graphstorm/dataloading/dataset.py#L57>`_ class (for edge tasks, the same class is used). The ``GSgnnData`` could be created as shown in the code below.
 
 .. code-block:: python
 
-    train_data = GSgnnNodeTrainData(config.graph_name,
-                                    config.part_config,
-                                    train_ntypes=config.target_ntype,
-                                    node_feat_field=node_feat_fields,
-                                    label_field=config.label_field)
+    train_data = GSgnnData(config.part_config)
 
-Arguments of this class include the partition configuration JSON file path, which are the outputs of the :ref:`Step 1 <step-1>`. The ``graph_name`` can be found in the JSON file.
+Arguments of this class include the partition configuration JSON file path, which are the outputs of the :ref:`Step 1 <step-1>`.
 
-The other values, the ``train_ntypes``, the ``label_field``, and the ``node_feat_field``, should be consistent with the values in the raw data :ref:`input configuration JSON <input-config>` defined in the :ref:`Step 1 <step-1>`. The ``train_ntypes`` is the ``node_type`` that has ``labels`` specified. The ``label_fields`` is the value specified in ``label_col`` of the ``train_ntype``. The ``node_feat_field`` is a dictionary, whose key is the values of ``node_type``, and value is the values of ``feature_name``.
-
-Then we can put this dataset into GraphStorm's `GSgnnNodeDataLoader <https://github.com/awslabs/graphstorm/blob/main/python/graphstorm/dataloading/dataloading.py#L544>`_, which is like:
+Then we can put this dataset into GraphStorm's `GSgnnNodeDataLoader <https://github.com/awslabs/graphstorm/blob/main/python/graphstorm/dataloading/dataloading.py#L1237>`_, which is like:
 
 .. code-block:: python
 
+    # Get train idx
+    train_idxs = train_data.get_node_train_set(config.target_ntype)
     # Define the GraphStorm train dataloader
-    dataloader = GSgnnNodeDataLoader(train_data, train_data.train_idxs, fanout=config.fanout,
-                                     batch_size=config.batch_size, device=device, train_task=True)
+    dataloader = GSgnnNodeDataLoader(train_data,
+                                     train_idxs, fanout=config.fanout,
+                                     batch_size=config.batch_size,
+                                     label_field=config.label_field,
+                                     node_feats=node_feat_fields,train_task=True)
+
     # Optional: Define the evaluation dataloader
-    eval_dataloader = GSgnnNodeDataLoader(train_data, train_data.val_idxs,fanout=config.fanout,
-                                          batch_size=config.eval_batch_size, device=device,
+    val_idxs = train_data.get_node_val_set(eval_ntype)
+    eval_dataloader = GSgnnNodeDataLoader(train_data,
+                                          val_idxs,
+                                          fanout=config.fanout,
+                                          batch_size=config.eval_batch_size,
+                                          label_field=config.label_field,
+                                          node_feats=node_feat_fields,
                                           train_task=False)
     # Optional: Define the evaluation dataloader
-    test_dataloader = GSgnnNodeDataLoader(train_data, train_data.test_idxs,fanout=config.fanout,
-                                          batch_size=config.eval_batch_size, device=device,
+    test_idxs = train_data.get_node_test_set(eval_ntype)
+    test_dataloader = GSgnnNodeDataLoader(train_data,
+                                          test_idxs,
+                                          fanout=config.fanout,
+                                          batch_size=config.eval_batch_size,
+                                          label_field=config.label_field,
+                                          node_feats=node_feat_fields,
                                           train_task=False)
 
-GraphStorm provides a set of dataloaders for different GML tasks. Here we deal with a node task, hence using the node dataloader, which takes the graph data created above as the first argument. The second argument is the label index that the GraphStorm dataset extracts from the graph as indicated in the target nodes' ``train_mask``, ``val_mask``, and ``test_mask``, which are automatically generated by GraphStorm graph construction tool with the specified ``split_pct`` field. The ``GSgnnNodeTrainData`` automatically extracts these indexes out and set its properties so that you can directly use them like ``graph_data.train_idxs`` and ``graph_data.val_idxs``, and ``graph_data.test_idxs``. The rest of arguments are similar to the common training flow, except that we set the ``train_task`` to be ``False`` for the evaluation and test dataloader.
+GraphStorm provides a set of dataloaders for different GML tasks. Here we deal with a node task, hence using the node dataloader, which takes the graph data created above as the first argument. The second argument is the label index that the GraphStorm dataset extracts from the graph as indicated in the target nodes' ``train_mask``, ``val_mask``, and ``test_mask``, which are automatically generated by GraphStorm graph construction tool with the specified ``split_pct`` field. The ``GSgnnData`` provides functions to get the indexes of train data, validation data and test data through ``get_node_train_set``, ``get_node_val_set`` and ``get_node_test_set``, respectively.
+The ``label_field`` is also required by the GSgnnNodeDataLoader to get the labels for model training and evaluation.
+The ``node_feats`` and ``edge_feats`` are optional to GSgnnNodeDataLoader, which define the node features and edge features, respectively, to be used for the task associated with the dataloader.
+The rest of arguments are similar to the common training flow, except that we set the ``train_task`` to be ``False`` for the evaluation and test dataloader.
 
 Use GraphStorm's model trainer to wrap your model and attach evaluator and task tracker to it
 ````````````````````````````````````````````````````````````````````````````````````````````````

--- a/docs/source/api/graphstorm.dataloading.rst
+++ b/docs/source/api/graphstorm.dataloading.rst
@@ -33,10 +33,7 @@ DataSets
     :nosignatures:
     :template: datasettemplate.rst
 
-    GSgnnNodeTrainData
-    GSgnnNodeInferData
-    GSgnnEdgeTrainData
-    GSgnnEdgeInferData
+    GSgnnData
 
 DataLoaders
 ------------

--- a/docs/source/tutorials/own-data.rst
+++ b/docs/source/tutorials/own-data.rst
@@ -244,8 +244,8 @@ Required DGL graph format
 ```````````````````````````
 - a `dgl.heterograph <https://docs.dgl.ai/generated/dgl.heterograph.html#dgl.heterograph>`_.
 - All nodes/edges features are set in nodes/edges' data field, and remember the feature names, which will be used in the later steps.
-    - For nodes' features, the common way to set features is like ``g.nodes['nodetypename'].data['featurename']=nodefeaturetensor``, The formal explanation of DGL's node feature could be found in the `Using node features <https://docs.dgl.ai/generated/dgl.DGLGraph.nodes.html>`_.
-    - For edges' features, the common way to set features is like ``g.edges['edgetypename'].data['featurename']=edgefeaturetensor``, The formal explanation of DGL's edge feature could be found in the `Using edge features <https://docs.dgl.ai/generated/dgl.DGLGraph.edges.html>`_.
+    - For nodes' features, the common way to set features is like ``g.nodes['nodetypename'].data['featurename']=nodefeaturetensor``, The formal explanation of DGL's node feature could be found in the `Using node features <https://docs.dgl.ai/generated/dgl.DGLGraph.nodes.html>`_. Please make sure every node feature is a 2D tensor.
+    - For edges' features, the common way to set features is like ``g.edges['edgetypename'].data['featurename']=edgefeaturetensor``, The formal explanation of DGL's edge feature could be found in the `Using edge features <https://docs.dgl.ai/generated/dgl.DGLGraph.edges.html>`_. Please make sure every edge feature is a 2D tensor.
 - Save labels (for node/edge tasks) into the target nodes/edges as a feature, and remember the label feature names, which will be used in the later steps.
     - The common way to set node-related labels as a feature is like ``g.nodes['predictnodetypename'].data['labelname']=nodelabeltensor``.
     - The common way to set edge-related labels as a feature is like ``g.nodes['predictedgetypename'].data['labelname']=edgelabeltensor``.
@@ -435,7 +435,7 @@ Similar to the :ref:`Quick-Start <quick-start-standalone>` tutorial, users can l
               --node-feat-name paper:feat author:feat subject:feat \
               --restore-model-path /tmp/acm_nc/models/epoch-0 \
               --save-prediction-path  /tmp/acm_nc/predictions
-    
+
     # Link Prediction
     python -m graphstorm.run.gs_link_prediction \
               --inference \

--- a/examples/customized_models/HGT/README.md
+++ b/examples/customized_models/HGT/README.md
@@ -17,7 +17,7 @@ In order to plus users' own GNN models into the GraphStorm Framework, users need
     - Define your own loss function, or use GraphStorm's built-in loss functions that can handel common classification, regression, and link predictioin tasks.
     - In case having unused weights problem, modify the loss computation to include a regulation computation of all parameters
 
-3. Use the GraphStorm's dataset, e.g., [GSgnnNodeTrainData](https://github.com/awslabs/graphstorm/blob/main/python/graphstorm/dataloading/dataset.py#L469) and dataloader, e.g., [GSgnnNodeDataLoader](https://github.com/awslabs/graphstorm/blob/main/python/graphstorm/dataloading/dataloading.py#L544) to construct distributed graph loading and mini-batch sampling.
+3. Use the GraphStorm's dataset, e.g., [GSgnnData](https://github.com/awslabs/graphstorm/blob/main/python/graphstorm/dataloading/dataset.py#L157) and dataloader, e.g., [GSgnnNodeDataLoader](https://github.com/awslabs/graphstorm/blob/main/python/graphstorm/dataloading/dataloading.py#L544) to construct distributed graph loading and mini-batch sampling.
 
 4. Wrap your model in a GraphStorm trainer, e.g., [GSgnnNodePredictionTrainer](https://github.com/awslabs/graphstorm/blob/main/python/graphstorm/trainer/np_trainer.py), which will handle the training process with its fit() method.
 

--- a/examples/customized_models/HGT/hgt_nc.py
+++ b/examples/customized_models/HGT/hgt_nc.py
@@ -12,7 +12,7 @@ from graphstorm.config import GSConfig
 from graphstorm import model as gsmodel
 from graphstorm.trainer import GSgnnNodePredictionTrainer
 from graphstorm.inference import GSgnnNodePredictionInferrer
-from graphstorm.dataloading import GSgnnNodeTrainData, GSgnnNodeInferData
+from graphstorm.dataloading import GSgnnData
 from graphstorm.dataloading import GSgnnNodeDataLoader
 from graphstorm.eval import GSgnnAccEvaluator
 from graphstorm.tracker import GSSageMakerTaskTracker
@@ -272,11 +272,7 @@ def main(args):
         node_feat_fields[node_type] = feat_names.split(',')
 
     # Define the GraphStorm training dataset
-    train_data = GSgnnNodeTrainData(config.graph_name,
-                                    config.part_config,
-                                    train_ntypes=config.target_ntype,
-                                    node_feat_field=node_feat_fields,
-                                    label_field=config.label_field)
+    train_data = GSgnnData(config.part_config)
 
     # Create input arguments for the HGT model
     node_dict = {}
@@ -311,18 +307,29 @@ def main(args):
     trainer = GSgnnNodePredictionTrainer(model, topk_model_to_save=config.topk_model_to_save)
     trainer.setup_device(device=get_device())
 
+    train_idxs = train_data.get_node_train_set(config.target_ntype)
     # Define the GraphStorm train dataloader
-    dataloader = GSgnnNodeDataLoader(train_data, train_data.train_idxs, fanout=config.fanout,
-                                     batch_size=config.batch_size, train_task=True)
+    dataloader = GSgnnNodeDataLoader(train_data, train_idxs, fanout=config.fanout,
+                                     batch_size=config.batch_size,
+                                     node_feats=node_feat_fields,
+                                     label_field=config.label_field,
+                                     train_task=True)
 
+    eval_ntype = config.eval_target_ntype
+    val_idxs = train_data.get_node_val_set(eval_ntype)
+    test_idxs = train_data.get_node_test_set(eval_ntype)
     # Optional: Define the evaluation dataloader
-    eval_dataloader = GSgnnNodeDataLoader(train_data, train_data.val_idxs,fanout=config.fanout,
+    eval_dataloader = GSgnnNodeDataLoader(train_data, val_idxs, fanout=config.fanout,
                                           batch_size=config.eval_batch_size,
+                                          node_feats=node_feat_fields,
+                                          label_field=config.label_field,
                                           train_task=False)
 
     # Optional: Define the evaluation dataloader
-    test_dataloader = GSgnnNodeDataLoader(train_data, train_data.test_idxs,fanout=config.fanout,
+    test_dataloader = GSgnnNodeDataLoader(train_data, test_idxs, fanout=config.fanout,
                                           batch_size=config.eval_batch_size,
+                                          node_feats=node_feat_fields,
+                                          label_field=config.label_field,
                                           train_task=False)
 
     # Optional: set up a evaluator
@@ -351,18 +358,18 @@ def main(args):
     model.restore_model(best_model_path)
 
     # Create a dataset for inference.
-    infer_data = GSgnnNodeInferData(config.graph_name, config.part_config,
-                                    eval_ntypes=config.target_ntype,
-                                    node_feat_field=node_feat_fields,
-                                    label_field=config.label_field)
+    infer_data = GSgnnData(config.part_config)
 
     # Create an inference for a node task.
     infer = GSgnnNodePredictionInferrer(model)
     infer.setup_device(device=get_device())
     infer.setup_evaluator(evaluator)
     infer.setup_task_tracker(tracker)
-    dataloader = GSgnnNodeDataLoader(infer_data, infer_data.test_idxs,
+    infer_idxs = infer_data.get_node_infer_set(eval_ntype)
+    dataloader = GSgnnNodeDataLoader(infer_data,infer_idxs,
                                     fanout=config.fanout, batch_size=100,
+                                    node_feats=node_feat_fields,
+                                    label_field=config.label_field,
                                     train_task=False)
 
     # Run inference on the inference dataset and save the GNN embeddings in the specified path.
@@ -390,7 +397,7 @@ if __name__ == '__main__':
                            default=argparse.SUPPRESS,
                           help="Print more information. \
                                 For customized models, MUST have this argument!!")
-    argparser.add_argument("--local_rank", type=int,
+    argparser.add_argument("--local-rank", type=int,
                            help="The rank of the trainer. \
                                  For customized models, MUST have this argument!!")
 

--- a/examples/peft_llm_gnn/main_lp.py
+++ b/examples/peft_llm_gnn/main_lp.py
@@ -5,7 +5,7 @@ from graphstorm.config import get_argument_parser
 from graphstorm.config import GSConfig
 from graphstorm.dataloading import GSgnnLinkPredictionDataLoader, GSgnnLinkPredictionTestDataLoader
 from graphstorm.eval import GSgnnMrrLPEvaluator
-from graphstorm.dataloading import GSgnnLPTrainData
+from graphstorm.dataloading import GSgnnData
 from graphstorm.utils import get_device
 from graphstorm.inference import GSgnnLinkPredictionInferrer
 from graphstorm.trainer import GSgnnLinkPredictionTrainer
@@ -20,14 +20,12 @@ def main(config_args):
     gs.initialize(ip_config=config.ip_config, backend=config.backend,
                   local_rank=config.local_rank)
     # Define the training dataset
-    train_data = GSgnnLPTrainData(
-        config.graph_name,
+    train_data = GSgnnData(
         config.part_config,
-        train_etypes=config.train_etype,
-        eval_etypes=config.eval_etype,
-        label_field=None,
         node_feat_field=config.node_feat_name,
     )
+    train_etypes=config.train_etype
+    eval_etypes=config.eval_etype
 
     model = GNNLLM_LP(
             g=train_data.g,
@@ -69,23 +67,27 @@ def main(config_args):
     trainer.setup_task_tracker(tracker)
 
     # create train loader with uniform negative sampling
+    train_idxs = train_data.get_edge_train_set(train_etypes)
     dataloader = GSgnnLinkPredictionDataLoader(
         train_data,
-        train_data.train_idxs,
+        train_idxs,
         fanout=config.fanout,
         batch_size=config.batch_size,
         num_negative_edges=config.num_negative_edges,
+        node_feats=config.node_feat_name,
         train_task=True,
         reverse_edge_types_map=config.reverse_edge_types_map,
         exclude_training_targets=config.exclude_training_targets,
     )
 
     # create val loader
+    val_idxs = train_data.get_edge_val_set(eval_etypes)
     val_dataloader = GSgnnLinkPredictionTestDataLoader(
         train_data,
-        train_data.val_idxs,
+        val_idxs,
         batch_size=config.eval_batch_size,
         num_negative_edges=config.num_negative_edges,
+        node_feats=config.node_feat_name,
         fanout=config.fanout,
     )
 
@@ -112,11 +114,13 @@ def main(config_args):
     infer.setup_evaluator(evaluator)
     infer.setup_task_tracker(tracker)
     # Create test loader
+    infer_idxs = train_data.get_edge_infer_set(eval_etypes)
     test_dataloader = GSgnnLinkPredictionTestDataLoader(
         train_data,
-        train_data.test_idxs,
+        infer_idxs,
         batch_size=config.eval_batch_size,
         num_negative_edges=config.num_negative_edges_eval,
+        node_feats=config.node_feat_name,
         fanout=config.fanout,
     )
     # Run inference on the inference dataset and save the GNN embeddings in the specified path.

--- a/examples/peft_llm_gnn/main_nc.py
+++ b/examples/peft_llm_gnn/main_nc.py
@@ -4,7 +4,7 @@ from graphstorm.config import get_argument_parser
 from graphstorm.config import GSConfig
 from graphstorm.dataloading import GSgnnNodeDataLoader
 from graphstorm.eval import GSgnnAccEvaluator
-from graphstorm.dataloading import GSgnnNodeTrainData
+from graphstorm.dataloading import GSgnnData
 from graphstorm.utils import get_device
 from graphstorm.inference import GSgnnNodePredictionInferrer
 from graphstorm.trainer import GSgnnNodePredictionTrainer
@@ -18,14 +18,8 @@ def main(config_args):
     gs.initialize(ip_config=config.ip_config, backend=config.backend,
                   local_rank=config.local_rank)
     # Define the training dataset
-    train_data = GSgnnNodeTrainData(
-        config.graph_name,
-        config.part_config,
-        train_ntypes=config.target_ntype,
-        eval_ntypes=config.eval_target_ntype,
-        label_field=config.label_field,
-        node_feat_field=config.node_feat_name,
-    )
+    train_data = GSgnnData(
+        config.part_config)
 
     model = GNNLLM_NC(
             g=train_data.g,
@@ -66,20 +60,26 @@ def main(config_args):
     trainer.setup_task_tracker(tracker)
 
     # create train loader
+    train_idxs = train_data.get_node_train_set(config.target_ntype)
     dataloader = GSgnnNodeDataLoader(
         train_data,
-        train_data.train_idxs,
+        train_idxs,
         fanout=config.fanout,
         batch_size=config.batch_size,
+        node_feats=config.node_feat_name,
+        label_field=config.label_field,
         train_task=True,
     )
 
     # create val loader
+    val_idxs = train_data.get_node_val_set(config.eval_target_ntype)
     val_dataloader = GSgnnNodeDataLoader(
         train_data,
-        train_data.val_idxs,
+        val_idxs,
         fanout=config.fanout,
         batch_size=config.eval_batch_size,
+        node_feats=config.node_feat_name,
+        label_field=config.label_field,
         train_task=False,
     )
 
@@ -106,11 +106,14 @@ def main(config_args):
     infer.setup_evaluator(evaluator)
     infer.setup_task_tracker(tracker)
     # Create test loader
+    test_idxs = train_data.get_node_test_set(config.eval_target_ntype)
     test_dataloader = GSgnnNodeDataLoader(
         train_data,
-        train_data.test_idxs,
+        test_idxs,
         fanout=config.fanout,
         batch_size=config.eval_batch_size,
+        node_feats=config.node_feat_name,
+        label_field=config.label_field,
         train_task=False,
     )
     # Run inference on the inference dataset and save the GNN embeddings in the specified path.

--- a/examples/temporal_graph_learning/graphstorm_train_script_nc_config.yaml
+++ b/examples/temporal_graph_learning/graphstorm_train_script_nc_config.yaml
@@ -41,6 +41,6 @@ gsf:
     use_self_loop: true
 udf:
   save_result_path: tgat_nc_gpu
-  eval_target_ntype:
-  - paper
+  eval_target_ntypes:
+    - paper
 version: 1.0

--- a/examples/temporal_graph_learning/main_nc.py
+++ b/examples/temporal_graph_learning/main_nc.py
@@ -4,7 +4,7 @@ from graphstorm.config import get_argument_parser
 from graphstorm.config import GSConfig
 from graphstorm.dataloading import GSgnnNodeDataLoader
 from graphstorm.eval import GSgnnAccEvaluator
-from graphstorm.dataloading import GSgnnNodeTrainData
+from graphstorm.dataloading import GSgnnData
 from graphstorm.utils import get_device
 from graphstorm.trainer import GSgnnNodePredictionTrainer
 
@@ -18,14 +18,8 @@ def main(config_args):
                   local_rank=config.local_rank)
 
     # Define the training dataset
-    train_data = GSgnnNodeTrainData(
-        config.graph_name,
-        config.part_config,
-        train_ntypes=config.target_ntype,
-        eval_ntypes=config.eval_target_ntype,
-        label_field=config.label_field,
-        node_feat_field=config.node_feat_name,
-    )
+    train_data = GSgnnData(
+        config.part_config)
 
     # Define TGAT model
     model = create_rgcn_model_for_nc(train_data.g, config)
@@ -33,7 +27,7 @@ def main(config_args):
 
     # Create a trainer for NC tasks.
     trainer = GSgnnNodePredictionTrainer(
-        model, gs.get_rank(), topk_model_to_save=config.topk_model_to_save
+        model, topk_model_to_save=config.topk_model_to_save
     )
 
     if config.restore_model_path is not None:
@@ -57,29 +51,38 @@ def main(config_args):
     trainer.setup_evaluator(evaluator)
 
     # create train loader
+    train_idxs = train_data.get_node_train_set(config.target_ntype)
     dataloader = GSgnnNodeDataLoader(
         train_data,
-        train_data.train_idxs,
+        train_idxs,
         fanout=config.fanout,
         batch_size=config.batch_size,
+        node_feats=config.node_feat_name,
+        label_field=config.label_field,
         train_task=True,
     )
 
     # create val loader
+    val_idxs = train_data.get_node_val_set(config.eval_target_ntypes)
     val_dataloader = GSgnnNodeDataLoader(
         train_data,
-        train_data.val_idxs,
+        val_idxs,
         fanout=config.fanout,
         batch_size=config.eval_batch_size,
+        node_feats=config.node_feat_name,
+        label_field=config.label_field,
         train_task=False,
     )
 
     # create test loader
+    test_idxs = train_data.get_node_test_set(config.eval_target_ntypes)
     test_dataloader = GSgnnNodeDataLoader(
         train_data,
-        train_data.test_idxs,
+        test_idxs,
         fanout=config.fanout,
         batch_size=config.eval_batch_size,
+        node_feats=config.node_feat_name,
+        label_field=config.label_field,
         train_task=False,
     )
 

--- a/python/graphstorm/config/argument.py
+++ b/python/graphstorm/config/argument.py
@@ -755,6 +755,14 @@ class GSConfig:
         return None
 
     @property
+    def edge_feat_name(self):
+        """ User defined edge feature name
+
+        Not used by GraphStorm, reserved for future usage.
+        """
+        return None
+
+    @property
     def node_feat_name(self):
         """ User defined node feature name
 

--- a/python/graphstorm/dataloading/__init__.py
+++ b/python/graphstorm/dataloading/__init__.py
@@ -35,10 +35,7 @@ from .dataloading import (GSgnnEdgeDataLoaderBase,
                           GSgnnLinkPredictionDataLoaderBase,
                           GSgnnNodeDataLoaderBase)
 
-from .dataset import GSgnnEdgeTrainData, GSgnnLPTrainData
-from .dataset import GSgnnEdgeInferData
-from .dataset import GSgnnNodeTrainData
-from .dataset import GSgnnNodeInferData
+from .dataset import GSgnnData
 
 from .dataloading import (BUILTIN_LP_UNIFORM_NEG_SAMPLER,
                           BUILTIN_LP_JOINT_NEG_SAMPLER,

--- a/python/graphstorm/dataloading/dataloading.py
+++ b/python/graphstorm/dataloading/dataloading.py
@@ -355,7 +355,11 @@ class GSgnnEdgeDataLoader(GSgnnEdgeDataLoaderBase):
         from graphstorm.trainer import GSgnnEdgePredictionTrainer
 
         ep_data = GSgnnData(...)
-        ep_dataloader = GSgnnEdgeDataLoader(ep_data, target_idx, fanout=[15, 10], batch_size=128)
+        target_idx = ep_data.get_edge_train_set(...)
+        ep_dataloader = GSgnnEdgeDataLoader(
+            ep_data, target_idx,
+            fanout=[15, 10], batch_size=128,
+            label_field=config.label_field)
         ep_trainer = GSgnnEdgePredictionTrainer(...)
         ep_trainer.fit(ep_dataloader, num_epochs=10)
     """
@@ -679,6 +683,7 @@ class GSgnnLinkPredictionDataLoader(GSgnnLinkPredictionDataLoaderBase):
         from graphstorm.trainer import GSgnnLinkPredictionTrainer
 
         lp_data = GSgnnData(...)
+        target_idx = lp_data.get_edge_train_set(...)
         lp_dataloader = GSgnnLinkPredictionDataLoader(lp_data, target_idx, fanout=[15, 10],
                                                     num_negative_edges=10, batch_size=128)
         lp_trainer = GSgnnLinkPredictionTrainer(...)
@@ -1542,9 +1547,11 @@ class GSgnnNodeDataLoader(GSgnnNodeDataLoaderBase):
         from graphstorm.trainer import GSgnnNodePredictionTrainer
 
         np_data = GSgnnData(...)
+        target_idx = np_data.get_node_train_set(...)
         np_dataloader = GSgnnNodeDataLoader(np_data, target_idx, fanout=[15, 10],
                                             batch_size=128,
-                                            label_field="label", node_feats="feat")
+                                            label_field="label",
+                                            node_feats="feat")
         np_trainer = GSgnnNodePredictionTrainer(...)
         np_trainer.fit(np_dataloader, num_epochs=10)
     """

--- a/python/graphstorm/dataloading/dataset.py
+++ b/python/graphstorm/dataloading/dataset.py
@@ -159,8 +159,6 @@ class GSgnnData():
 
     Parameters
     ----------
-    graph_name : str
-        The graph name
     part_config : str
         The path of the partition configuration file.
     node_feat_field: str or dict of list of str

--- a/python/graphstorm/dataloading/dataset.py
+++ b/python/graphstorm/dataloading/dataset.py
@@ -16,20 +16,19 @@
     Various datasets for the GSF
 """
 import os
-import abc
 import logging
 import re
 
 import torch as th
 import dgl
+import pandas as pd
 from dgl.distributed.constants import DEFAULT_NTYPE, DEFAULT_ETYPE
 from torch.utils.data import Dataset
-import pandas as pd
 
-import  graphstorm as gs
 from ..utils import get_rank, get_world_size, is_distributed, barrier, is_wholegraph
 from ..utils import sys_tracker
 from .utils import dist_sum, flip_node_mask
+from ..utils import get_graph_name
 
 from ..wholegraph import is_wholegraph_embedding
 
@@ -76,13 +75,27 @@ def prepare_batch_input(g, input_nodes,
             # concatenate multiple features together
             feats = []
             for fname in feat_name:
+                assert fname in g.nodes[ntype].data, \
+                    f"{fname} does not exist as a node feature of {ntype}"
                 data = g.nodes[ntype].data[fname]
                 if is_wholegraph_embedding(data):
                     data = data.gather(nid.to(dev))
                 else:
                     data = data[nid].to(dev)
                 feats.append(data)
-            feat[ntype] = th.cat(feats, dim=1)
+            assert len(feats) > 0, \
+                "No feature exists in the graph. " \
+                f"Expecting the graph have following node features {feat_name}."
+
+            if len(feats[0].shape) == 1:
+                # The feature is 1D. It will be features for label
+                assert len(feats) == 1, \
+                    "For 1D features, we assume they are label features." \
+                    f"Please access them 1 by 1, but get {feat_name}"
+                feat[ntype] = feats[0]
+            else:
+                # The feature is 2D
+                feat[ntype] = th.cat(feats, dim=1)
     return feat
 
 def prepare_batch_edge_input(g, input_edges,
@@ -108,22 +121,37 @@ def prepare_batch_edge_input(g, input_edges,
         If a node type has features, it will get node features.
     """
     feat = {}
-    for etypes, eid in input_edges.items():
+    for etype, eid in input_edges.items():
         feat_name = None if feat_field is None else \
             [feat_field] if isinstance(feat_field, str) \
-            else feat_field[etypes] if etypes in feat_field else None
+            else feat_field[etype] if etype in feat_field else None
 
         if feat_name is not None:
             # concatenate multiple features together
             feats = []
             for fname in feat_name:
-                data = g.edges[etypes].data[fname]
+                assert fname in g.edges[etype].data, \
+                    f"{fname} does not exist as an edge feature of {etype}"
+                data = g.edges[etype].data[fname]
                 if is_wholegraph_embedding(data):
                     data = data.gather(eid.to(dev))
                 else:
                     data = data[eid].to(dev)
                 feats.append(data)
-            feat[etypes] = th.cat(feats, dim=1)
+
+            assert len(feats) > 0, \
+                "No feature exists in the graph. " \
+                f"Expecting the graph have following edge features {feat_name}."
+
+            if len(feats[0].shape) == 1:
+                # The feature is 1D. It will be features for label
+                assert len(feats) == 1, \
+                    "For 1D features, we assume they are label features." \
+                    f"Please access them 1 by 1, but get {feat_name}"
+                feat[etype] = feats[0]
+            else:
+                # The feature is 2D
+                feat[etype] = th.cat(feats, dim=1)
     return feat
 
 class GSgnnData():
@@ -136,30 +164,42 @@ class GSgnnData():
     part_config : str
         The path of the partition configuration file.
     node_feat_field: str or dict of list of str
-        Fields to extract node features. It's a dict if different node types have
+        The fields of the node features that will be encoded by GSNodeInputLayer.
+        It's a dict if different node types have
         different feature names.
+        Default: None
     edge_feat_field : str or dict of list of str
-        The field of the edge features. It's a dict if different edge types have
+        The fields of the edge features.
+        It's a dict if different edge types have
         different feature names.
-    decoder_edge_feat: str or dict of list of str
-        Edge features used by decoder
+        This argument is reserved by future usage.
+        Default: None
     lm_feat_ntypes : list of str
         The node types that contains text features.
+        Default: None
     lm_feat_etypes : list of tuples
         The edge types that contains text features.
+        Default: None
     """
 
-    def __init__(self, graph_name, part_config, node_feat_field, edge_feat_field,
-                 decoder_edge_feat=None, lm_feat_ntypes=None, lm_feat_etypes=None):
+    def __init__(self, part_config, node_feat_field=None, edge_feat_field=None,
+                 lm_feat_ntypes=None, lm_feat_etypes=None):
+        graph_name = get_graph_name(part_config)
         self._g = dgl.distributed.DistGraph(graph_name, part_config=part_config)
+        self._graph_name = graph_name
+        # Note: node_feat_field and edge_feat_field are useful in three cases:
+        # 1. WholeGraph: As the feature information is not stored in g,
+        #    node_feat_field and edge_feat_field are used to tell GraphStorm
+        #    what features should be loaded by WholeGraph
+        # 2. Used by _ReconstructedNeighborSampler to decide whether a node
+        #    or an edge has feature.
+        # 3. Used by do_full_graph_inference and do_mini_batch_inference when
+        #    computing input embeddings.
+        self._check_node_feats(node_feat_field)
         self._node_feat_field = node_feat_field
         self._edge_feat_field = edge_feat_field
         self._lm_feat_ntypes = lm_feat_ntypes if lm_feat_ntypes is not None else []
         self._lm_feat_etypes = lm_feat_etypes if lm_feat_etypes is not None else []
-
-        self._train_idxs = {}
-        self._val_idxs = {}
-        self._test_idxs = {}
 
         if get_rank() == 0:
             g = self._g
@@ -195,11 +235,11 @@ class GSgnnData():
 
             # load edge feature from wholegraph memory
             # TODO(IN): Add support for edge_feat_field
-            if decoder_edge_feat:
-                if isinstance(decoder_edge_feat, str):
-                    decoder_edge_feat = {etype: [decoder_edge_feat] \
+            if edge_feat_field:
+                if isinstance(edge_feat_field, str):
+                    edge_feat_field = {etype: [edge_feat_field] \
                         for etype in self._g.canonical_etypes}
-                for etype, feat_names in decoder_edge_feat.items():
+                for etype, feat_names in edge_feat_field.items():
                     data = {}
                     etype_wg = ":".join(etype)
                     for name in feat_names:
@@ -216,17 +256,7 @@ class GSgnnData():
                         self._g._edata_store[etype].update(data)
 
             barrier()
-        self.prepare_data(self._g)
         sys_tracker.check('construct training data')
-
-    @abc.abstractmethod
-    def prepare_data(self, g):
-        """ Prepare the dataset.
-
-        Arguement
-        ---------
-        g: Dist DGLGraph
-        """
 
     @property
     def g(self):
@@ -235,14 +265,40 @@ class GSgnnData():
         return self._g
 
     @property
+    def graph_name(self):
+        """ The graph name
+        """
+        return self._graph_name
+
+    @property
     def node_feat_field(self):
-        """the field of node feature"""
+        """The field of node feature"""
         return self._node_feat_field
 
     @property
     def edge_feat_field(self):
         """the field of edge feature"""
         return self._edge_feat_field
+
+    def _check_node_feats(self, node_feat_field):
+        g = self._g
+        if node_feat_field is None:
+            return
+
+        for ntype in g.ntypes:
+            if isinstance(node_feat_field, str):
+                feat_names = [node_feat_field]
+            elif isinstance(node_feat_field, dict):
+                feat_names = node_feat_field[ntype] \
+                    if ntype in node_feat_field else []
+            else:
+                raise TypeError("Node feature field must be a string " \
+                                "or a dictionary of list of strings, " \
+                                f"but get {node_feat_field}")
+            for feat_name in feat_names:
+                assert feat_name in g.nodes[ntype].data, \
+                    f"Warning. The feature \"{feat_name}\" " \
+                    f"does not exists for the node type \"{ntype}\"."
 
     def has_node_feats(self, ntype):
         """ Test if the specified node type has features.
@@ -310,13 +366,15 @@ class GSgnnData():
         """
         return etype in self._lm_feat_etypes
 
-    def get_node_feats(self, input_nodes, device='cpu'):
+    def get_node_feats(self, input_nodes, nfeat_fields, device='cpu'):
         """ Get the node features
 
         Parameters
         ----------
         input_nodes : Tensor or dict of Tensors
             The input node IDs
+        nfeat_fields : str or dict of list
+            The node features to collect from graph
         device : Pytorch device
             The device where the returned node features are stored.
 
@@ -329,17 +387,18 @@ class GSgnnData():
             assert len(g.ntypes) == 1, \
                     "We don't know the input node type, but the graph has more than one node type."
             input_nodes = {g.ntypes[0]: input_nodes}
-        return prepare_batch_input(g, input_nodes, dev=device,
-                                   feat_field=self._node_feat_field)
 
-    def get_edge_feats(self, input_edges, edge_feat_field, device='cpu'):
+        return prepare_batch_input(g, input_nodes, dev=device,
+                                   feat_field=nfeat_fields)
+
+    def get_edge_feats(self, input_edges, efeat_fields, device='cpu'):
         """ Get the edge features
 
         Parameters
         ----------
         input_edges : Tensor or dict of Tensors
             The input edge IDs
-        edge_feat_field: str or dict of [str ..]
+        efeat_fields: str or dict of [str ..]
             The edge data fields that stores the edge features to retrieve
         device : Pytorch device
             The device where the returned edge features are stored.
@@ -354,176 +413,278 @@ class GSgnnData():
                     "We don't know the input edge type, but the graph has more than one edge type."
             input_edges = {g.canonical_etypes[0]: input_edges}
         return prepare_batch_edge_input(g, input_edges, dev=device,
-                                        feat_field=edge_feat_field)
+                                        feat_field=efeat_fields)
 
-    def get_node_feat_size(self):
-        """ Get node feat size using the given node_feat_field
-
-        All parameters are coming from this class's own attributes.
-
-        Note: If the self._node_feat_field is None, i.e., not given, the function will return a
-              dictionary containing all node types in the self.g, and the feature sizes are all 0s.
-              If given the node_feat_field, will return dictionary that only contains given node
-              types.
-        """
-        return gs.get_node_feat_size(self.g, self._node_feat_field)
-
-class GSgnnEdgeData(GSgnnData):  # pylint: disable=abstract-method
-    """ Data for edge tasks
-
-    Parameters
-    ----------
-    graph_name : str
-        The graph name
-    part_config : str
-        The path of the partition configuration file.
-    label_field : str
-        The field for storing labels
-    node_feat_field: str or dict of list of str
-        Fields to extract node features. It's a dict if different node types have
-        different feature names.
-    edge_feat_field : str or dict of list of str
-        The field of the edge features. It's a dict if different edge types have
-        different feature names.
-    decoder_edge_feat: str or dict of list of str
-        Edge features used by decoder
-    lm_feat_ntypes : list of str
-        The node types that contains text features.
-    lm_feat_etypes : list of tuples
-        The edge types that contains text features.
-    """
-    def __init__(self, graph_name, part_config, label_field=None,
-                 node_feat_field=None, edge_feat_field=None,
-                 decoder_edge_feat=None, lm_feat_ntypes=None, lm_feat_etypes=None):
-        super(GSgnnEdgeData, self).__init__(graph_name, part_config,
-                                            node_feat_field, edge_feat_field,
-                                            decoder_edge_feat,
-                                            lm_feat_ntypes=lm_feat_ntypes,
-                                            lm_feat_etypes=lm_feat_etypes)
-        self._label_field = label_field
-        self._decoder_edge_feat = decoder_edge_feat
-        if label_field is not None:
-            self._labels = {}
-            for etype in self._g.canonical_etypes:
-                if label_field in self._g.edges[etype].data:
-                    self._labels[etype] = self._g.edges[etype].data[label_field]
-        else:
-            self._labels = None
-
-    def get_labels(self, eids, device='cpu'):
-        """ Get the edge labels
+    def _check_ntypes(self, ntypes):
+        """ Check the input ntype(s) and convert it into list of strs
 
         Parameters
-        ----------
-        eids : Tensor or dict of Tensors
-            The edge IDs
-        device : Pytorch device
-            The device where the returned edge labels are stored.
+        __________
+        ntypes: str or list of str
+            List of node types
+
+        Return
+        ------
+        list: list of node types
+        """
+        assert ntypes is not None, \
+            "Prediction ntype(s) must be provided."
+        if isinstance(ntypes, str):
+            ntypes = [ntypes]
+        assert isinstance(ntypes, list), \
+                "Prediction ntypes have to be a string or a list of strings."
+
+        if ntypes == [DEFAULT_NTYPE]:
+            # DGL Graph edge type is not canonical. It is just list[str].
+            assert self._g.ntypes == [DEFAULT_NTYPE] and \
+                   self._g.etypes == [DEFAULT_ETYPE[1]], \
+                f"It is required to be a homogeneous graph when target_ntype is not provided " \
+                f"or is set to {DEFAULT_NTYPE} on node tasks, expect node type " \
+                f"to be {[DEFAULT_NTYPE]} and edge type to be {[DEFAULT_ETYPE[1]]}, " \
+                f"but get {self._g.ntypes} and {self._g.etypes}"
+
+        return ntypes
+
+    def _check_node_mask(self, ntypes, masks):
+        """ Check the node mask(s) and convert it into list of strs
+
+        Parameters
+        __________
+        ntypes: str or list of str
+            List of node types
+        masks: str or list of str
+            The node features field storing the masks.
+
+        Return
+        ------
+        list: list of mask fields
+        """
+        if isinstance(ntypes, str):
+            # ntypes is a string, convert it into list
+            ntypes = [ntypes]
+
+        if isinstance(masks, str):
+            # Mask is a string
+            # All the masks are using the same name
+            masks = [masks] * len(ntypes)
+
+        assert len(ntypes) == len(masks), \
+            "Expecting the number of ntypes matches the number of mask fields, " \
+            f"But get {len(ntypes)} and {len(masks)}." \
+            f"The node types are {ntypes} and the mask fileds are {masks}"
+        return masks
+
+    def get_unlabeled_node_set(self, train_idxs, mask="train_mask"):
+        """ Collect nodes not used for training.
+
+        Parameters
+        __________
+        train_idxs: dict
+            The training set.
+        mask: str or list of str
+            The node feature field storing the training mask.
+            Default: "train_mask"
 
         Returns
         -------
-        dict of Tensors : the returned edge labels.
+        dict of Tensors : The returned node indexes
         """
-        assert self._labels is not None, "The dataset does not have edge labels."
-        assert isinstance(eids, dict)
-        labels = {}
-        for etype, eid in eids.items():
-            assert etype in self._labels
-            labels[etype] = self._labels[etype][eid].to(device)
-        return labels
+        g = self.g
+        pb = g.get_partition_book()
+        unlabeled_idxs = {}
+        num_unlabeled = 0
+        ntypes = list(train_idxs.keys())
+        masks = self._check_node_mask(ntypes, mask)
 
-    @property
-    def labels(self):
-        """Labels"""
-        return self._labels
+        for ntype, msk in zip(ntypes, masks):
+            unlabeled_mask = flip_node_mask(g.nodes[ntype].data[msk],
+                                            train_idxs[ntype])
+            node_trainer_ids = g.nodes[ntype].data['trainer_id'] \
+                if 'trainer_id' in g.nodes[ntype].data else None
 
-    @property
-    def decoder_edge_feat(self):
-        """edge features used by decoder"""
-        return self._decoder_edge_feat
+            unlabeled_idx = dgl.distributed.node_split(unlabeled_mask,
+                                                       pb, ntype=ntype, force_even=True,
+                                                       node_trainer_ids=node_trainer_ids)
+            assert unlabeled_idx is not None, "There is no unlabeled data."
+            num_unlabeled += len(unlabeled_idx)
+            unlabeled_idxs[ntype] = unlabeled_idx
+        logging.info('part %d, unlabeled: %d', get_rank(), num_unlabeled)
+        return unlabeled_idxs
 
-    @property
-    def train_idxs(self):
-        """train set's indexes"""
-        return self._train_idxs
+    def get_node_train_set(self, ntypes, mask="train_mask"):
+        """ Get node training set for nodes of ntypes.
 
-    @property
-    def val_idxs(self):
-        """validation set's indexes"""
-        return self._val_idxs
+        Parameters
+        __________
+        ntypes: str or list of str
+            Node types to get the training set.
+        mask: str or list of str
+            The node feature field storing the training mask.
+            Default: "train_mask"
 
-    @property
-    def test_idxs(self):
-        """test set's indexes"""
-        return self._test_idxs
+        Returns
+        -------
+        dict of Tensors : The returned training node indexes
+        """
+        g = self._g
+        pb = g.get_partition_book()
+        train_idxs = {}
+        num_train = 0
+        ntypes = self._check_ntypes(ntypes)
+        masks = self._check_node_mask(ntypes, mask)
 
-class GSgnnEdgeTrainData(GSgnnEdgeData):
-    r""" Edge prediction training data
+        for ntype, msk in zip(ntypes, masks):
+            if msk in g.nodes[ntype].data:
+                node_trainer_ids = g.nodes[ntype].data['trainer_id'] \
+                    if 'trainer_id' in g.nodes[ntype].data else None
 
-    The GSgnnEdgeTrainData prepares the data for training edge prediction.
+                train_idx = dgl.distributed.node_split(g.nodes[ntype].data[msk],
+                                                       pb, ntype=ntype, force_even=True,
+                                                       node_trainer_ids=node_trainer_ids)
+                assert train_idx is not None, "There is no training data."
+                num_train += len(train_idx)
+                train_idxs[ntype] = train_idx
 
-    Parameters
-    ----------
-    graph_name : str
-        The graph name
-    part_config : str
-        The path of the partition configuration file.
-    train_etypes : tuple of str or list of tuples
-        Target edge types for training
-    eval_etypes : tuple of str or list of tuples
-        Target edge types for evaluation
-    label_field : str
-        The field for storing labels
-    node_feat_field: str or dict of list of str
-        Fields to extract node features. It's a dict if different node types have
-        different feature names.
-    edge_feat_field : str or dict of list of str
-        The field of the edge features. It's a dict if different edge types have
-        different feature names.
-    decoder_edge_feat: str or dict of list of str
-        Edge features used by decoder
+                logging.debug('part %d | ntype %s, mask %s | train: %d',
+                              get_rank(), ntype, msk, len(train_idx))
+            else:
+                # Train mask may not exist for certain node types
+                logging.debug('part %d | ntype %s, mask %s | train: 0',
+                            get_rank(), ntype, msk)
+        logging.info('part %d, train %d', get_rank(), num_train)
+        return train_idxs
 
-    Examples
-    ----------
+    def _get_node_set(self, ntypes, mask):
+        """ called by get_node_val_set and get_node_test_set
+        """
+        g = self._g
+        pb = g.get_partition_book()
+        idxs = {}
+        num_data = 0
+        ntypes = self._check_ntypes(ntypes)
+        masks = self._check_node_mask(ntypes, mask)
 
-    .. code:: python
+        for ntype, msk in zip(ntypes, masks):
+            if msk in g.nodes[ntype].data:
+                idx = dgl.distributed.node_split(g.nodes[ntype].data[msk],
+                                                     pb, ntype=ntype, force_even=True)
+                # If there is no validation/test data, idx is None.
+                idx = [] if idx is None else idx
+                num_data += len(idx)
+                # If there are validation/test data globally, we should add them to the dict.
+                if dist_sum(len(idx)) > 0:
+                    idxs[ntype] = idx
 
-        from graphstorm.dataloading import GSgnnEdgeTrainData
-        from graphstorm.dataloading import GSgnnEdgeDataLoader
-        ep_data = GSgnnEdgeTrainData(graph_name='dummy', part_config=part_config,
-                                        train_etypes=[('n1', 'e1', 'n2')], label_field='label',
-                                        node_feat_field='node_feat', edge_feat_field='edge_feat')
-        ep_dataloader = GSgnnEdgeDataLoader(ep_data, target_idx={"e1":[0]},
-                                            fanout=[15, 10], batch_size=128)
-    """
-    def __init__(self, graph_name, part_config, train_etypes, eval_etypes=None,
-                 label_field=None, node_feat_field=None, edge_feat_field=None,
-                 decoder_edge_feat=None, lm_feat_ntypes=None, lm_feat_etypes=None):
-        if train_etypes is not None:
-            assert isinstance(train_etypes, (tuple, list)), \
-                    "The prediction etypes for training has to be a tuple or a list of tuples."
-            if isinstance(train_etypes, tuple):
-                train_etypes = [train_etypes]
-            self._train_etypes = train_etypes
-        else:
-            self._train_etypes = None
+                logging.debug('part %d | ntype %s, mask %s | num nodes: %d',
+                          get_rank(), ntype, msk, len(idx))
+        return idxs, num_data
 
-        if eval_etypes is not None:
-            assert isinstance(eval_etypes, (tuple, list)), \
-                    "The prediction etypes for evaluation has to be a tuple or a list of tuples."
-            if isinstance(eval_etypes, tuple):
-                eval_etypes = [eval_etypes]
-            self._eval_etypes = eval_etypes
-        else:
-            self._eval_etypes = train_etypes
+    def get_node_val_set(self, ntypes, mask="val_mask"):
+        """ Get node validation set for nodes of ntypes.
 
-        super(GSgnnEdgeTrainData, self).__init__(graph_name, part_config, label_field,
-                                                 node_feat_field, edge_feat_field,
-                                                 decoder_edge_feat,
-                                                 lm_feat_ntypes=lm_feat_ntypes,
-                                                 lm_feat_etypes=lm_feat_etypes)
+        Parameters
+        __________
+        ntypes: str or list of str
+            Node types to get the validation set.
+        mask: str or list of str
+            The node feature field storing the validation mask.
+            Default: "val_mask"
 
-        if self._train_etypes == [DEFAULT_ETYPE]:
+        Returns
+        -------
+        dict of Tensors : The returned validation node indexes
+        """
+        idxs, num_data = self._get_node_set(ntypes, mask)
+        logging.info('part %d, val %d', get_rank(), num_data)
+
+        return idxs
+
+    def get_node_test_set(self, ntypes, mask="test_mask"):
+        """ Get node test set for nodes of ntypes.
+
+        Parameters
+        __________
+        ntypes: str or list of str
+            Node types to get the test set.
+        mask: str or list of str
+            The node feature field storing the test mask.
+            Default: "test_mask"
+
+        Returns
+        -------
+        dict of Tensors : The returned test node indexes
+        """
+        idxs, num_data = self._get_node_set(ntypes, mask)
+        logging.info('part %d, test %d', get_rank(), num_data)
+
+        return idxs
+
+    def get_node_infer_set(self, ntypes, mask="test_mask"):
+        """ Get node set for inference.
+
+        If the mask exists in g.nodes[ntype].data, the inference set
+        is collected based on the mask.
+        If not, the entire node set are treated as the inference set.
+
+        Parameters
+        __________
+        ntypes: str or list of str
+            Node types to get the inference set.
+        mask: str or list of str
+            The node feature field storing the inference mask.
+            Default: "test_mask"
+
+        Returns
+        -------
+        dict of Tensors : The returned inference node indexes.
+        """
+        g = self._g
+        pb = g.get_partition_book()
+        infer_idxs = {}
+        ntypes = self._check_ntypes(ntypes)
+        masks = self._check_node_mask(ntypes, mask)
+
+        for ntype, msk in zip(ntypes, masks):
+            node_trainer_ids = g.nodes[ntype].data['trainer_id'] \
+                if 'trainer_id' in g.nodes[ntype].data else None
+            if msk in g.nodes[ntype].data:
+                # We only do inference on a subset of nodes
+                # according to the mask
+                infer_idx = dgl.distributed.node_split(g.nodes[ntype].data[msk],
+                                                       pb, ntype=ntype, force_even=True,
+                                                       node_trainer_ids=node_trainer_ids)
+                logging.info("%s contains %s, we will do inference based on the mask",
+                             ntype, msk)
+            else:
+                # We will do inference on the entire edge set
+                logging.info("%s does not contains %s" + \
+                        "We will do inference on the entire node set.", ntype, msk)
+                infer_idx = dgl.distributed.node_split(
+                    th.full((g.num_nodes(ntype),), True, dtype=th.bool),
+                    pb, ntype=ntype, force_even=True,
+                    node_trainer_ids=node_trainer_ids)
+            infer_idxs[ntype] = infer_idx
+
+        return infer_idxs
+
+    def _check_etypes(self, etypes):
+        """ Check the input etype(s) and convert it into list of tuples
+
+        Parameters
+        __________
+        etypes: tuples or list of tuples
+            Edge types
+
+        Return
+        list: list of edge types
+        ------
+        """
+        assert isinstance(etypes, (tuple, list)), \
+            "Prediction etypes have to be a tuple or a list of tuples."
+        if isinstance(etypes, tuple):
+            etypes = [etypes]
+
+        if etypes == [DEFAULT_ETYPE]:
             # DGL Graph edge type is not canonical. It is just list[str].
             assert self._g.ntypes == [DEFAULT_NTYPE] and \
                    self._g.etypes == [DEFAULT_ETYPE[1]], \
@@ -531,603 +692,222 @@ class GSgnnEdgeTrainData(GSgnnEdgeData):
                 f"or is set to {DEFAULT_ETYPE} on edge tasks, expect node type " \
                 f"to be {[DEFAULT_NTYPE]} and edge type to be {[DEFAULT_ETYPE[1]]}, " \
                 f"but get {self._g.ntypes} and {self._g.etypes}"
+        return etypes
 
-    def prepare_data(self, g):
+    def _check_edge_mask(self, etypes, masks):
+        """ Check the edge mask(s) and convert it into list of strs
+
+        Parameters
+        __________
+        etypes: tuple or list of tuple
+            List of edge types
+        masks: str or list of str
+            The edge feature fields storing the masks.
+
+        Return
+        ------
+        list: list of mask fields
         """
-        Prepare the training, validation and testing edge set.
+        if isinstance(etypes, tuple):
+            # etypes is a tuple of strings, convert it into list
+            etypes = [etypes]
 
-        It will setup the following class fields:
-        self._train_idxs: the edge indices of the local training set.
-        self._val_idxs: the edge indices of the local validation set, can be empty.
-        self._test_idxs: the edge indices of the local test set, can be empty.
+        if isinstance(masks, str):
+            # Mask is a string
+            # All the masks are using the same name
+            masks = [masks] * len(etypes)
 
-        Arguement
-        ---------
-        g: Dist DGLGraph
+        assert len(etypes) == len(masks), \
+            "Expecting the number of etypes matches the number of mask fields, " \
+            f"But get {len(etypes)} and {len(masks)}." \
+            f"The edge types are {etypes} and the mask fileds are {masks}"
+
+        return masks
+
+    def _exclude_reverse_etype(self, etypes, reverse_edge_types_map=None):
+        if reverse_edge_types_map is None:
+            return etypes
+        etypes = set(etypes)
+        for rev_etype in list(reverse_edge_types_map.values()):
+            etypes.remove(rev_etype)
+        return list(etypes)
+
+    def get_edge_train_set(self, etypes=None, mask="train_mask",
+                           reverse_edge_types_map=None):
+        """ Get edge training set for edges of etypes.
+
+        Parameters
+        __________
+        etypes: list of str
+            List of edge types to get the training set.
+            If set to None, all the edge types are included.
+            Default: None
+        mask: str or list of str
+            The edge feature field storing the training mask.
+            Default: "train_mask"
+        reverse_edge_types_map: dict
+            A map for reverse edge type.
+            Default: None
+
+        Returns
+        -------
+        dict of Tensors : The returned training edge indexes.
         """
-        train_idxs = {}
-        val_idxs = {}
-        test_idxs = {}
-        num_train = num_val = num_test = 0
+        g = self._g
         pb = g.get_partition_book()
-        if self.train_etypes is None:
-            self._train_etypes = g.canonical_etypes
-        for canonical_etype in self.train_etypes:
-            if 'train_mask' in g.edges[canonical_etype].data:
+        train_idxs = {}
+        num_train = 0
+        etypes = self._exclude_reverse_etype(g.canonical_etypes, reverse_edge_types_map) \
+            if etypes is None else self._check_etypes(etypes)
+        masks = self._check_edge_mask(etypes, mask)
+
+        for canonical_etype, msk in zip(etypes, masks):
+            if msk in g.edges[canonical_etype].data:
                 train_idx = dgl.distributed.edge_split(
-                    g.edges[canonical_etype].data['train_mask'],
+                    g.edges[canonical_etype].data[msk],
                     pb, etype=canonical_etype, force_even=True)
             else:
                 # If there are no training masks, we assume all edges can be used for training.
                 # Therefore, we use a more memory efficient way to split the edge list.
                 # TODO(zhengda) we need to split the edges properly to increase the data locality.
                 train_idx = split_full_edge_list(g, canonical_etype, get_rank())
+
             assert train_idx is not None, "There is no training data."
             num_train += len(train_idx)
             train_idxs[canonical_etype] = train_idx
 
-        # If eval_etypes is None, we use all edge types.
-        if self.eval_etypes is None:
-            self._eval_etypes = g.canonical_etypes
-        for canonical_etype in self.eval_etypes:
-            # user must provide validation mask
-            if 'val_mask' in g.edges[canonical_etype].data:
-                val_idx = dgl.distributed.edge_split(
-                    g.edges[canonical_etype].data['val_mask'],
-                    pb, etype=canonical_etype, force_even=True)
-                val_idx = [] if val_idx is None else val_idx
-                num_val += len(val_idx)
-                # If there are validation data globally, we should add them to the dict.
-                if dist_sum(len(val_idx)) > 0:
-                    val_idxs[canonical_etype] = val_idx
-            if 'test_mask' in g.edges[canonical_etype].data:
-                test_idx = dgl.distributed.edge_split(
-                    g.edges[canonical_etype].data['test_mask'],
-                    pb, etype=canonical_etype, force_even=True)
-                test_idx = [] if test_idx is None else test_idx
-                num_test += len(test_idx)
-                # If there are test data globally, we should add them to the dict.
-                if dist_sum(len(test_idx)) > 0:
-                    test_idxs[canonical_etype] = test_idx
-        logging.info('part %d, train: %d, val: %d, test: %d',
-                     get_rank(), num_train, num_val, num_test)
+            logging.debug('part %d | etype %s, mask %s | train: %d',
+                          get_rank(), canonical_etype, mask, len(train_idx))
+        logging.info('part %d, train %d', get_rank(), num_train)
+        return train_idxs
 
-        self._train_idxs = train_idxs
-        self._val_idxs = val_idxs
-        self._test_idxs = test_idxs
-
-    @property
-    def train_etypes(self):
-        """edge type for training"""
-        return self._train_etypes
-
-    @property
-    def eval_etypes(self):
-        """edge type for evaluation"""
-        return self._eval_etypes
-
-class GSgnnLPTrainData(GSgnnEdgeTrainData):
-    """ Link prediction training data
-
-    Parameters
-    ----------
-    graph_name : str
-        The graph name
-    part_config : str
-        The path of the partition configuration file.
-    train_etypes : tuple of str or list of tuples
-        Target edge types for training
-    eval_etypes : tuple of str or list of tuples
-        Target edge types for evaluation
-    label_field : str
-        The field for storing labels
-    node_feat_field: str or dict of list of str
-        Fields to extract node features. It's a dict if different node types have
-        different feature names.
-    edge_feat_field : str or dict of list of str
-        The field of the edge features. It's a dict if different edge types have
-        different feature names.
-    pos_graph_feat_field: str or dist of str
-        The field of the edge features used by positive graph in link prediction.
-    lm_feat_ntypes : list of str
-        The node types that contains text features.
-    lm_feat_etypes : list of tuples
-        The edge types that contains text features.
-    """
-    def __init__(self, graph_name, part_config, train_etypes, eval_etypes=None,
-                 label_field=None, node_feat_field=None,
-                 edge_feat_field=None, pos_graph_feat_field=None,
-                 lm_feat_ntypes=None, lm_feat_etypes=None):
-        super(GSgnnLPTrainData, self).__init__(graph_name, part_config,
-                                               train_etypes, eval_etypes, label_field,
-                                               node_feat_field, edge_feat_field,
-                                               lm_feat_ntypes=lm_feat_ntypes,
-                                               lm_feat_etypes=lm_feat_etypes)
-        self._pos_graph_feat_field = pos_graph_feat_field
-
-    @property
-    def pos_graph_feat_field(self):
-        """ Get edge feature fields of positive graphs
+    def _get_edge_set(self, etypes, mask, reverse_edge_types_map):
+        """ called by get_edge_val_set and get_edge_test_set
         """
-        return self._pos_graph_feat_field
-
-class GSgnnEdgeInferData(GSgnnEdgeData):
-    r""" Edge prediction inference data
-
-    GSgnnEdgeInferData prepares the data for edge prediction inference.
-
-    Parameters
-    ----------
-    graph_name : str
-        The graph name
-    part_config : str
-        The path of the partition configuration file.
-    eval_etypes : tuple of str or list of tuples
-        Target edge types for evaluation
-    label_field : str
-        The field for storing labels
-    node_feat_field: str or dict of list of str
-        Fields to extract node features. It's a dict if different node types have
-        different feature names.
-    edge_feat_field : str or dict of list of str
-        The field of the edge features. It's a dict if different edge types have
-        different feature names.
-    decoder_edge_feat: str or dict of list of str
-        Edge features used by decoder
-    lm_feat_ntypes : list of str
-        The node types that contains text features.
-    lm_feat_etypes : list of tuples
-        The edge types that contains text features.
-
-    Examples
-    ----------
-
-    .. code:: python
-
-        from graphstorm.dataloading import GSgnnEdgeInferData
-        from graphstorm.dataloading import GSgnnEdgeDataLoader
-        ep_data = GSgnnEdgeInferData(graph_name='dummy', part_config=part_config,
-                                        eval_etypes=[('n1', 'e1', 'n2')], label_field='label',
-                                        node_feat_field='node_feat', edge_feat_field='edge_feat')
-        ep_dataloader = GSgnnEdgeDataLoader(ep_data, target_idx={"e1":[0]},
-                                            fanout=[15, 10], batch_size=128)
-    """
-    def __init__(self, graph_name, part_config, eval_etypes,
-                 label_field=None, node_feat_field=None, edge_feat_field=None,
-                 decoder_edge_feat=None, lm_feat_ntypes=None, lm_feat_etypes=None):
-        if eval_etypes is not None:
-            assert isinstance(eval_etypes, (tuple, list)), \
-                    "The prediction etypes for evaluation has to be a tuple or a list of tuples."
-            if isinstance(eval_etypes, tuple):
-                eval_etypes = [eval_etypes]
-            self._eval_etypes = eval_etypes
-        else:
-            self._eval_etypes = None # Test on all edge types
-
-        super(GSgnnEdgeInferData, self).__init__(graph_name, part_config, label_field,
-                                                 node_feat_field, edge_feat_field,
-                                                 decoder_edge_feat,
-                                                 lm_feat_ntypes=lm_feat_ntypes,
-                                                 lm_feat_etypes=lm_feat_etypes)
-        if self._eval_etypes == [DEFAULT_ETYPE]:
-            # DGL Graph edge type is not canonical. It is just list[str].
-            assert self._g.ntypes == [DEFAULT_NTYPE] and \
-                   self._g.etypes == [DEFAULT_ETYPE[1]], \
-                f"It is required to be a homogeneous graph when target_etype is not provided " \
-                f"or is set to {DEFAULT_ETYPE} on edge tasks, expect node type " \
-                f"to be {[DEFAULT_NTYPE]} and edge type to be {[DEFAULT_ETYPE[1]]}, " \
-                f"but get {self._g.ntypes} and {self._g.etypes}"
-
-    def prepare_data(self, g):
-        """ Prepare the testing edge set if any
-
-        It will setup self._test_idxs, the edge indices of the local test set.
-        The test_idxs can be empty.
-
-        Arguement
-        ---------
-        g: Dist DGLGraph
-        """
+        g = self._g
         pb = g.get_partition_book()
-        test_idxs = {}
+        idxs = {}
+        num_data = 0
+        etypes = self._exclude_reverse_etype(g.canonical_etypes, reverse_edge_types_map) \
+            if etypes is None else self._check_etypes(etypes)
+        masks = self._check_edge_mask(etypes, mask)
+
+        for canonical_etype, msk in zip(etypes, masks):
+            # user must provide validation/test mask
+            if msk in g.edges[canonical_etype].data:
+                idx = dgl.distributed.edge_split(
+                    g.edges[canonical_etype].data[msk],
+                    pb, etype=canonical_etype, force_even=True)
+                idx = [] if idx is None else idx
+                num_data += len(idx)
+                # If there are validation data globally, we should add them to the dict.
+                if dist_sum(len(idx)) > 0:
+                    idxs[canonical_etype] = idx
+
+                logging.debug('part %d | etype %s, mask %s | val/test: %d',
+                              get_rank(), canonical_etype, msk, len(idx))
+        return idxs, num_data
+
+    def get_edge_val_set(self, etypes=None, mask="val_mask",
+                         reverse_edge_types_map=None):
+        """ Get edge validation set for edges of etypes.
+
+        Parameters
+        __________
+        etypes: list of str
+            List of edge types to get the val set.
+            If set to None, all the edge types are included.
+        mask: str or list of str
+            The edge feature field storing the val mask.
+            Default: "val_mask"
+        reverse_edge_types_map: dict
+            A map for reverse edge type.
+
+        Returns
+        -------
+        dict of Tensors : The returned validation edge indexes
+        """
+        idxs, num_data = self._get_edge_set(etypes, mask, reverse_edge_types_map)
+        logging.info('part %d, val %d', get_rank(), num_data)
+
+        return idxs
+
+    def get_edge_test_set(self, etypes=None, mask="test_mask",
+                          reverse_edge_types_map=None):
+        """ Get edge test set for edges of etypes.
+
+        Parameters
+        __________
+        etypes: list of str
+            List of edge types to get the test set.
+            If set to None, all the edge types are included.
+        mask: str or list of str
+            The edge feature field storing the test mask.
+            Default: "test_mask"
+        reverse_edge_types_map: dict
+            A map for reverse edge type.
+
+        Returns
+        -------
+        dict of Tensors : The returned test edge indexes.
+        """
+        idxs, num_data = self._get_edge_set(etypes, mask, reverse_edge_types_map)
+        logging.info('part %d, test %d', get_rank(), num_data)
+
+        return idxs
+
+    def get_edge_infer_set(self, etypes=None, mask="test_mask", reverse_edge_types_map=None):
+        """ Get edge set for inference.
+
+        If the mask exists in g.edges[etype].data, the inference set
+        is collected based on the mask.
+        If not, the entire edge set are treated as the inference set.
+
+        Parameters
+        __________
+        etypes: list of str
+            List of edge types to get the inference set.
+            If set to None, all the edge types are included.
+            Default: None
+        mask: str or list of str
+            The edge feature field storing the inference mask.
+            Default: "test_mask"
+        reverse_edge_types_map: dict
+            A map for reverse edge type.
+
+        Returns
+        -------
+        dict of Tensors : The returned inference edge indexes
+        """
+        g = self._g
+        pb = g.get_partition_book()
         infer_idxs = {}
-        # If eval_etypes is None, we use all edge types.
-        if self.eval_etypes is None:
-            self._eval_etypes = g.canonical_etypes
-        for canonical_etype in self.eval_etypes:
-            if 'test_mask' in g.edges[canonical_etype].data:
-                # test_mask exists
-                # we will do evaluation or inference on test data.
+        # If etypes is None, we use all edge types.
+        etypes = self._exclude_reverse_etype(g.canonical_etypes, reverse_edge_types_map) \
+            if etypes is None else self._check_etypes(etypes)
+        masks = self._check_edge_mask(etypes, mask)
+
+        for canonical_etype, msk in zip(etypes, masks):
+            if msk in g.edges[canonical_etype].data:
+                # mask exists
                 test_idx = dgl.distributed.edge_split(
-                    g.edges[canonical_etype].data['test_mask'],
+                    g.edges[canonical_etype].data[msk],
                     pb, etype=canonical_etype, force_even=True)
                 # If there are test data globally, we should add them to the dict.
                 if test_idx is not None and dist_sum(len(test_idx)) > 0:
-                    test_idxs[canonical_etype] = test_idx
                     infer_idxs[canonical_etype] = test_idx
             else:
-                # Inference only
+                # mask does not exist
                 # we will do inference on the entire edge set
                 if get_rank() == 0:
-                    logging.info("%s does not contains test_mask, skip testing %s. " + \
-                            "We will do inference on the entire edge set.",
-                            str(canonical_etype), str(canonical_etype))
+                    logging.info("We will do inference on the entire edge set of %s.",
+                            str(canonical_etype))
                 infer_idx = dgl.distributed.edge_split(
                     th.full((g.num_edges(canonical_etype),), True, dtype=th.bool),
                     pb, etype=canonical_etype, force_even=True)
                 infer_idxs[canonical_etype] = infer_idx
 
-        self._test_idxs = test_idxs
-        self._infer_idxs = infer_idxs
-
-    @property
-    def eval_etypes(self):
-        """edge type for evaluation"""
-        return self._eval_etypes
-
-    @property
-    def infer_idxs(self):
-        """ Set of edges to do inference.
-        """
-        return self._infer_idxs
-
-#### Node classification/regression Task Data ####
-class GSgnnNodeData(GSgnnData):  # pylint: disable=abstract-method
-    """ Data for node tasks
-
-    Parameters
-    ----------
-    graph_name : str
-        The graph name
-    part_config : str
-        The path of the partition configuration file.
-    label_field : str
-        The field for storing labels
-    node_feat_field: str or dict of list of str
-        Fields to extract node features. It's a dict if different node types have
-        different feature names.
-    edge_feat_field : str or dict of list of str
-        The field of the edge features. It's a dict if different edge types have
-        different feature names.
-    lm_feat_ntypes : list of str
-        The node types that contains text features.
-    lm_feat_etypes : list of tuples
-        The edge types that contains text features.
-    """
-    def __init__(self, graph_name, part_config, label_field=None,
-                 node_feat_field=None, edge_feat_field=None,
-                 lm_feat_ntypes=None, lm_feat_etypes=None):
-        super(GSgnnNodeData, self).__init__(graph_name, part_config,
-                                            node_feat_field, edge_feat_field,
-                                            lm_feat_ntypes=lm_feat_ntypes,
-                                            lm_feat_etypes=lm_feat_etypes)
-        self._label_field = label_field
-        if label_field is not None:
-            self._labels = {}
-            for ntype in self._g.ntypes:
-                if label_field in self._g.nodes[ntype].data:
-                    self._labels[ntype] = self._g.nodes[ntype].data[label_field]
-        else:
-            self._labels = None
-
-    def get_labels(self, nids, device='cpu'):
-        """ Get the node labels
-
-        Parameters
-        ----------
-        nids : Tensor or dict of Tensors
-            The seed nodes
-        device : Pytorch device
-            The device where the returned node labels are stored.
-
-        Returns
-        -------
-        dict of Tensors : the returned node labels.
-        """
-        assert self._labels is not None, "The dataset does not have labels."
-        assert isinstance(nids, dict)
-        labels = {}
-        for ntype, nid in nids.items():
-            assert ntype in self._labels
-            labels[ntype] = self._labels[ntype][nid].to(device)
-        return labels
-
-    @property
-    def labels(self):
-        """Labels"""
-        return self._labels
-
-    @property
-    def train_idxs(self):
-        """train set's indexes"""
-        return self._train_idxs
-
-    @property
-    def val_idxs(self):
-        """validation set's indexes"""
-        return self._val_idxs
-
-    @property
-    def test_idxs(self):
-        """test set's indexes"""
-        return self._test_idxs
-
-class GSgnnNodeTrainData(GSgnnNodeData):
-    r""" Training data for node tasks
-
-    GSgnnNodeTrainData prepares the data for training node prediction.
-
-    Parameters
-    ----------
-    graph_name : str
-        The graph name
-    part_config : str
-        The path of the partition configuration file.
-    train_ntypes : str or list of str
-        Target node types for training
-    eval_ntypes : str or list of str
-        Target node types for evaluation
-    label_field : str
-        The field for storing labels
-    node_feat_field: str or dict of list of str
-        Fields to extract node features. It's a dict if different node types have
-        different feature names.
-    edge_feat_field : str or dict of list of str
-        The field of the edge features. It's a dict if different edge types have
-        different feature names.
-    lm_feat_ntypes : list of str
-        The node types that contains text features.
-    lm_feat_etypes : list of tuples
-        The edge types that contains text features.
-
-    Examples
-    ----------
-
-    .. code:: python
-
-        from graphstorm.dataloading import GSgnnNodeTrainData
-        from graphstorm.dataloading import GSgnnNodeDataLoader
-
-        np_data = GSgnnNodeTrainData(graph_name='dummy', part_config=part_config,
-                                        train_ntypes=['n1'], label_field='label',
-                                        node_feat_field='feat')
-        np_dataloader = GSgnnNodeDataLoader(np_data, target_idx={'n1':[0]},
-                                            fanout=[15, 10], batch_size=128)
-    """
-    def __init__(self, graph_name, part_config, train_ntypes, eval_ntypes=None,
-                 label_field=None, node_feat_field=None, edge_feat_field=None,
-                 lm_feat_ntypes=None, lm_feat_etypes=None):
-        if isinstance(train_ntypes, str):
-            train_ntypes = [train_ntypes]
-        assert isinstance(train_ntypes, list), \
-                "prediction ntypes for training has to be a string or a list of strings."
-        self._train_ntypes = train_ntypes
-        if eval_ntypes is not None:
-            if isinstance(eval_ntypes, str):
-                eval_ntypes = [eval_ntypes]
-            assert isinstance(eval_ntypes, list), \
-                "prediction ntypes for evaluation has to be a string or a list of strings."
-            self._eval_ntypes = eval_ntypes
-        else:
-            self._eval_ntypes = train_ntypes
-
-        super(GSgnnNodeTrainData, self).__init__(graph_name, part_config,
-                                                 label_field=label_field,
-                                                 node_feat_field=node_feat_field,
-                                                 edge_feat_field=edge_feat_field,
-                                                 lm_feat_ntypes=lm_feat_ntypes,
-                                                 lm_feat_etypes=lm_feat_etypes)
-        if self._train_ntypes == [DEFAULT_NTYPE]:
-            # DGL Graph edge type is not canonical. It is just list[str].
-            assert self._g.ntypes == [DEFAULT_NTYPE] and \
-                   self._g.etypes == [DEFAULT_ETYPE[1]], \
-                f"It is required to be a homogeneous graph when target_ntype is not provided " \
-                f"or is set to {DEFAULT_NTYPE} on node tasks, expect node type " \
-                f"to be {[DEFAULT_NTYPE]} and edge type to be {[DEFAULT_ETYPE[1]]}, " \
-                f"but get {self._g.ntypes} and {self._g.etypes}"
-
-    def prepare_data(self, g):
-        pb = g.get_partition_book()
-        train_idxs = {}
-        val_idxs = {}
-        test_idxs = {}
-        num_train = num_val = num_test = 0
-        for ntype in self.train_ntypes:
-            assert 'train_mask' in g.nodes[ntype].data, \
-                    f"For training dataset, train_mask must be provided on nodes of {ntype}."
-
-            if 'trainer_id' in g.nodes[ntype].data:
-                node_trainer_ids = g.nodes[ntype].data['trainer_id']
-                train_idx = dgl.distributed.node_split(g.nodes[ntype].data['train_mask'],
-                                                       pb, ntype=ntype, force_even=True,
-                                                       node_trainer_ids=node_trainer_ids)
-            else:
-                train_idx = dgl.distributed.node_split(g.nodes[ntype].data['train_mask'],
-                                                       pb, ntype=ntype, force_even=True)
-            assert train_idx is not None, "There is no training data."
-            num_train += len(train_idx)
-            train_idxs[ntype] = train_idx
-
-        for ntype in self.eval_ntypes:
-            if 'val_mask' in g.nodes[ntype].data:
-                val_idx = dgl.distributed.node_split(g.nodes[ntype].data['val_mask'],
-                                                     pb, ntype=ntype, force_even=True)
-                # If there is no validation data, val_idx is None.
-                val_idx = [] if val_idx is None else val_idx
-                num_val += len(val_idx)
-                # If there are validation data globally, we should add them to the dict.
-                if dist_sum(len(val_idx)) > 0:
-                    val_idxs[ntype] = val_idx
-            if 'test_mask' in g.nodes[ntype].data:
-                test_idx = dgl.distributed.node_split(g.nodes[ntype].data['test_mask'],
-                                                      pb, ntype=ntype, force_even=True)
-                # If there is no test data, test_idx is None.
-                test_idx = [] if test_idx is None else test_idx
-                num_test += len(test_idx)
-                # If there are test data globally, we should add them to the dict.
-                if dist_sum(len(test_idx)) > 0:
-                    test_idxs[ntype] = test_idx
-
-        logging.info('part %d, train: %d, val: %d, test: %d',
-                     get_rank(), num_train, num_val, num_test)
-
-        self._train_idxs = train_idxs
-        self._val_idxs = val_idxs
-        self._test_idxs = test_idxs
-
-    def get_unlabeled_idxs(self):
-        """ Collect indices of nodes not used for training.
-        """
-        g = self.g
-        pb = g.get_partition_book()
-        unlabeled_idxs = {}
-        num_unlabeled = 0
-        for ntype in self.train_ntypes:
-            unlabeled_mask = flip_node_mask(g.nodes[ntype].data['train_mask'],
-                                            self._train_idxs[ntype])
-            if 'trainer_id' in g.nodes[ntype].data:
-                node_trainer_ids = g.nodes[ntype].data['trainer_id']
-                unlabeled_idx = dgl.distributed.node_split(unlabeled_mask,
-                                                       pb, ntype=ntype, force_even=True,
-                                                       node_trainer_ids=node_trainer_ids)
-            else:
-                unlabeled_idx = dgl.distributed.node_split(unlabeled_mask,
-                                                       pb, ntype=ntype, force_even=True)
-            assert unlabeled_idx is not None, "There is no training data."
-            num_unlabeled += len(unlabeled_idx)
-            unlabeled_idxs[ntype] = unlabeled_idx
-        logging.info('part %d, unlabeled: %d', get_rank(), num_unlabeled)
-        return unlabeled_idxs
-
-    @property
-    def train_ntypes(self):
-        """node type for training"""
-        return self._train_ntypes
-
-    @property
-    def eval_ntypes(self):
-        """node type for evaluation"""
-        return self._eval_ntypes
-
-class GSgnnNodeInferData(GSgnnNodeData):
-    r""" Inference data for node tasks
-
-    GSgnnNodeInferData prepares the data for node prediction inference.
-
-    Parameters
-    ----------
-    graph_name : str
-        The graph name
-    part_config : str
-        The path of the partition configuration file.
-    eval_ntypes : str or list of str
-        Target node types
-    label_field : str
-        The field for storing labels
-    node_feat_field: str or dict of list of str
-        Fields to extract node features. It's a dict if different node types have
-        different feature names.
-    edge_feat_field : str or dict of list of str
-        The field of the edge features. It's a dict if different edge types have
-        different feature names.
-    lm_feat_ntypes : list of str
-        The node types that contains text features.
-    lm_feat_etypes : list of tuples
-        The edge types that contains text features.
-
-    Examples
-    ----------
-
-    .. code:: python
-
-        from graphstorm.dataloading import GSgnnNodeInferData
-        from graphstorm.dataloading import
-
-        np_data = GSgnnNodeInferData(graph_name='dummy', part_config=part_config,
-                                        eval_ntypes=['n1'], label_field='label',
-                                        node_feat_field='feat')
-        np_dataloader = GSgnnNodeDataLoader(np_data, target_idx={'n1':[0]},
-                                            fanout=[15, 10], batch_size=128)
-    """
-    def __init__(self, graph_name, part_config, eval_ntypes,
-                 label_field=None, node_feat_field=None, edge_feat_field=None,
-                 lm_feat_ntypes=None, lm_feat_etypes=None):
-        if isinstance(eval_ntypes, str):
-            eval_ntypes = [eval_ntypes]
-        assert isinstance(eval_ntypes, list), \
-                "prediction ntypes for evaluation has to be a string or a list of strings."
-        self._eval_ntypes = eval_ntypes
-
-        super(GSgnnNodeInferData, self).__init__(graph_name, part_config,
-                                                 label_field=label_field,
-                                                 node_feat_field=node_feat_field,
-                                                 edge_feat_field=edge_feat_field,
-                                                 lm_feat_ntypes=lm_feat_ntypes,
-                                                 lm_feat_etypes=lm_feat_etypes)
-
-        if self._eval_ntypes == [DEFAULT_NTYPE]:
-            # DGL Graph edge type is not canonical. It is just list[str].
-            assert self._g.ntypes == [DEFAULT_NTYPE] and \
-                   self._g.etypes == [DEFAULT_ETYPE[1]], \
-                f"It is required to be a homogeneous graph when target_ntype is not provided " \
-                f"or is set to {DEFAULT_NTYPE} on node tasks, expect node type " \
-                f"to be {[DEFAULT_NTYPE]} and edge type to be {[DEFAULT_ETYPE[1]]}, " \
-                f"but get {self._g.ntypes} and {self._g.etypes}"
-
-    def prepare_data(self, g):
-        """
-        Prepare the testing node set if any
-
-        It will setup self._test_idxs, the node indices of the local test set.
-        The test_idxs can be empty.
-
-        Arguement
-        ---------
-        g: DistGraph
-            The distributed graph.
-        """
-        pb = g.get_partition_book()
-        test_idxs = {}
-        infer_idxs = {}
-        for ntype in self.eval_ntypes:
-            node_trainer_ids = g.nodes[ntype].data['trainer_id'] \
-                if 'trainer_id' in g.nodes[ntype].data else None
-            if 'test_mask' in g.nodes[ntype].data:
-                # test_mask exists
-                # we will do evaluation or inference on test data.
-                test_idx = dgl.distributed.node_split(g.nodes[ntype].data['test_mask'],
-                                                      pb, ntype=ntype, force_even=True,
-                                                      node_trainer_ids=node_trainer_ids)
-                # If there are test data globally, we should add them to the dict.
-                if test_idx is not None and dist_sum(len(test_idx)) > 0:
-                    test_idxs[ntype] = test_idx
-                    infer_idxs[ntype] = test_idx
-                elif test_idx is None:
-                    logging.warning("%s does not contains test data, skip testing %s",
-                                    ntype, ntype)
-            else:
-                # Inference only
-                # we will do inference on the entire edge set
-                logging.info("%s does not contains test_mask, skip testing %s. " + \
-                        "We will do inference on the entire node set.", ntype, ntype)
-                infer_idx = dgl.distributed.node_split(
-                    th.full((g.num_nodes(ntype),), True, dtype=th.bool),
-                    pb, ntype=ntype, force_even=True,
-                    node_trainer_ids=node_trainer_ids)
-                infer_idxs[ntype] = infer_idx
-        self._test_idxs = test_idxs
-        self._infer_idxs = infer_idxs
-
-    @property
-    def eval_ntypes(self):
-        """node type for evaluation"""
-        return self._eval_ntypes
-
-    @property
-    def infer_idxs(self):
-        """ Set of nodes to do inference.
-        """
-        return self._infer_idxs
+        return infer_idxs
 
 class GSDistillData(Dataset):
     """ Dataset for distillation

--- a/python/graphstorm/dataloading/utils.py
+++ b/python/graphstorm/dataloading/utils.py
@@ -136,3 +136,53 @@ def flip_node_mask(dist_tensor, indices):
         part_policy=dist_tensor.part_policy)
     flipped_dist_tensor[indices] = 1 - dist_tensor[indices]
     return flipped_dist_tensor
+
+def verify_label_field(label_field):
+    """ Verify the format of label fields
+
+        Parameters
+        ----------
+        label_field: str or dict of str
+    """
+    assert label_field is not None and \
+        (isinstance(label_field, str) or \
+        (isinstance(label_field, dict) and \
+            isinstance(list(label_field.values())[0], str))), \
+        "Label field must be provided as a string or dict of string, " \
+        f"but get {label_field}"
+
+def verify_node_feat_fields(node_feats):
+    """ Verify the format of node feature fields
+
+        Parameters
+        ----------
+        node_feats: str, or dist of list of str
+            str: All the nodes have the same feature name.
+            list of string: All the nodes have the same list of features.
+            dist of list of string: Each node type have different set of node features.
+    """
+    assert node_feats is None or \
+            isinstance(node_feats, str) or \
+            (isinstance(node_feats, dict) and \
+                isinstance(list(node_feats.values())[0], list) and \
+                isinstance(list(node_feats.values())[0][0], str)), \
+                "Node features must be a string, " \
+                f"or a dict of list of string, but get {node_feats}."
+
+def verify_edge_feat_fields(edge_feats):
+    """ Verify the format of edge feature fields
+
+        Parameters
+        ----------
+        edge_feats: str, or dist of list of str
+            str: All the edges have the same feature name.
+            list of string: All the edges have the same list of features.
+            dist of list of string: Each edge type have different set of edge features.
+    """
+    assert edge_feats is None or \
+            isinstance(edge_feats, str) or \
+            (isinstance(edge_feats, dict) and \
+                isinstance(list(edge_feats.values())[0], list) and \
+                isinstance(list(edge_feats.values())[0][0], str)), \
+                "Edge features must be a string, " \
+                f"or a dict of list of string, but get {edge_feats}."

--- a/python/graphstorm/eval/evaluator.py
+++ b/python/graphstorm/eval/evaluator.py
@@ -329,7 +329,7 @@ class GSgnnInstanceEvaluator():
     @property
     def history(self):
         """ Evaluation history
-        
+
             Returns
             -------
             A list of evaluation history in training. The detailed contents of the list rely
@@ -826,7 +826,7 @@ class GSgnnMrrLPEvaluator(GSgnnLPEvaluator):
         The early stop strategy. GraphStorm supports two strategies:
         1) consecutive_increase and 2) average_increase.
     """
-    def __init__(self, eval_frequency, data,
+    def __init__(self, eval_frequency, data, # pylint: disable=unused-argument
                  num_negative_edges_eval, lp_decoder_type,
                  use_early_stop=False,
                  early_stop_burnin_rounds=0,
@@ -836,9 +836,6 @@ class GSgnnMrrLPEvaluator(GSgnnLPEvaluator):
         super(GSgnnMrrLPEvaluator, self).__init__(eval_frequency,
             eval_metric, use_early_stop, early_stop_burnin_rounds,
             early_stop_rounds, early_stop_strategy)
-        self.train_idxs = data.train_idxs
-        self.val_idxs = data.val_idxs
-        self.test_idxs = data.test_idxs
         self.num_negative_edges_eval = num_negative_edges_eval
         self.lp_decoder_type = lp_decoder_type
 

--- a/python/graphstorm/inference/emb_infer.py
+++ b/python/graphstorm/inference/emb_infer.py
@@ -16,11 +16,6 @@
     Inferer wrapper for embedding generation.
 """
 import logging
-from graphstorm.config import  (BUILTIN_TASK_NODE_CLASSIFICATION,
-                                BUILTIN_TASK_NODE_REGRESSION,
-                                BUILTIN_TASK_EDGE_CLASSIFICATION,
-                                BUILTIN_TASK_EDGE_REGRESSION,
-                                BUILTIN_TASK_LINK_PREDICTION)
 from .graphstorm_infer import GSInferrer
 from ..model.utils import save_full_node_embeddings as save_gsgnn_embeddings
 from ..model import do_full_graph_inference, do_mini_batch_inference
@@ -38,7 +33,7 @@ class GSgnnEmbGenInferer(GSInferrer):
     model : GSgnnNodeModel
         The GNN model with different task.
     """
-    def infer(self, data, task_type, save_embed_path, eval_fanout,
+    def infer(self, data, infer_ntypes, save_embed_path, eval_fanout,
             use_mini_batch_infer=False,
             node_id_mapping_file=None,
             save_embed_format="pytorch",
@@ -51,8 +46,8 @@ class GSgnnEmbGenInferer(GSInferrer):
         ----------
         data: GSgnnData
             The GraphStorm dataset
-        task_type : str
-            task_type must be one of graphstorm builtin task types
+        infer_ntypes : list of str
+            List of node types to compute embeddings.
         save_embed_path : str
             The path where the GNN embeddings will be saved.
         eval_fanout: list of int
@@ -65,7 +60,7 @@ class GSgnnEmbGenInferer(GSInferrer):
         save_embed_format : str
             Specify the format of saved embeddings.
         infer_batch_size: int
-            Specify the inference batch size when computing node embeddings 
+            Specify the inference batch size when computing node embeddings
             with mini batch inference.
         """
         assert save_embed_path is not None, \
@@ -73,20 +68,6 @@ class GSgnnEmbGenInferer(GSInferrer):
 
         sys_tracker.check('start generating embedding')
         self._model.eval()
-
-        # infer ntypes must be sorted for node embedding saving
-        if task_type == BUILTIN_TASK_LINK_PREDICTION:
-            infer_ntypes = None
-        elif task_type in {BUILTIN_TASK_NODE_REGRESSION, BUILTIN_TASK_NODE_CLASSIFICATION}:
-            infer_ntypes = sorted(data.infer_idxs)
-        elif task_type in {BUILTIN_TASK_EDGE_CLASSIFICATION, BUILTIN_TASK_EDGE_REGRESSION}:
-            infer_ntypes = set()
-            for etype in data.infer_idxs:
-                infer_ntypes.add(etype[0])
-                infer_ntypes.add(etype[2])
-            infer_ntypes = sorted(infer_ntypes)
-        else:
-            raise TypeError("Not supported for task type: ", task_type)
 
         if use_mini_batch_infer:
             embs = do_mini_batch_inference(self._model, data, batch_size=infer_batch_size,

--- a/python/graphstorm/model/edge_gnn.py
+++ b/python/graphstorm/model/edge_gnn.py
@@ -215,25 +215,27 @@ def edge_mini_batch_gnn_predict(model, loader, return_proba=True, return_label=F
                 if not isinstance(input_nodes, dict):
                     assert len(g.ntypes) == 1
                     input_nodes = {g.ntypes[0]: input_nodes}
-                if data.decoder_edge_feat is not None:
+                if loader.decoder_edge_feat_fields is not None:
                     input_edges = {etype: target_edge_graph.edges[etype].data[dgl.EID] \
                         for etype in target_edge_graph.canonical_etypes}
             if is_wholegraph():
                 tmp_node_keys = [ntype for ntype in g.ntypes if ntype not in input_nodes]
-                if data.decoder_edge_feat is not None:
+                if loader.decoder_edge_feat_fields is not None:
                     tmp_edge_keys = [etype for etype in g.canonical_etypes \
                         if etype not in input_edges]
                 prepare_for_wholegraph(g, input_nodes, input_edges)
-            input_feats = data.get_node_feats(input_nodes, device)
+            nfeat_fields = loader.node_feat_fields
+            input_feats = data.get_node_feats(input_nodes, nfeat_fields, device)
             if blocks is None:
                 continue
             # Remove additional keys (ntypes) added for WholeGraph compatibility
             for ntype in tmp_node_keys:
                 del input_nodes[ntype]
-            if data.decoder_edge_feat is not None:
-                edge_decoder_feats = data.get_edge_feats(input_edges,
-                                                         data.decoder_edge_feat,
-                                                         device)
+            if loader.decoder_edge_feat_fields is not None:
+                edge_decoder_feats = \
+                    data.get_edge_feats(input_edges,
+                                        loader.decoder_edge_feat_fields,
+                                        device)
                 # Remove additional keys (etypes) added for WholeGraph compatibility
                 for etype in tmp_edge_keys:
                     del input_edges[etype]
@@ -257,7 +259,8 @@ def edge_mini_batch_gnn_predict(model, loader, return_proba=True, return_label=F
                 # retrieving seed edge id from the graph to find labels
                 # TODO(zhengda) the data loader should return labels directly.
                 seeds = target_edge_graph.edges[target_etype].data[dgl.EID]
-                lbl = data.get_labels({target_etype: seeds})
+                label_field = loader.label_field
+                lbl = data.get_edge_feats({target_etype: seeds}, label_field)
                 assert len(lbl) == 1
                 append_to_dict(lbl, labels)
             if isinstance(pred, dict):
@@ -314,9 +317,9 @@ def edge_mini_batch_predict(model, emb, loader, return_proba=True, return_label=
     labels = {}
 
     if return_label:
-        assert data.labels is not None, \
-            "Return label is required, but the label field is not provided whem" \
-            "initlaizing the inference dataset."
+        assert loader.label_field is not None, \
+            "Return label is required, but the label field is not provided when" \
+            "initlaizing the inference dataloader."
 
     len_dataloader = max_num_batch = len(loader)
     num_batch = th.tensor([len_dataloader], device=device)
@@ -330,14 +333,14 @@ def edge_mini_batch_predict(model, emb, loader, return_proba=True, return_label=
         # the order when gather tensors from other trainers
         for iter_l in range(max_num_batch):
             tmp_edge_keys = []
-            input_edges = {} if data.decoder_edge_feat is not None else None
+            input_edges = {} if loader.decoder_edge_feat_fields is not None else None
             # TODO suppport multiple target edge types
             if iter_l < len_dataloader:
                 input_nodes, target_edge_graph, _ = next(dataloader_iter)
-                if data.decoder_edge_feat is not None:
+                if loader.decoder_edge_feat_fields is not None:
                     input_edges = {etype: target_edge_graph.edges[etype].data[dgl.EID] \
                         for etype in target_edge_graph.canonical_etypes}
-            if is_wholegraph() and data.decoder_edge_feat is not None:
+            if is_wholegraph() and loader.decoder_edge_feat_fields is not None:
                 tmp_edge_keys = [etype for etype in g.canonical_etypes \
                     if etype not in input_edges]
                 prepare_for_wholegraph(g, None, input_edges)
@@ -347,9 +350,9 @@ def edge_mini_batch_predict(model, emb, loader, return_proba=True, return_label=
             for ntype, in_nodes in input_nodes.items():
                 batch_embs[ntype] = emb[ntype][in_nodes].to(device)
             target_edge_graph = target_edge_graph.to(device)
-            if data.decoder_edge_feat is not None:
+            if loader.decoder_edge_feat_fields is not None:
                 edge_decoder_feats = data.get_edge_feats(input_edges,
-                                                         data.decoder_edge_feat,
+                                                         loader.decoder_edge_feat_fields,
                                                          target_edge_graph.device)
                 # Remove additional keys (etypes) added for WholeGraph compatibility
                 for etype in tmp_edge_keys:
@@ -368,8 +371,11 @@ def edge_mini_batch_predict(model, emb, loader, return_proba=True, return_label=
             # TODO(zhengda) we need to have the data loader reads everything,
             # instead of reading labels here.
             if return_label:
-                lbl = data.get_labels(
-                    {target_etype: target_edge_graph.edges[target_etype].data[dgl.EID]})
+                label_field = loader.label_field
+                lbl = data.get_edge_feats(
+                    {target_etype: target_edge_graph.edges[target_etype].data[dgl.EID]},
+                    label_field)
+
                 append_to_dict(lbl, labels)
     barrier()
 

--- a/python/graphstorm/model/embed.py
+++ b/python/graphstorm/model/embed.py
@@ -205,9 +205,9 @@ class GSNodeEncoderInputLayer(GSNodeInputLayer):
 
         from graphstorm import get_node_feat_size
         from graphstorm.model import GSgnnNodeModel, GSNodeEncoderInputLayer
-        from graphstorm.dataloading import GSgnnNodeTrainData
+        from graphstorm.dataloading import GSgnnData
 
-        np_data = GSgnnNodeTrainData(...)
+        np_data = GSgnnData(...)
 
         model = GSgnnEdgeModel(alpha_l2norm=0)
         feat_size = get_node_feat_size(np_data.g, 'feat')

--- a/python/graphstorm/model/gat_encoder.py
+++ b/python/graphstorm/model/gat_encoder.py
@@ -137,10 +137,10 @@ class GATEncoder(GraphConvEncoder):
         from graphstorm.model.gat_encoder import GATEncoder
         from graphstorm.model.node_decoder import EntityClassifier
         from graphstorm.model import GSgnnNodeModel, GSNodeEncoderInputLayer
-        from graphstorm.dataloading import GSgnnNodeTrainData
+        from graphstorm.dataloading import GSgnnData
         from graphstorm.model import do_full_graph_inference
 
-        np_data = GSgnnNodeTrainData(...)
+        np_data = GSgnnData(...)
 
         model = GSgnnNodeModel(alpha_l2norm=0)
         feat_size = get_node_feat_size(np_data.g, 'feat')

--- a/python/graphstorm/model/gatv2_encoder.py
+++ b/python/graphstorm/model/gatv2_encoder.py
@@ -141,10 +141,10 @@ class GATv2Encoder(GraphConvEncoder):
         from graphstorm.model.gat_encoder import GATv2Encoder
         from graphstorm.model.node_decoder import EntityClassifier
         from graphstorm.model import GSgnnNodeModel, GSNodeEncoderInputLayer
-        from graphstorm.dataloading import GSgnnNodeTrainData
+        from graphstorm.dataloading import GSgnnData
         from graphstorm.model import do_full_graph_inference
 
-        np_data = GSgnnNodeTrainData(...)
+        np_data = GSgnnData(...)
 
         model = GSgnnNodeModel(alpha_l2norm=0)
         feat_size = get_node_feat_size(np_data.g, 'feat')

--- a/python/graphstorm/model/hgt_encoder.py
+++ b/python/graphstorm/model/hgt_encoder.py
@@ -314,10 +314,10 @@ class HGTEncoder(GraphConvEncoder):
         from graphstorm.model.hgt_encoder import HGTEncoder
         from graphstorm.model.edge_decoder import MLPEdgeDecoder
         from graphstorm.model import GSgnnEdgeModel, GSNodeEncoderInputLayer
-        from graphstorm.dataloading import GSgnnNodeTrainData
+        from graphstorm.dataloading import GSgnnData
         from graphstorm.model import do_full_graph_inference
 
-        np_data = GSgnnNodeTrainData(...)
+        np_data = GSgnnData(...)
 
         model = GSgnnEdgeModel(alpha_l2norm=0)
         feat_size = get_node_feat_size(np_data.g, 'feat')

--- a/python/graphstorm/model/lm_embed.py
+++ b/python/graphstorm/model/lm_embed.py
@@ -492,7 +492,7 @@ class GSPureLMNodeInputLayer(GSNodeInputLayer):
     .. code:: python
 
         from graphstorm.model import GSgnnNodeModel, GSPureLMNodeInputLayer
-        from graphstorm.dataloading import GSgnnNodeTrainData
+        from graphstorm.dataloading import GSgnnData
 
         node_lm_configs = [
             {
@@ -502,7 +502,7 @@ class GSPureLMNodeInputLayer(GSNodeInputLayer):
                 "node_types": ['a']
             }
         ]
-        np_data = GSgnnNodeTrainData(...)
+        np_data = GSgnnData(...)
         model = GSgnnNodeModel(...)
         lm_train_nodes=10
         encoder = GSPureLMNodeInputLayer(g=np_data.g, node_lm_configs=node_lm_configs,
@@ -687,8 +687,8 @@ class GSLMNodeEncoderInputLayer(GSNodeEncoderInputLayer):
 
         from graphstorm import get_node_feat_size
         from graphstorm.model import GSgnnNodeModel, GSLMNodeEncoderInputLayer
-        from graphstorm.dataloading import GSgnnNodeTrainData
-        np_data = GSgnnNodeTrainData(...)
+        from graphstorm.dataloading import GSgnnData
+        np_data = GSgnnData(...)
         model = GSgnnNodeModel(...)
         feat_size = get_node_feat_size(np_data.g, 'feat')
         node_lm_configs = [{"lm_type": "bert",

--- a/python/graphstorm/model/node_gnn.py
+++ b/python/graphstorm/model/node_gnn.py
@@ -210,9 +210,9 @@ def node_mini_batch_gnn_predict(model, loader, return_proba=True, return_label=F
     preds = {}
 
     if return_label:
-        assert data.labels is not None, \
-            "Return label is required, but the label field is not provided whem" \
-            "initlaizing the inference dataset."
+        assert loader.label_field is not None, \
+            "Return label is required, but the label field is not provided when" \
+            "initlaizing the loader."
 
     embs = {}
     labels = {}
@@ -241,7 +241,8 @@ def node_mini_batch_gnn_predict(model, loader, return_proba=True, return_label=F
             if is_wholegraph():
                 tmp_keys = [ntype for ntype in g.ntypes if ntype not in input_nodes]
                 prepare_for_wholegraph(g, input_nodes)
-            input_feats = data.get_node_feats(input_nodes, device)
+            nfeat_fields = loader.node_feat_fields
+            input_feats = data.get_node_feats(input_nodes, nfeat_fields, device)
             if blocks is None:
                 continue
             # Remove additional keys (ntypes) added for WholeGraph compatibility
@@ -249,7 +250,8 @@ def node_mini_batch_gnn_predict(model, loader, return_proba=True, return_label=F
                 del input_nodes[ntype]
             blocks = [block.to(device) for block in blocks]
             pred, emb = model.predict(blocks, input_feats, None, input_nodes, return_proba)
-            label = data.get_labels(seeds)
+            label_field = loader.label_field
+            label = data.get_node_feats(seeds, label_field)
             if return_label:
                 append_to_dict(label, labels)
 
@@ -312,9 +314,9 @@ def node_mini_batch_predict(model, emb, loader, return_proba=True, return_label=
     data = loader.data
 
     if return_label:
-        assert data.labels is not None, \
-            "Return label is required, but the label field is not provided whem" \
-            "initlaizing the inference dataset."
+        assert loader.label_field is not None, \
+            "Return label is required, but the label field is not provided when" \
+            "initlaizing the inference dataloader."
 
     preds = {}
     labels = {}
@@ -337,7 +339,8 @@ def node_mini_batch_predict(model, emb, loader, return_proba=True, return_label=
                 else:
                     preds[ntype] = [pred.cpu()]
                 if return_label:
-                    lbl = data.get_labels(seeds)
+                    label_field = loader.label_field
+                    lbl = data.get_node_feats(seeds, label_field)
                     if ntype in labels:
                         labels[ntype].append(lbl[ntype])
                     else:

--- a/python/graphstorm/model/rgat_encoder.py
+++ b/python/graphstorm/model/rgat_encoder.py
@@ -246,10 +246,10 @@ class RelationalGATEncoder(GraphConvEncoder):
         from graphstorm.model.rgat_encoder import RelationalGATEncoder
         from graphstorm.model.node_decoder import EntityClassifier
         from graphstorm.model import GSgnnNodeModel, GSNodeEncoderInputLayer
-        from graphstorm.dataloading import GSgnnNodeTrainData
+        from graphstorm.dataloading import GSgnnData
         from graphstorm.model import do_full_graph_inference
 
-        np_data = GSgnnNodeTrainData(...)
+        np_data = GSgnnData(...)
 
         model = GSgnnNodeModel(alpha_l2norm=0)
         feat_size = get_node_feat_size(np_data.g, 'feat')

--- a/python/graphstorm/model/rgcn_encoder.py
+++ b/python/graphstorm/model/rgcn_encoder.py
@@ -293,10 +293,10 @@ class RelationalGCNEncoder(GraphConvEncoder):
         from graphstorm.model.rgcn_encoder import RelationalGCNEncoder
         from graphstorm.model.node_decoder import EntityClassifier
         from graphstorm.model import GSgnnNodeModel, GSNodeEncoderInputLayer
-        from graphstorm.dataloading import GSgnnNodeTrainData
+        from graphstorm.dataloading import GSgnnData
         from graphstorm.model import do_full_graph_inference
 
-        np_data = GSgnnNodeTrainData(...)
+        np_data = GSgnnData(...)
 
         model = GSgnnNodeModel(alpha_l2norm=0)
         feat_size = get_node_feat_size(np_data.g, 'feat')

--- a/python/graphstorm/model/sage_encoder.py
+++ b/python/graphstorm/model/sage_encoder.py
@@ -177,10 +177,10 @@ class SAGEEncoder(GraphConvEncoder):
         from graphstorm.model.sage_encoder import SAGEEncoder
         from graphstorm.model.node_decoder import EntityClassifier
         from graphstorm.model import GSgnnNodeModel, GSNodeEncoderInputLayer
-        from graphstorm.dataloading import GSgnnNodeTrainData
+        from graphstorm.dataloading import GSgnnData
         from graphstorm.model import do_full_graph_inference
 
-        np_data = GSgnnNodeTrainData(...)
+        np_data = GSgnnData(...)
 
         model = GSgnnNodeModel(alpha_l2norm=0)
         feat_size = get_node_feat_size(np_data.g, 'feat')

--- a/python/graphstorm/run/gsgnn_emb/gsgnn_node_emb.py
+++ b/python/graphstorm/run/gsgnn_emb/gsgnn_node_emb.py
@@ -19,7 +19,7 @@ import graphstorm as gs
 from graphstorm.config import get_argument_parser
 from graphstorm.config import GSConfig
 from graphstorm.utils import rt_profiler, sys_tracker, get_device, use_wholegraph
-from graphstorm.dataloading import (GSgnnEdgeInferData, GSgnnNodeInferData)
+from graphstorm.dataloading import GSgnnData
 from graphstorm.config import  (BUILTIN_TASK_NODE_CLASSIFICATION,
                                 BUILTIN_TASK_NODE_REGRESSION,
                                 BUILTIN_TASK_EDGE_CLASSIFICATION,
@@ -44,26 +44,17 @@ def main(config_args):
     if gs.get_rank() == 0:
         tracker.log_params(config.__dict__)
 
-    if config.task_type == BUILTIN_TASK_LINK_PREDICTION:
-        input_data = GSgnnEdgeInferData(config.graph_name,
-                                        config.part_config,
-                                        eval_etypes=config.eval_etype,
-                                        node_feat_field=config.node_feat_name,
-                                        lm_feat_ntypes=get_lm_ntypes(config.node_lm_configs))
-    elif config.task_type in {BUILTIN_TASK_NODE_REGRESSION, BUILTIN_TASK_NODE_CLASSIFICATION}:
-        input_data = GSgnnNodeInferData(config.graph_name,
-                                        config.part_config,
-                                        eval_ntypes=config.target_ntype,
-                                        node_feat_field=config.node_feat_name,
-                                        lm_feat_ntypes=get_lm_ntypes(config.node_lm_configs))
-    elif config.task_type in {BUILTIN_TASK_EDGE_CLASSIFICATION, BUILTIN_TASK_EDGE_REGRESSION}:
-        input_data = GSgnnEdgeInferData(config.graph_name,
-                                        config.part_config,
-                                        eval_etypes=config.target_etype,
-                                        node_feat_field=config.node_feat_name,
-                                        lm_feat_ntypes=get_lm_ntypes(config.node_lm_configs))
-    else:
-        raise TypeError("Not supported for task type: ", config.task_type)
+    assert config.task_type in [BUILTIN_TASK_LINK_PREDICTION,
+                                BUILTIN_TASK_NODE_REGRESSION,
+                                BUILTIN_TASK_NODE_CLASSIFICATION,
+                                BUILTIN_TASK_EDGE_CLASSIFICATION,
+                                BUILTIN_TASK_EDGE_REGRESSION], \
+        f"Not supported for task type: {config.task_type}"
+
+    input_data = GSgnnData(config.part_config,
+                           node_feat_field=config.node_feat_name,
+                           edge_feat_field=config.edge_feat_name,
+                           lm_feat_ntypes=get_lm_ntypes(config.node_lm_configs))
 
     # assert the setting for the graphstorm embedding generation.
     assert config.save_embed_path is not None, \
@@ -87,7 +78,23 @@ def main(config_args):
     emb_generator = GSgnnEmbGenInferer(model)
     emb_generator.setup_device(device=get_device())
 
-    emb_generator.infer(input_data, config.task_type,
+    task_type = config.task_type
+    # infer ntypes must be sorted for node embedding saving
+    if task_type == BUILTIN_TASK_LINK_PREDICTION:
+        infer_ntypes = None
+    elif task_type in {BUILTIN_TASK_NODE_REGRESSION, BUILTIN_TASK_NODE_CLASSIFICATION}:
+        # TODO(xiangsx): Support multi-task on multiple node types.
+        infer_ntypes = [config.target_ntype]
+    elif task_type in {BUILTIN_TASK_EDGE_CLASSIFICATION, BUILTIN_TASK_EDGE_REGRESSION}:
+        infer_ntypes = set()
+        for etype in config.target_etype:
+            infer_ntypes.add(etype[0])
+            infer_ntypes.add(etype[2])
+        infer_ntypes = sorted(list(infer_ntypes))
+    else:
+        raise TypeError("Not supported for task type: ", task_type)
+
+    emb_generator.infer(input_data, infer_ntypes,
                 save_embed_path=config.save_embed_path,
                 eval_fanout=config.eval_fanout,
                 use_mini_batch_infer=config.use_mini_batch_infer,

--- a/python/graphstorm/run/gsgnn_ep/ep_infer_gnn.py
+++ b/python/graphstorm/run/gsgnn_ep/ep_infer_gnn.py
@@ -21,7 +21,7 @@ from graphstorm.config import get_argument_parser
 from graphstorm.config import GSConfig
 from graphstorm.inference import GSgnnEdgePredictionInferrer
 from graphstorm.eval import GSgnnAccEvaluator, GSgnnRegressionEvaluator
-from graphstorm.dataloading import GSgnnEdgeInferData, GSgnnEdgeDataLoader
+from graphstorm.dataloading import GSgnnData, GSgnnEdgeDataLoader
 from graphstorm.utils import get_device, get_lm_ntypes, use_wholegraph
 
 def get_evaluator(config): # pylint: disable=unused-argument
@@ -48,13 +48,10 @@ def main(config_args):
                   local_rank=config.local_rank,
                   use_wholegraph=config.use_wholegraph_embed or use_wg_feats)
 
-    infer_data = GSgnnEdgeInferData(config.graph_name,
-                                    config.part_config,
-                                    eval_etypes=config.target_etype,
-                                    node_feat_field=config.node_feat_name,
-                                    label_field=config.label_field,
-                                    decoder_edge_feat=config.decoder_edge_feat,
-                                    lm_feat_ntypes=get_lm_ntypes(config.node_lm_configs))
+    infer_data = GSgnnData(config.part_config,
+                           node_feat_field=config.node_feat_name,
+                           edge_feat_field=config.edge_feat_name,
+                           lm_feat_ntypes=get_lm_ntypes(config.node_lm_configs))
     model = gs.create_builtin_edge_gnn_model(infer_data.g, config, train_task=False)
     model.restore_model(config.restore_model_path,
                         model_layer_to_load=config.restore_model_layers)
@@ -62,23 +59,26 @@ def main(config_args):
     infer = GSgnnEdgePredictionInferrer(model)
     infer.setup_device(device=get_device())
     if not config.no_validation:
+        target_idxs = infer_data.get_edge_test_set(config.target_etype)
         evaluator = get_evaluator(config)
         infer.setup_evaluator(evaluator)
-        assert len(infer_data.test_idxs) > 0, \
+        assert len(target_idxs) > 0, \
             "There is not test data for evaluation. " \
             "You can use --no-validation true to avoid do testing"
-        target_idxs = infer_data.test_idxs
     else:
-        assert len(infer_data.infer_idxs) > 0, \
+        target_idxs = infer_data.get_edge_infer_set(config.target_etype)
+        assert len(target_idxs) > 0, \
             f"To do inference on {config.target_etype} without doing evaluation, " \
             "you should not define test_mask as its edge feature. " \
             "GraphStorm will do inference on the whole edge set. "
-        target_idxs = infer_data.infer_idxs
     tracker = gs.create_builtin_task_tracker(config)
     infer.setup_task_tracker(tracker)
     fanout = config.eval_fanout if config.use_mini_batch_infer else []
     dataloader = GSgnnEdgeDataLoader(infer_data, target_idxs, fanout=fanout,
                                      batch_size=config.eval_batch_size,
+                                     node_feats=config.node_feat_name,
+                                     label_field=config.label_field,
+                                     decoder_edge_feats=config.decoder_edge_feat,
                                      train_task=False,
                                      reverse_edge_types_map=config.reverse_edge_types_map,
                                      remove_target_edge_type=config.remove_target_edge_type,

--- a/python/graphstorm/run/gsgnn_ep/ep_infer_lm.py
+++ b/python/graphstorm/run/gsgnn_ep/ep_infer_lm.py
@@ -22,7 +22,7 @@ from graphstorm.config import get_argument_parser
 from graphstorm.config import GSConfig
 from graphstorm.inference import GSgnnEdgePredictionInferrer
 from graphstorm.eval import GSgnnAccEvaluator, GSgnnRegressionEvaluator
-from graphstorm.dataloading import GSgnnEdgeInferData, GSgnnEdgeDataLoader
+from graphstorm.dataloading import GSgnnData, GSgnnEdgeDataLoader
 from graphstorm.utils import get_device
 
 def get_evaluator(config): # pylint: disable=unused-argument
@@ -46,26 +46,32 @@ def main(config_args):
 
     gs.initialize(ip_config=config.ip_config, backend=config.backend,
                   local_rank=config.local_rank)
-
-    infer_data = GSgnnEdgeInferData(config.graph_name,
-                                    config.part_config,
-                                    eval_etypes=config.target_etype,
-                                    node_feat_field=config.node_feat_name,
-                                    label_field=config.label_field,
-                                    decoder_edge_feat=config.decoder_edge_feat)
+    # language model only encoder does not allow node and edge features
+    # except LM related features.
+    infer_data = GSgnnData(config.part_config)
     model = gs.create_builtin_edge_model(infer_data.g, config, train_task=False)
     model.restore_model(config.restore_model_path,
                         model_layer_to_load=config.restore_model_layers)
     infer = GSgnnEdgePredictionInferrer(model)
     infer.setup_device(device=get_device())
     if not config.no_validation:
+        target_idxs = infer_data.get_edge_test_set(config.target_etype)
         evaluator = get_evaluator(config)
         infer.setup_evaluator(evaluator)
-        assert len(infer_data.test_idxs) > 0, "There is not test data for evaluation."
+        assert len(target_idxs) > 0, "There is no test data for evaluation."
+    else:
+        target_idxs = infer_data.get_edge_infer_set(config.target_etype)
+        assert len(target_idxs) > 0, \
+            f"To do inference on {config.target_etype} without doing evaluation, " \
+            "you should not define test_mask as its edge feature. " \
+            "GraphStorm will do inference on the whole edge set. "
     tracker = gs.create_builtin_task_tracker(config)
     infer.setup_task_tracker(tracker)
-    dataloader = GSgnnEdgeDataLoader(infer_data, infer_data.test_idxs, fanout=[],
+    dataloader = GSgnnEdgeDataLoader(infer_data, target_idxs, fanout=[],
                                      batch_size=config.eval_batch_size,
+                                     node_feats=config.node_feat_name,
+                                     label_field=config.label_field,
+                                     decoder_edge_feats=config.decoder_edge_feat,
                                      train_task=False,
                                      remove_target_edge_type=False)
     # Preparing input layer for training or inference.

--- a/python/graphstorm/run/gsgnn_ep/ep_infer_lm.py
+++ b/python/graphstorm/run/gsgnn_ep/ep_infer_lm.py
@@ -46,7 +46,8 @@ def main(config_args):
 
     gs.initialize(ip_config=config.ip_config, backend=config.backend,
                   local_rank=config.local_rank)
-    # language model only encoder does not allow node and edge features
+    # The model only uses language model(s) as its encoder
+    # It will not use node or edge features
     # except LM related features.
     infer_data = GSgnnData(config.part_config)
     model = gs.create_builtin_edge_model(infer_data.g, config, train_task=False)

--- a/python/graphstorm/run/gsgnn_ep/gsgnn_ep.py
+++ b/python/graphstorm/run/gsgnn_ep/gsgnn_ep.py
@@ -22,7 +22,7 @@ import graphstorm as gs
 from graphstorm.config import get_argument_parser
 from graphstorm.config import GSConfig
 from graphstorm.trainer import GSgnnEdgePredictionTrainer
-from graphstorm.dataloading import GSgnnEdgeTrainData, GSgnnEdgeDataLoader
+from graphstorm.dataloading import GSgnnData, GSgnnEdgeDataLoader
 from graphstorm.eval import GSgnnAccEvaluator
 from graphstorm.eval import GSgnnRegressionEvaluator
 from graphstorm.model.utils import save_full_node_embeddings
@@ -64,13 +64,10 @@ def main(config_args):
     rt_profiler.init(config.profile_path, rank=gs.get_rank())
     sys_tracker.init(config.verbose, rank=gs.get_rank())
     # edge predict only handle edge feature in decoder
-    train_data = GSgnnEdgeTrainData(config.graph_name,
-                                    config.part_config,
-                                    train_etypes=config.target_etype,
-                                    node_feat_field=config.node_feat_name,
-                                    label_field=config.label_field,
-                                    decoder_edge_feat=config.decoder_edge_feat,
-                                    lm_feat_ntypes=get_lm_ntypes(config.node_lm_configs))
+    train_data = GSgnnData(config.part_config,
+                           node_feat_field=config.node_feat_name,
+                           edge_feat_field=config.edge_feat_name,
+                           lm_feat_ntypes=get_lm_ntypes(config.node_lm_configs))
     model = gs.create_builtin_edge_gnn_model(train_data.g, config, train_task=True)
     trainer = GSgnnEdgePredictionTrainer(model, topk_model_to_save=config.topk_model_to_save)
     if config.restore_model_path is not None:
@@ -81,15 +78,20 @@ def main(config_args):
         # TODO(zhengda) we need to refactor the evaluator.
         evaluator = get_evaluator(config)
         trainer.setup_evaluator(evaluator)
-        assert len(train_data.val_idxs) > 0, "The training data do not have validation set."
+        val_idxs = train_data.get_edge_val_set(config.target_etype)
+        assert len(val_idxs) > 0, "The training data do not have validation set."
         # TODO(zhengda) we need to compute the size of the entire validation set to make sure
         # we have validation data.
     tracker = gs.create_builtin_task_tracker(config)
     if gs.get_rank() == 0:
         tracker.log_params(config.__dict__)
     trainer.setup_task_tracker(tracker)
-    dataloader = GSgnnEdgeDataLoader(train_data, train_data.train_idxs, fanout=config.fanout,
+    train_idxs = train_data.get_edge_train_set(config.target_etype)
+    dataloader = GSgnnEdgeDataLoader(train_data, train_idxs, fanout=config.fanout,
                                      batch_size=config.batch_size,
+                                     node_feats=config.node_feat_name,
+                                     label_field=config.label_field,
+                                     decoder_edge_feats=config.decoder_edge_feat,
                                      train_task=True,
                                      reverse_edge_types_map=config.reverse_edge_types_map,
                                      remove_target_edge_type=config.remove_target_edge_type,
@@ -100,17 +102,25 @@ def main(config_args):
     test_dataloader = None
     # we don't need fanout for full-graph inference
     fanout = config.eval_fanout if config.use_mini_batch_infer else []
-    if len(train_data.val_idxs) > 0:
-        val_dataloader = GSgnnEdgeDataLoader(train_data, train_data.val_idxs, fanout=fanout,
+    val_idxs = train_data.get_edge_val_set(config.target_etype)
+    test_idxs = train_data.get_edge_test_set(config.target_etype)
+    if len(val_idxs) > 0:
+        val_dataloader = GSgnnEdgeDataLoader(train_data, val_idxs, fanout=fanout,
             batch_size=config.eval_batch_size,
+            node_feats=config.node_feat_name,
+            label_field=config.label_field,
+            decoder_edge_feats=config.decoder_edge_feat,
             train_task=False,
             reverse_edge_types_map=config.reverse_edge_types_map,
             remove_target_edge_type=config.remove_target_edge_type,
             construct_feat_ntype=config.construct_feat_ntype,
             construct_feat_fanout=config.construct_feat_fanout)
-    if len(train_data.test_idxs) > 0:
-        test_dataloader = GSgnnEdgeDataLoader(train_data, train_data.test_idxs, fanout=fanout,
+    if len(test_idxs) > 0:
+        test_dataloader = GSgnnEdgeDataLoader(train_data, test_idxs, fanout=fanout,
             batch_size=config.eval_batch_size,
+            node_feats=config.node_feat_name,
+            label_field=config.label_field,
+            decoder_edge_feats=config.decoder_edge_feat,
             train_task=False,
             reverse_edge_types_map=config.reverse_edge_types_map,
             remove_target_edge_type=config.remove_target_edge_type,

--- a/python/graphstorm/run/gsgnn_ep/gsgnn_lm_ep.py
+++ b/python/graphstorm/run/gsgnn_ep/gsgnn_lm_ep.py
@@ -60,7 +60,8 @@ def main(config_args):
                   local_rank=config.local_rank)
     rt_profiler.init(config.profile_path, rank=gs.get_rank())
     sys_tracker.init(config.verbose, rank=gs.get_rank())
-    # language model only encoder does not allow node and edge features
+    # The model only uses language model(s) as its encoder
+    # It will not use node or edge features
     # except LM related features.
     train_data = GSgnnData(config.part_config)
     model = gs.create_builtin_edge_model(train_data.g, config, train_task=True)

--- a/python/graphstorm/run/gsgnn_ep/gsgnn_lm_ep.py
+++ b/python/graphstorm/run/gsgnn_ep/gsgnn_lm_ep.py
@@ -22,7 +22,7 @@ import graphstorm as gs
 from graphstorm.config import get_argument_parser
 from graphstorm.config import GSConfig
 from graphstorm.trainer import GSgnnEdgePredictionTrainer
-from graphstorm.dataloading import GSgnnEdgeTrainData, GSgnnEdgeDataLoader
+from graphstorm.dataloading import GSgnnData, GSgnnEdgeDataLoader
 from graphstorm.eval import GSgnnAccEvaluator
 from graphstorm.eval import GSgnnRegressionEvaluator
 from graphstorm.model.utils import save_full_node_embeddings
@@ -60,12 +60,9 @@ def main(config_args):
                   local_rank=config.local_rank)
     rt_profiler.init(config.profile_path, rank=gs.get_rank())
     sys_tracker.init(config.verbose, rank=gs.get_rank())
-    train_data = GSgnnEdgeTrainData(config.graph_name,
-                                    config.part_config,
-                                    train_etypes=config.target_etype,
-                                    node_feat_field=config.node_feat_name,
-                                    label_field=config.label_field,
-                                    decoder_edge_feat=config.decoder_edge_feat)
+    # language model only encoder does not allow node and edge features
+    # except LM related features.
+    train_data = GSgnnData(config.part_config)
     model = gs.create_builtin_edge_model(train_data.g, config, train_task=True)
     trainer = GSgnnEdgePredictionTrainer(model, topk_model_to_save=config.topk_model_to_save)
     if config.restore_model_path is not None:
@@ -76,29 +73,42 @@ def main(config_args):
         # TODO(zhengda) we need to refactor the evaluator.
         evaluator = get_evaluator(config)
         trainer.setup_evaluator(evaluator)
-        assert len(train_data.val_idxs) > 0, "The training data do not have validation set."
+        val_idxs = train_data.get_edge_val_set(config.target_etype)
+        assert len(val_idxs) > 0, "The training data do not have validation set."
         # TODO(zhengda) we need to compute the size of the entire validation set to make sure
         # we have validation data.
     tracker = gs.create_builtin_task_tracker(config)
     if gs.get_rank() == 0:
         tracker.log_params(config.__dict__)
     trainer.setup_task_tracker(tracker)
-    dataloader = GSgnnEdgeDataLoader(train_data, train_data.train_idxs, fanout=[],
+    train_idxs = train_data.get_edge_train_set(config.target_etype)
+    dataloader = GSgnnEdgeDataLoader(train_data, train_idxs, fanout=[],
                                      batch_size=config.batch_size,
+                                     node_feats=config.node_feat_name,
+                                     label_field=config.label_field,
+                                     decoder_edge_feats=config.decoder_edge_feat,
                                      train_task=True,
                                      remove_target_edge_type=False)
     val_dataloader = None
     test_dataloader = None
     # we don't need fanout for full-graph inference
     fanout = []
-    if len(train_data.val_idxs) > 0:
-        val_dataloader = GSgnnEdgeDataLoader(train_data, train_data.val_idxs, fanout=fanout,
+    val_idxs = train_data.get_edge_val_set(config.target_etype)
+    test_idxs = train_data.get_edge_test_set(config.target_etype)
+    if len(val_idxs) > 0:
+        val_dataloader = GSgnnEdgeDataLoader(train_data, val_idxs, fanout=fanout,
             batch_size=config.eval_batch_size,
+            node_feats=config.node_feat_name,
+            label_field=config.label_field,
+            decoder_edge_feats=config.decoder_edge_feat,
             train_task=False,
             remove_target_edge_type=False)
-    if len(train_data.test_idxs) > 0:
-        test_dataloader = GSgnnEdgeDataLoader(train_data, train_data.test_idxs, fanout=fanout,
+    if len(test_idxs) > 0:
+        test_dataloader = GSgnnEdgeDataLoader(train_data, test_idxs, fanout=fanout,
             batch_size=config.eval_batch_size,
+            node_feats=config.node_feat_name,
+            label_field=config.label_field,
+            decoder_edge_feats=config.decoder_edge_feat,
             train_task=False,
             remove_target_edge_type=False)
 

--- a/python/graphstorm/run/gsgnn_lp/gsgnn_lm_lp.py
+++ b/python/graphstorm/run/gsgnn_lp/gsgnn_lm_lp.py
@@ -79,7 +79,8 @@ def main(config_args):
                   local_rank=config.local_rank)
     rt_profiler.init(config.profile_path, rank=gs.get_rank())
     sys_tracker.init(config.verbose, rank=gs.get_rank())
-    # language model only encoder does not allow node and edge features
+    # The model only uses language model(s) as its encoder
+    # It will not use node or edge features
     # except LM related features.
     train_data = GSgnnData(config.part_config)
     model = gs.create_builtin_lp_model(train_data.g, config, train_task=True)

--- a/python/graphstorm/run/gsgnn_lp/gsgnn_lm_lp.py
+++ b/python/graphstorm/run/gsgnn_lp/gsgnn_lm_lp.py
@@ -22,7 +22,7 @@ import graphstorm as gs
 from graphstorm.config import get_argument_parser
 from graphstorm.config import GSConfig
 from graphstorm.trainer import GSgnnLinkPredictionTrainer
-from graphstorm.dataloading import GSgnnLPTrainData
+from graphstorm.dataloading import GSgnnData
 from graphstorm.dataloading import GSgnnLinkPredictionDataLoader
 from graphstorm.dataloading import (GSgnnLPJointNegDataLoader,
                                     GSgnnLPLocalUniformNegDataLoader,
@@ -87,12 +87,9 @@ def main(config_args):
                   local_rank=config.local_rank)
     rt_profiler.init(config.profile_path, rank=gs.get_rank())
     sys_tracker.init(config.verbose, rank=gs.get_rank())
-    train_data = GSgnnLPTrainData(config.graph_name,
-                                  config.part_config,
-                                  train_etypes=config.train_etype,
-                                  eval_etypes=config.eval_etype,
-                                  node_feat_field=config.node_feat_name,
-                                  pos_graph_feat_field=config.lp_edge_weight_for_loss)
+    # language model only encoder does not allow node and edge features
+    # except LM related features.
+    train_data = GSgnnData(config.part_config)
     model = gs.create_builtin_lp_model(train_data.g, config, train_task=True)
     trainer = GSgnnLinkPredictionTrainer(model, topk_model_to_save=config.topk_model_to_save)
     if config.restore_model_path is not None:
@@ -104,7 +101,8 @@ def main(config_args):
         # Currently, we only support mrr
         evaluator = get_evaluator(config, train_data)
         trainer.setup_evaluator(evaluator)
-        assert len(train_data.val_idxs) > 0, "The training data do not have validation set."
+        val_idxs = train_data.get_edge_val_set(config.eval_etype)
+        assert len(val_idxs) > 0, "The training data do not have validation set."
         # TODO(zhengda) we need to compute the size of the entire validation set to make sure
         # we have validation data.
     tracker = gs.create_builtin_task_tracker(config)
@@ -128,8 +126,12 @@ def main(config_args):
         dataloader_cls = GSgnnAllEtypeLPJointNegDataLoader
     else:
         raise ValueError('Unknown negative sampler')
-    dataloader = dataloader_cls(train_data, train_data.train_idxs, [],
+    train_idxs = train_data.get_edge_train_set(config.train_etype)
+    dataloader = dataloader_cls(train_data,
+                                train_idxs, [],
                                 config.batch_size, config.num_negative_edges,
+                                node_feats=config.node_feat_name,
+                                pos_graph_edge_feats=config.lp_edge_weight_for_loss,
                                 train_task=True,
                                 edge_dst_negative_field=config.train_etypes_negative_dstnode,
                                 num_hard_negs=config.num_train_hard_negatives)
@@ -147,20 +149,36 @@ def main(config_args):
             f'[{BUILTIN_LP_UNIFORM_NEG_SAMPLER}, {BUILTIN_LP_JOINT_NEG_SAMPLER}]')
     val_dataloader = None
     test_dataloader = None
-    if len(train_data.val_idxs) > 0:
+
+    val_idxs = train_data.get_edge_val_set(config.eval_etype)
+    if len(val_idxs) > 0:
         if config.eval_etypes_negative_dstnode is not None:
-            val_dataloader = test_dataloader_cls(train_data, train_data.val_idxs,
-                config.eval_batch_size, config.eval_etypes_negative_dstnode)
+            val_dataloader = test_dataloader_cls(train_data, val_idxs,
+                config.eval_batch_size,
+                config.eval_etypes_negative_dstnode,
+                node_feats=config.node_feat_name,
+                pos_graph_edge_feats=config.lp_edge_weight_for_loss)
         else:
-            val_dataloader = test_dataloader_cls(train_data, train_data.val_idxs,
-                config.eval_batch_size, config.num_negative_edges_eval)
-    if len(train_data.test_idxs) > 0:
+            val_dataloader = test_dataloader_cls(train_data, val_idxs,
+                config.eval_batch_size,
+                config.num_negative_edges_eval,
+                node_feats=config.node_feat_name,
+                pos_graph_edge_feats=config.lp_edge_weight_for_loss)
+
+    test_idxs = train_data.get_edge_test_set(config.eval_etype)
+    if len(test_idxs) > 0:
         if config.eval_etypes_negative_dstnode is not None:
-            test_dataloader = test_dataloader_cls(train_data, train_data.test_idxs,
-                config.eval_batch_size, config.eval_etypes_negative_dstnode)
+            test_dataloader = test_dataloader_cls(train_data, test_idxs,
+                config.eval_batch_size,
+                config.eval_etypes_negative_dstnode,
+                node_feats=config.node_feat_name,
+                pos_graph_edge_feats=config.lp_edge_weight_for_loss)
         else:
-            test_dataloader = test_dataloader_cls(train_data, train_data.test_idxs,
-                config.eval_batch_size, config.num_negative_edges_eval)
+            test_dataloader = test_dataloader_cls(train_data, test_idxs,
+                config.eval_batch_size,
+                config.num_negative_edges_eval,
+                node_feats=config.node_feat_name,
+                pos_graph_edge_feats=config.lp_edge_weight_for_loss)
 
     # Preparing input layer for training or inference.
     # The input layer can pre-compute node features in the preparing step if needed.

--- a/python/graphstorm/run/gsgnn_lp/gsgnn_lp.py
+++ b/python/graphstorm/run/gsgnn_lp/gsgnn_lp.py
@@ -22,7 +22,7 @@ import graphstorm as gs
 from graphstorm.config import get_argument_parser
 from graphstorm.config import GSConfig
 from graphstorm.trainer import GSgnnLinkPredictionTrainer
-from graphstorm.dataloading import GSgnnLPTrainData
+from graphstorm.dataloading import GSgnnData
 from graphstorm.dataloading import GSgnnLinkPredictionDataLoader
 from graphstorm.dataloading import (GSgnnLPJointNegDataLoader,
                                     GSgnnLPLocalUniformNegDataLoader,
@@ -103,13 +103,10 @@ def main(config_args):
                   use_wholegraph=config.use_wholegraph_embed or use_wg_feats)
     rt_profiler.init(config.profile_path, rank=gs.get_rank())
     sys_tracker.init(config.verbose, rank=gs.get_rank())
-    train_data = GSgnnLPTrainData(config.graph_name,
-                                  config.part_config,
-                                  train_etypes=config.train_etype,
-                                  eval_etypes=config.eval_etype,
-                                  node_feat_field=config.node_feat_name,
-                                  pos_graph_feat_field=config.lp_edge_weight_for_loss,
-                                  lm_feat_ntypes=get_lm_ntypes(config.node_lm_configs))
+    train_data = GSgnnData(config.part_config,
+                           node_feat_field=config.node_feat_name,
+                           edge_feat_field=config.edge_feat_name,
+                           lm_feat_ntypes=get_lm_ntypes(config.node_lm_configs))
     model = gs.create_builtin_lp_gnn_model(train_data.g, config, train_task=True)
     trainer = GSgnnLinkPredictionTrainer(model, topk_model_to_save=config.topk_model_to_save)
     if config.restore_model_path is not None:
@@ -121,7 +118,8 @@ def main(config_args):
         # Currently, we only support mrr
         evaluator = get_evaluator(config, train_data)
         trainer.setup_evaluator(evaluator)
-        assert len(train_data.val_idxs) > 0, "The training data do not have validation set."
+        val_idxs = train_data.get_edge_val_set(config.eval_etype)
+        assert len(val_idxs) > 0, "The training data do not have validation set."
         # TODO(zhengda) we need to compute the size of the entire validation set to make sure
         # we have validation data.
     tracker = gs.create_builtin_task_tracker(config)
@@ -153,8 +151,11 @@ def main(config_args):
         dataloader_cls = FastGSgnnLPLocalJointNegDataLoader
     else:
         raise ValueError('Unknown negative sampler')
-    dataloader = dataloader_cls(train_data, train_data.train_idxs, config.fanout,
+    train_idxs = train_data.get_edge_train_set(config.train_etype)
+    dataloader = dataloader_cls(train_data, train_idxs, config.fanout,
                                 config.batch_size, config.num_negative_edges,
+                                node_feats=config.node_feat_name,
+                                pos_graph_edge_feats=config.lp_edge_weight_for_loss,
                                 train_task=True,
                                 reverse_edge_types_map=config.reverse_edge_types_map,
                                 exclude_training_targets=config.exclude_training_targets,
@@ -176,28 +177,40 @@ def main(config_args):
             f'[{BUILTIN_LP_UNIFORM_NEG_SAMPLER}, {BUILTIN_LP_JOINT_NEG_SAMPLER}]')
     val_dataloader = None
     test_dataloader = None
-    if len(train_data.val_idxs) > 0:
+    val_idxs = train_data.get_edge_val_set(config.eval_etype)
+    if len(val_idxs) > 0:
         if config.eval_etypes_negative_dstnode is not None:
-            val_dataloader = test_dataloader_cls(train_data, train_data.val_idxs,
+            val_dataloader = test_dataloader_cls(train_data, val_idxs,
                 config.eval_batch_size,
                 fixed_edge_dst_negative_field=config.eval_etypes_negative_dstnode,
                 fanout=config.eval_fanout,
-                fixed_test_size=config.fixed_test_size)
+                fixed_test_size=config.fixed_test_size,
+                node_feats=config.node_feat_name,
+                pos_graph_edge_feats=config.lp_edge_weight_for_loss)
         else:
-            val_dataloader = test_dataloader_cls(train_data, train_data.val_idxs,
-                config.eval_batch_size, config.num_negative_edges_eval, config.eval_fanout,
-                fixed_test_size=config.fixed_test_size)
-    if len(train_data.test_idxs) > 0:
+            val_dataloader = test_dataloader_cls(train_data, val_idxs,
+                config.eval_batch_size,
+                config.num_negative_edges_eval, config.eval_fanout,
+                fixed_test_size=config.fixed_test_size,
+                node_feats=config.node_feat_name,
+                pos_graph_edge_feats=config.lp_edge_weight_for_loss)
+
+    test_idxs = train_data.get_edge_test_set(config.eval_etype)
+    if len(test_idxs) > 0:
         if config.eval_etypes_negative_dstnode is not None:
-            test_dataloader = test_dataloader_cls(train_data, train_data.test_idxs,
+            test_dataloader = test_dataloader_cls(train_data, test_idxs,
                 config.eval_batch_size,
                 fixed_edge_dst_negative_field=config.eval_etypes_negative_dstnode,
                 fanout=config.eval_fanout,
-                fixed_test_size=config.fixed_test_size)
+                fixed_test_size=config.fixed_test_size,
+                node_feats=config.node_feat_name,
+                pos_graph_edge_feats=config.lp_edge_weight_for_loss)
         else:
-            test_dataloader = test_dataloader_cls(train_data, train_data.test_idxs,
+            test_dataloader = test_dataloader_cls(train_data, test_idxs,
                 config.eval_batch_size, config.num_negative_edges_eval, config.eval_fanout,
-                fixed_test_size=config.fixed_test_size)
+                fixed_test_size=config.fixed_test_size,
+                node_feats=config.node_feat_name,
+                pos_graph_edge_feats=config.lp_edge_weight_for_loss)
 
     # Preparing input layer for training or inference.
     # The input layer can pre-compute node features in the preparing step if needed.

--- a/python/graphstorm/run/gsgnn_lp/lp_infer_gnn.py
+++ b/python/graphstorm/run/gsgnn_lp/lp_infer_gnn.py
@@ -53,21 +53,23 @@ def main(config_args):
                         model_layer_to_load=config.restore_model_layers)
     infer = GSgnnLinkPredictionInferrer(model)
     infer.setup_device(device=get_device())
-    test_idxs = infer_data.get_edge_test_set(config.eval_etype)
     if not config.no_validation:
+        infer_idxs = infer_data.get_edge_test_set(config.eval_etype)
         infer.setup_evaluator(
             GSgnnMrrLPEvaluator(config.eval_frequency,
                                 infer_data,
                                 config.num_negative_edges_eval,
                                 config.lp_decoder_type))
-        assert len(test_idxs) > 0, "There is not test data for evaluation."
+        assert len(infer_idxs) > 0, "There is not test data for evaluation."
+    else:
+        infer_idxs = infer_data.get_edge_infer_set(config.eval_etype)
     tracker = gs.create_builtin_task_tracker(config)
     infer.setup_task_tracker(tracker)
     # We only support full-graph inference for now.
     if config.eval_etypes_negative_dstnode is not None:
         # The negatives used in evaluation is fixed.
         dataloader = GSgnnLinkPredictionPredefinedTestDataLoader(
-            infer_data, test_idxs,
+            infer_data, infer_idxs,
             batch_size=config.eval_batch_size,
             fixed_edge_dst_negative_field=config.eval_etypes_negative_dstnode,
             fanout=config.eval_fanout,
@@ -82,7 +84,7 @@ def main(config_args):
                 'Supported test negative samplers include '
                 f'[{BUILTIN_LP_UNIFORM_NEG_SAMPLER}, {BUILTIN_LP_JOINT_NEG_SAMPLER}]')
 
-        dataloader = test_dataloader_cls(infer_data, test_idxs,
+        dataloader = test_dataloader_cls(infer_data, infer_idxs,
             batch_size=config.eval_batch_size,
             num_negative_edges=config.num_negative_edges_eval,
             fanout=config.eval_fanout,

--- a/python/graphstorm/run/gsgnn_lp/lp_infer_gnn.py
+++ b/python/graphstorm/run/gsgnn_lp/lp_infer_gnn.py
@@ -21,7 +21,7 @@ from graphstorm.config import get_argument_parser
 from graphstorm.config import GSConfig
 from graphstorm.inference import GSgnnLinkPredictionInferrer
 from graphstorm.eval import GSgnnMrrLPEvaluator
-from graphstorm.dataloading import GSgnnEdgeInferData
+from graphstorm.dataloading import GSgnnData
 from graphstorm.dataloading import (GSgnnLinkPredictionTestDataLoader,
                                     GSgnnLinkPredictionJointTestDataLoader,
                                     GSgnnLinkPredictionPredefinedTestDataLoader)
@@ -44,34 +44,34 @@ def main(config_args):
                   local_rank=config.local_rank,
                   use_wholegraph=config.use_wholegraph_embed or use_wg_feats)
 
-    infer_data = GSgnnEdgeInferData(config.graph_name,
-                                    config.part_config,
-                                    eval_etypes=config.eval_etype,
-                                    node_feat_field=config.node_feat_name,
-                                    decoder_edge_feat=config.decoder_edge_feat,
-                                    lm_feat_ntypes=get_lm_ntypes(config.node_lm_configs))
+    infer_data = GSgnnData(config.part_config,
+                           node_feat_field=config.node_feat_name,
+                           edge_feat_field=config.edge_feat_name,
+                           lm_feat_ntypes=get_lm_ntypes(config.node_lm_configs))
     model = gs.create_builtin_lp_gnn_model(infer_data.g, config, train_task=False)
     model.restore_model(config.restore_model_path,
                         model_layer_to_load=config.restore_model_layers)
     infer = GSgnnLinkPredictionInferrer(model)
     infer.setup_device(device=get_device())
+    test_idxs = infer_data.get_edge_test_set(config.eval_etype)
     if not config.no_validation:
         infer.setup_evaluator(
             GSgnnMrrLPEvaluator(config.eval_frequency,
                                 infer_data,
                                 config.num_negative_edges_eval,
                                 config.lp_decoder_type))
-        assert len(infer_data.test_idxs) > 0, "There is not test data for evaluation."
+        assert len(test_idxs) > 0, "There is not test data for evaluation."
     tracker = gs.create_builtin_task_tracker(config)
     infer.setup_task_tracker(tracker)
     # We only support full-graph inference for now.
     if config.eval_etypes_negative_dstnode is not None:
         # The negatives used in evaluation is fixed.
         dataloader = GSgnnLinkPredictionPredefinedTestDataLoader(
-            infer_data, infer_data.test_idxs,
+            infer_data, test_idxs,
             batch_size=config.eval_batch_size,
             fixed_edge_dst_negative_field=config.eval_etypes_negative_dstnode,
-            fanout=config.eval_fanout)
+            fanout=config.eval_fanout,
+            node_feats=config.node_feat_name)
     else:
         if config.eval_negative_sampler == BUILTIN_LP_UNIFORM_NEG_SAMPLER:
             test_dataloader_cls = GSgnnLinkPredictionTestDataLoader
@@ -82,10 +82,11 @@ def main(config_args):
                 'Supported test negative samplers include '
                 f'[{BUILTIN_LP_UNIFORM_NEG_SAMPLER}, {BUILTIN_LP_JOINT_NEG_SAMPLER}]')
 
-        dataloader = test_dataloader_cls(infer_data, infer_data.test_idxs,
+        dataloader = test_dataloader_cls(infer_data, test_idxs,
             batch_size=config.eval_batch_size,
             num_negative_edges=config.num_negative_edges_eval,
-            fanout=config.eval_fanout)
+            fanout=config.eval_fanout,
+            node_feats=config.node_feat_name)
     infer.infer(infer_data, dataloader,
                 save_embed_path=config.save_embed_path,
                 edge_mask_for_gnn_embeddings=None if config.no_validation else \

--- a/python/graphstorm/run/gsgnn_lp/lp_infer_lm.py
+++ b/python/graphstorm/run/gsgnn_lp/lp_infer_lm.py
@@ -38,7 +38,8 @@ def main(config_args):
 
     gs.initialize(ip_config=config.ip_config, backend=config.backend,
                   local_rank=config.local_rank)
-    # language model only encoder does not allow node and edge features
+    # The model only uses language model(s) as its encoder
+    # It will not use node or edge features
     # except LM related features.
     infer_data = GSgnnData(config.part_config)
     model = gs.create_builtin_lp_model(infer_data.g, config, train_task=False)

--- a/python/graphstorm/run/gsgnn_lp/lp_infer_lm.py
+++ b/python/graphstorm/run/gsgnn_lp/lp_infer_lm.py
@@ -22,7 +22,7 @@ from graphstorm.config import get_argument_parser
 from graphstorm.config import GSConfig
 from graphstorm.inference import GSgnnLinkPredictionInferrer
 from graphstorm.eval import GSgnnMrrLPEvaluator
-from graphstorm.dataloading import GSgnnEdgeInferData
+from graphstorm.dataloading import GSgnnData
 from graphstorm.dataloading import (GSgnnLinkPredictionTestDataLoader,
                                     GSgnnLinkPredictionJointTestDataLoader,
                                     GSgnnLinkPredictionPredefinedTestDataLoader)
@@ -38,33 +38,32 @@ def main(config_args):
 
     gs.initialize(ip_config=config.ip_config, backend=config.backend,
                   local_rank=config.local_rank)
-
-    infer_data = GSgnnEdgeInferData(config.graph_name,
-                                    config.part_config,
-                                    eval_etypes=config.eval_etype,
-                                    node_feat_field=config.node_feat_name,
-                                    decoder_edge_feat=config.decoder_edge_feat)
+    # language model only encoder does not allow node and edge features
+    # except LM related features.
+    infer_data = GSgnnData(config.part_config)
     model = gs.create_builtin_lp_model(infer_data.g, config, train_task=False)
     model.restore_model(config.restore_model_path,
                         model_layer_to_load=config.restore_model_layers)
     infer = GSgnnLinkPredictionInferrer(model)
     infer.setup_device(device=get_device())
+    test_idxs = infer_data.get_edge_test_set(config.eval_etype)
     if not config.no_validation:
         infer.setup_evaluator(
             GSgnnMrrLPEvaluator(config.eval_frequency,
                                 infer_data,
                                 config.num_negative_edges_eval,
                                 config.lp_decoder_type))
-        assert len(infer_data.test_idxs) > 0, "There is not test data for evaluation."
+        assert len(test_idxs) > 0, "There is not test data for evaluation."
     tracker = gs.create_builtin_task_tracker(config)
     infer.setup_task_tracker(tracker)
     # We only support full-graph inference for now.
     if config.eval_etypes_negative_dstnode is not None:
         # The negatives used in evaluation is fixed.
         dataloader = GSgnnLinkPredictionPredefinedTestDataLoader(
-            infer_data, infer_data.test_idxs,
+            infer_data, test_idxs,
             batch_size=config.eval_batch_size,
-            fixed_edge_dst_negative_field=config.eval_etypes_negative_dstnode)
+            fixed_edge_dst_negative_field=config.eval_etypes_negative_dstnode,
+            node_feats=config.node_feat_name)
     else:
         if config.eval_negative_sampler == BUILTIN_LP_UNIFORM_NEG_SAMPLER:
             test_dataloader_cls = GSgnnLinkPredictionTestDataLoader
@@ -75,9 +74,10 @@ def main(config_args):
                 'Supported test negative samplers include '
                 f'[{BUILTIN_LP_UNIFORM_NEG_SAMPLER}, {BUILTIN_LP_JOINT_NEG_SAMPLER}]')
 
-        dataloader = test_dataloader_cls(infer_data, infer_data.test_idxs,
+        dataloader = test_dataloader_cls(infer_data, test_idxs,
             batch_size=config.eval_batch_size,
-            num_negative_edges=config.num_negative_edges_eval)
+            num_negative_edges=config.num_negative_edges_eval,
+            node_feats=config.node_feat_name)
     # Preparing input layer for training or inference.
     # The input layer can pre-compute node features in the preparing step if needed.
     # For example pre-compute all BERT embeddings

--- a/python/graphstorm/run/gsgnn_np/gsgnn_np.py
+++ b/python/graphstorm/run/gsgnn_np/gsgnn_np.py
@@ -23,7 +23,7 @@ from graphstorm.config import get_argument_parser
 from graphstorm.config import GSConfig
 from graphstorm.trainer import GSgnnNodePredictionTrainer
 from graphstorm.trainer import GLEMNodePredictionTrainer
-from graphstorm.dataloading import GSgnnNodeTrainData, GSgnnNodeDataLoader,\
+from graphstorm.dataloading import GSgnnData, GSgnnNodeDataLoader,\
     GSgnnNodeSemiSupDataLoader
 from graphstorm.eval import GSgnnAccEvaluator
 from graphstorm.eval import GSgnnRegressionEvaluator
@@ -67,13 +67,10 @@ def main(config_args):
                   use_wholegraph=config.use_wholegraph_embed or use_wg_feats)
     rt_profiler.init(config.profile_path, rank=gs.get_rank())
     sys_tracker.init(config.verbose, rank=gs.get_rank())
-    train_data = GSgnnNodeTrainData(config.graph_name,
-                                    config.part_config,
-                                    train_ntypes=config.target_ntype,
-                                    eval_ntypes=config.eval_target_ntype,
-                                    node_feat_field=config.node_feat_name,
-                                    label_field=config.label_field,
-                                    lm_feat_ntypes=get_lm_ntypes(config.node_lm_configs))
+    train_data = GSgnnData(config.part_config,
+                           node_feat_field=config.node_feat_name,
+                           edge_feat_field=config.edge_feat_name,
+                           lm_feat_ntypes=get_lm_ntypes(config.node_lm_configs))
     model = gs.create_builtin_node_gnn_model(train_data.g, config, train_task=True)
 
     if config.training_method["name"] == "glem":
@@ -85,10 +82,17 @@ def main(config_args):
         trainer.restore_model(model_path=config.restore_model_path,
                               model_layer_to_load=config.restore_model_layers)
     trainer.setup_device(device=get_device())
+    train_idxs = train_data.get_node_train_set(config.target_ntype)
+
+    eval_ntype = config.eval_target_ntype \
+        if config.eval_target_ntype is not None else config.target_ntype
+    val_idxs = train_data.get_node_val_set(eval_ntype)
+    test_idxs = train_data.get_node_test_set(eval_ntype)
+
     if not config.no_validation:
         evaluator = get_evaluator(config)
         trainer.setup_evaluator(evaluator)
-        assert len(train_data.val_idxs) > 0, "The training data do not have validation set."
+        assert len(val_idxs) > 0, "The training data do not have validation set."
         # TODO(zhengda) we need to compute the size of the entire validation set to make sure
         # we have validation data.
     tracker = gs.create_builtin_task_tracker(config)
@@ -98,34 +102,44 @@ def main(config_args):
 
     if config.use_pseudolabel:
         # Use nodes not in train_idxs as unlabeled node sets
-        unlabeled_idxs = train_data.get_unlabeled_idxs()
+        unlabeled_idxs = train_data.get_unlabeled_node_set(train_idxs)
         # semi-supervised loader
-        dataloader = GSgnnNodeSemiSupDataLoader(train_data, train_data.train_idxs, unlabeled_idxs,
+        dataloader = GSgnnNodeSemiSupDataLoader(train_data, train_idxs,
+                                                unlabeled_idxs,
                                                 fanout=config.fanout,
                                                 batch_size=config.batch_size,
                                                 train_task=True,
+                                                node_feats=config.node_feat_name,
+                                                label_field=config.label_field,
                                                 construct_feat_ntype=config.construct_feat_ntype,
                                                 construct_feat_fanout=config.construct_feat_fanout)
     else:
-        dataloader = GSgnnNodeDataLoader(train_data, train_data.train_idxs, fanout=config.fanout,
+        dataloader = GSgnnNodeDataLoader(train_data, train_idxs,
+                                         fanout=config.fanout,
                                          batch_size=config.batch_size,
                                          train_task=True,
+                                         node_feats=config.node_feat_name,
+                                         label_field=config.label_field,
                                          construct_feat_ntype=config.construct_feat_ntype,
                                          construct_feat_fanout=config.construct_feat_fanout)
     # we don't need fanout for full-graph inference
     fanout = config.eval_fanout if config.use_mini_batch_infer else []
     val_dataloader = None
     test_dataloader = None
-    if len(train_data.val_idxs) > 0:
-        val_dataloader = GSgnnNodeDataLoader(train_data, train_data.val_idxs, fanout=fanout,
+    if len(val_idxs) > 0:
+        val_dataloader = GSgnnNodeDataLoader(train_data, val_idxs, fanout=fanout,
                                              batch_size=config.eval_batch_size,
                                              train_task=False,
+                                             node_feats=config.node_feat_name,
+                                             label_field=config.label_field,
                                              construct_feat_ntype=config.construct_feat_ntype,
                                              construct_feat_fanout=config.construct_feat_fanout)
-    if len(train_data.test_idxs) > 0:
-        test_dataloader = GSgnnNodeDataLoader(train_data, train_data.test_idxs, fanout=fanout,
+    if len(test_idxs) > 0:
+        test_dataloader = GSgnnNodeDataLoader(train_data, test_idxs, fanout=fanout,
                                               batch_size=config.eval_batch_size,
                                               train_task=False,
+                                              node_feats=config.node_feat_name,
+                                              label_field=config.label_field,
                                               construct_feat_ntype=config.construct_feat_ntype,
                                               construct_feat_fanout=config.construct_feat_fanout)
 
@@ -168,7 +182,7 @@ def main(config_args):
         # of the weight matrics of the edge types of the last layer GNN
         # targetting these ntype(s) will not receive any gradient from
         # the training loss.
-        embeddings = {ntype: embeddings[ntype] for ntype in train_data.train_ntypes}
+        embeddings = {config.target_ntype: embeddings[config.target_ntype]}
         save_full_node_embeddings(
             train_data.g,
             config.save_embed_path,

--- a/python/graphstorm/run/gsgnn_np/np_infer_gnn.py
+++ b/python/graphstorm/run/gsgnn_np/np_infer_gnn.py
@@ -20,7 +20,7 @@ from graphstorm.config import get_argument_parser
 from graphstorm.config import GSConfig
 from graphstorm.inference import GSgnnNodePredictionInferrer
 from graphstorm.eval import GSgnnAccEvaluator, GSgnnRegressionEvaluator
-from graphstorm.dataloading import GSgnnNodeInferData, GSgnnNodeDataLoader
+from graphstorm.dataloading import GSgnnData, GSgnnNodeDataLoader
 from graphstorm.utils import get_device, get_lm_ntypes, use_wholegraph
 
 def get_evaluator(config): # pylint: disable=unused-argument
@@ -47,12 +47,10 @@ def main(config_args):
                   local_rank=config.local_rank,
                   use_wholegraph=config.use_wholegraph_embed or use_wg_feats)
 
-    infer_data = GSgnnNodeInferData(config.graph_name,
-                                    config.part_config,
-                                    eval_ntypes=config.target_ntype,
-                                    node_feat_field=config.node_feat_name,
-                                    label_field=config.label_field,
-                                    lm_feat_ntypes=get_lm_ntypes(config.node_lm_configs))
+    infer_data = GSgnnData(config.part_config,
+                           node_feat_field=config.node_feat_name,
+                           edge_feat_field=config.edge_feat_name,
+                           lm_feat_ntypes=get_lm_ntypes(config.node_lm_configs))
 
     model = gs.create_builtin_node_gnn_model(infer_data.g, config, train_task=False)
     model.restore_model(config.restore_model_path,
@@ -60,24 +58,26 @@ def main(config_args):
     infer = GSgnnNodePredictionInferrer(model)
     infer.setup_device(device=get_device())
     if not config.no_validation:
+        infer_idxs = infer_data.get_node_test_set(config.target_ntype)
         evaluator = get_evaluator(config)
         infer.setup_evaluator(evaluator)
-        assert len(infer_data.test_idxs) > 0, \
+        assert len(infer_idxs) > 0, \
             "There is not test data for evaluation. " \
             "You can use --no-validation true to avoid do testing"
-        target_idxs = infer_data.test_idxs
     else:
-        assert len(infer_data.infer_idxs) > 0, \
+        infer_idxs = infer_data.get_node_infer_set(config.target_ntype)
+        assert len(infer_idxs) > 0, \
             f"To do inference on {config.target_ntype} without doing evaluation, " \
             "you should not define test_mask as its node feature. " \
             "GraphStorm will do inference on the whole node set. "
-        target_idxs = infer_data.infer_idxs
     tracker = gs.create_builtin_task_tracker(config)
     infer.setup_task_tracker(tracker)
     fanout = config.eval_fanout if config.use_mini_batch_infer else []
-    dataloader = GSgnnNodeDataLoader(infer_data, target_idxs, fanout=fanout,
+    dataloader = GSgnnNodeDataLoader(infer_data, infer_idxs, fanout=fanout,
                                      batch_size=config.eval_batch_size,
                                      train_task=False,
+                                     node_feats=config.node_feat_name,
+                                     label_field=config.label_field,
                                      construct_feat_ntype=config.construct_feat_ntype,
                                      construct_feat_fanout=config.construct_feat_fanout)
     infer.infer(dataloader, save_embed_path=config.save_embed_path,

--- a/python/graphstorm/trainer/lp_trainer.py
+++ b/python/graphstorm/trainer/lp_trainer.py
@@ -58,12 +58,11 @@ class GSgnnLinkPredictionTrainer(GSgnnTrainer):
     .. code:: python
 
         from graphstorm.dataloading import GSgnnLinkPredictionDataLoader
-        from graphstorm.dataset import GSgnnEdgeTrainData
+        from graphstorm.dataset import GSgnnData
         from graphstorm.model import GSgnnLinkPredictionModel
         from graphstorm.trainer import GSgnnLinkPredictionTrainer
 
-        my_dataset = GSgnnEdgeTrainData(
-            "my_graph", "/path/to/part_config", train_etypes="edge_type")
+        my_dataset = GSgnnData("/path/to/part_config")
         target_idx = {"edge_type": target_edges_tensor}
         my_data_loader = GSgnnLinkPredictionDataLoader(
             my_dataset, target_idx, fanout=[10], batch_size=1024)
@@ -171,12 +170,13 @@ class GSgnnLinkPredictionTrainer(GSgnnTrainer):
                 if not isinstance(input_nodes, dict):
                     assert len(pos_graph.ntypes) == 1
                     input_nodes = {pos_graph.ntypes[0]: input_nodes}
-                input_feats = data.get_node_feats(input_nodes, device)
-                if data.pos_graph_feat_field is not None:
+                nfeat_fields = train_loader.node_feat_fields
+                input_feats = data.get_node_feats(input_nodes, nfeat_fields, device)
+                if train_loader.pos_graph_feat_fields is not None:
                     input_edges = {etype: pos_graph.edges[etype].data[dgl.EID] \
                         for etype in pos_graph.canonical_etypes}
                     pos_graph_feats = data.get_edge_feats(input_edges,
-                                                          data.pos_graph_feat_field,
+                                                          train_loader.pos_graph_feat_fields,
                                                           device)
                 else:
                     pos_graph_feats = None
@@ -293,7 +293,7 @@ class GSgnnLinkPredictionTrainer(GSgnnTrainer):
         ----------
         model : Pytorch model
             The GNN model.
-        data : GSgnnEdgeTrainData
+        data : GSgnnData
             The training dataset
         val_loader: GSNodeDataLoader
             The dataloader for validation data

--- a/python/graphstorm/trainer/np_trainer.py
+++ b/python/graphstorm/trainer/np_trainer.py
@@ -54,15 +54,15 @@ class GSgnnNodePredictionTrainer(GSgnnTrainer):
     .. code:: python
 
         from graphstorm.dataloading import GSgnnNodeDataLoader
-        from graphstorm.dataset import GSgnnNodeTrainData
+        from graphstorm.dataset import GSgnnData
         from graphstorm.model.node_gnn import GSgnnNodeModel
         from graphstorm.trainer import GSgnnNodePredictionTrainer
 
-        my_dataset = GSgnnNodeTrainData(
-            "my_graph", "/path/to/part_config", "my_node_type")
+        my_dataset = GSgnnData("/path/to/part_config")
         target_idx = {"my_node_type": target_nodes_tensor}
         my_data_loader = GSgnnNodeDataLoader(
-            my_dataset, target_idx, fanout=[10], batch_size=1024)
+            my_dataset, target_idx, fanout=[10], batch_size=1024,
+            label_field="label", node_feats="feat")
         my_model = GSgnnNodeModel(alpha_l2norm=0.0)
 
         trainer =  GSgnnNodePredictionTrainer(my_model, topk_model_to_save=1)
@@ -172,8 +172,10 @@ class GSgnnNodePredictionTrainer(GSgnnTrainer):
                 if not isinstance(input_nodes, dict):
                     assert len(g.ntypes) == 1
                     input_nodes = {g.ntypes[0]: input_nodes}
-                input_feats = data.get_node_feats(input_nodes, device)
-                lbl = data.get_labels(seeds, device)
+                nfeat_fields = train_loader.node_feat_fields
+                label_field = train_loader.label_field
+                input_feats = data.get_node_feats(input_nodes, nfeat_fields, device)
+                lbl = data.get_node_feats(seeds, label_field, device)
                 rt_profiler.record('train_node_feats')
 
                 blocks = [block.to(device) for block in blocks]

--- a/tests/unit-tests/data_utils.py
+++ b/tests/unit-tests/data_utils.py
@@ -242,6 +242,7 @@ def generate_dummy_hetero_graph_reconstruct(size='tiny', gen_mask=True):
         "n3": data_size,
         "n4": data_size,
     }
+    th.manual_seed(0)
 
     edges = {
         ("n1", "r0", "n0"): (th.randint(data_size, (data_size,)),

--- a/tests/unit-tests/test_dataloading.py
+++ b/tests/unit-tests/test_dataloading.py
@@ -35,8 +35,7 @@ from data_utils import (
 
 import graphstorm as gs
 from graphstorm.utils import setup_device, get_device
-from graphstorm.dataloading import GSgnnNodeTrainData, GSgnnNodeInferData
-from graphstorm.dataloading import GSgnnEdgeTrainData, GSgnnEdgeInferData
+from graphstorm.dataloading import GSgnnData
 from graphstorm.dataloading import GSgnnAllEtypeLinkPredictionDataLoader
 from graphstorm.dataloading import (GSgnnNodeDataLoader,
                                     GSgnnEdgeDataLoader,
@@ -78,272 +77,370 @@ def get_nonzero(mask):
     mask = mask[0:len(mask)]
     return th.nonzero(mask, as_tuple=True)[0]
 
-def test_GSgnnEdgeData_wo_test_mask():
-    for file in os.listdir("/dev/shm/"):
-        shutil.rmtree(file, ignore_errors=True)
+def test_GSgnnData():
+    # Create dist graph without reverse edges
     # initialize the torch distributed environment
     th.distributed.init_process_group(backend='gloo',
                                       init_method='tcp://127.0.0.1:23456',
                                       rank=0,
                                       world_size=1)
-
-    va_etypes = [("n0", "r1", "n1")]
-    with tempfile.TemporaryDirectory() as tmpdirname:
-        dist_graph, part_config = generate_dummy_dist_graph(graph_name='dummy',
-                                                            dirname=os.path.join(tmpdirname, 'dummy'),
-                                                            gen_mask=False)
-
-        ev_data_nomask = GSgnnEdgeInferData(graph_name='dummy', part_config=part_config,
-                                            eval_etypes=va_etypes)
-        ev_data_nomask2 = GSgnnEdgeInferData(graph_name='dummy', part_config=part_config,
-                                             eval_etypes=None)
-
-    assert ev_data_nomask.eval_etypes == va_etypes
-    assert ev_data_nomask2.eval_etypes == dist_graph.canonical_etypes
-
-    # eval graph without test mask
-    # all edges in the eval etype are treated as target edges
-    assert len(ev_data_nomask.infer_idxs) == len(va_etypes)
-    for etype in va_etypes:
-        assert th.all(ev_data_nomask.infer_idxs[etype] == th.arange(dist_graph.num_edges(etype)))
-
-    assert len(ev_data_nomask2.infer_idxs) == len(dist_graph.canonical_etypes)
-    for etype in dist_graph.canonical_etypes:
-        assert th.all(ev_data_nomask2.infer_idxs[etype] == th.arange(dist_graph.num_edges(etype)))
-
-    # after test pass, destroy all process group
-    th.distributed.destroy_process_group()
-
-def test_GSgnnNodeData_wo_test_mask():
-    for file in os.listdir("/dev/shm/"):
-        shutil.rmtree(file, ignore_errors=True)
-    # initialize the torch distributed environment
-    th.distributed.init_process_group(backend='gloo',
-                                      init_method='tcp://127.0.0.1:23456',
-                                      rank=0,
-                                      world_size=1)
-    va_ntypes = ["n1"]
-    with tempfile.TemporaryDirectory() as tmpdirname:
-        dist_graph, part_config = generate_dummy_dist_graph(graph_name='dummy2',
-                                                            dirname=os.path.join(tmpdirname, 'dummy2'),
-                                                            gen_mask=False)
-        infer_data_nomask = GSgnnNodeInferData(graph_name='dummy2', part_config=part_config,
-                                            eval_ntypes=va_ntypes)
-    assert infer_data_nomask.eval_ntypes == va_ntypes
-    # eval graph without test mask
-    # all nodes in the eval ntype are treated as target nodes
-    assert len(infer_data_nomask.infer_idxs) == len(va_ntypes)
-    for ntype in va_ntypes:
-        assert th.all(infer_data_nomask.infer_idxs[ntype] == th.arange(dist_graph.num_nodes(ntype)))
-
-    # after test pass, destroy all process group
-    th.distributed.destroy_process_group()
-
-def test_GSgnnEdgeData():
-    # initialize the torch distributed environment
-    th.distributed.init_process_group(backend='gloo',
-                                      init_method='tcp://127.0.0.1:23456',
-                                      rank=0,
-                                      world_size=1)
-
-    tr_etypes = [("n0", "r1", "n1"), ("n0", "r0", "n1")]
-    tr_single_etype = [("n0", "r1", "n1")]
-    va_etypes = [("n0", "r1", "n1")]
-    ts_etypes = [("n0", "r1", "n1")]
+    tr_ntypes = ['n1']
+    va_ntypes = ['n1']
+    ts_ntypes = ['n1']
+    in_ntypes = ['n1']
 
     with tempfile.TemporaryDirectory() as tmpdirname:
         # get the test dummy distributed graph
         dist_graph, part_config = generate_dummy_dist_graph(graph_name='dummy',
-                                                            dirname=os.path.join(tmpdirname, 'dummy'))
-        tr_data = GSgnnEdgeTrainData(graph_name='dummy', part_config=part_config,
-                                     train_etypes=tr_etypes, eval_etypes=va_etypes,
-                                     label_field='label')
-        tr_data1 = GSgnnEdgeTrainData(graph_name='dummy', part_config=part_config,
-                                      train_etypes=tr_etypes)
-        # pass train etypes as None
-        tr_data2 = GSgnnEdgeTrainData(graph_name='dummy', part_config=part_config,
-                                     train_etypes=None,
-                                     label_field='label')
-        # train etypes does not cover all etypes.
-        tr_data3 = GSgnnEdgeTrainData(graph_name='dummy', part_config=part_config,
-                                     train_etypes=tr_single_etype,
-                                     label_field='label')
-        ev_data = GSgnnEdgeInferData(graph_name='dummy', part_config=part_config,
-                                     eval_etypes=va_etypes)
-        # pass eval etypes as None
-        ev_data2 = GSgnnEdgeInferData(graph_name='dummy', part_config=part_config,
-                                      eval_etypes=None)
+                                                            dirname=tmpdirname, add_reverse=False)
+        gdata = GSgnnData(part_config=part_config)
 
-    # successful initialization with default setting
-    assert tr_data.train_etypes == tr_etypes
-    assert tr_data.eval_etypes == va_etypes
-    assert tr_data1.train_etypes == tr_etypes
-    assert tr_data1.eval_etypes == tr_etypes
-    assert ev_data.eval_etypes == va_etypes
-    assert tr_data2.train_etypes == tr_data2.eval_etypes
-    assert tr_data2.train_etypes == dist_graph.canonical_etypes
-    assert tr_data3.train_etypes == tr_single_etype
-    assert tr_data3.eval_etypes == tr_single_etype
-    assert ev_data2.eval_etypes == dist_graph.canonical_etypes
+        assert gdata.graph_name == 'dummy'
+        assert gdata.node_feat_field == None
+        assert gdata.edge_feat_field == None
+        assert gdata.has_node_feats('n1') is False
+        assert gdata.has_node_feats(('n0', 'r0', 'n1')) is False
+        assert gdata.has_node_lm_feats('n1') is False
+        assert gdata.has_edge_lm_feats(('n0', 'r0', 'n1')) is False
 
-    # sucessfully split train/val/test idxs
-    assert len(tr_data.train_idxs) == len(tr_etypes)
-    for etype in tr_etypes:
-        assert th.all(tr_data.train_idxs[etype] == get_nonzero(dist_graph.edges[etype[1]].data['train_mask']))
-    assert len(ev_data.train_idxs) == 0
+        # test node train/val/test idxs
+        for ntype in tr_ntypes:
+            assert th.all(gdata.get_node_train_set(ntype)[ntype] == get_nonzero(dist_graph.nodes[ntype].data['train_mask']))
+        for ntype in va_ntypes:
+            assert th.all(gdata.get_node_val_set(ntype)[ntype] == get_nonzero(dist_graph.nodes[ntype].data['val_mask']))
+        for ntype in ts_ntypes:
+            assert th.all(gdata.get_node_test_set(ntype)[ntype] == get_nonzero(dist_graph.nodes[ntype].data['test_mask']))
+        for ntype in in_ntypes:
+            # with test mask
+            assert th.all(gdata.get_node_infer_set(ntype)[ntype] == get_nonzero(dist_graph.nodes[ntype].data['test_mask']))
+        # without test mask
+        assert th.all(gdata.get_node_infer_set('n0')['n0'] == th.arange(dist_graph.num_nodes('n0')))
 
-    assert len(tr_data.val_idxs) == len(va_etypes)
-    for etype in va_etypes:
-        assert th.all(tr_data.val_idxs[etype] == get_nonzero(dist_graph.edges[etype[1]].data['val_mask']))
-    assert len(tr_data1.val_idxs) == len(tr_etypes)
-    for etype in tr_etypes:
-        assert th.all(tr_data1.val_idxs[etype] == get_nonzero(dist_graph.edges[etype[1]].data['val_mask']))
-    assert len(ev_data.val_idxs) == 0
+        # check node label
+        labels = gdata.get_node_feats({'n1': th.tensor([0, 1])}, 'label')
+        assert len(labels.keys()) == 1
+        assert 'n1' in labels
+        try:
+            labels = gdata.get_node_feats({'n0': th.tensor([0, 1])}, 'label')
+            no_label = False
+        except:
+            no_label = True
+        assert no_label
 
-    assert len(tr_data.test_idxs) == len(ts_etypes)
-    for etype in ts_etypes:
-        assert th.all(tr_data.test_idxs[etype] == get_nonzero(dist_graph.edges[etype[1]].data['test_mask']))
-    assert len(tr_data1.test_idxs) == len(tr_etypes)
-    for etype in tr_etypes:
-        assert th.all(tr_data1.test_idxs[etype] == get_nonzero(dist_graph.edges[etype[1]].data['test_mask']))
-    assert len(ev_data.test_idxs) == len(va_etypes)
-    assert len(ev_data.infer_idxs) == len(ev_data.test_idxs)
-    for etype in va_etypes:
-        assert th.all(ev_data.test_idxs[etype] == get_nonzero(dist_graph.edges[etype[1]].data['test_mask']))
-        assert th.all(ev_data.infer_idxs[etype] == get_nonzero(dist_graph.edges[etype[1]].data['test_mask']))
+        tr_etypes = [('n0', 'r1', 'n1'), ('n0', 'r0', 'n1')]
+        va_etypes = [('n0', 'r1', 'n1'), ('n0', 'r0', 'n1')]
+        ts_etypes = [('n0', 'r1', 'n1'), ('n0', 'r0', 'n1')]
+        if_etypes = [('n0', 'r1', 'n1'), ('n0', 'r0', 'n1')]
+        # test edge train/val/test idxs
+        train_idxs = gdata.get_edge_train_set()
+        assert len(train_idxs) == 2
+        for etype in tr_etypes:
+            assert th.all(gdata.get_edge_train_set(etype)[etype] == get_nonzero(dist_graph.edges[etype[1]].data['train_mask']))
+            assert th.all(train_idxs[etype] == get_nonzero(dist_graph.edges[etype[1]].data['train_mask']))
 
-    # pass train etypes as None
-    assert len(tr_data2.train_idxs) == len(dist_graph.canonical_etypes)
-    for etype in tr_etypes:
-        assert th.all(tr_data2.train_idxs[etype] == get_nonzero(dist_graph.edges[etype[1]].data['train_mask']))
-    for etype in tr_etypes:
-        assert th.all(tr_data2.val_idxs[etype] == get_nonzero(dist_graph.edges[etype[1]].data['val_mask']))
-    for etype in tr_etypes:
-        assert th.all(tr_data2.test_idxs[etype] == get_nonzero(dist_graph.edges[etype[1]].data['test_mask']))
+        val_idxs = gdata.get_edge_val_set()
+        assert len(val_idxs) == 2
+        for etype in va_etypes:
+            assert th.all(gdata.get_edge_val_set(etype)[etype] == get_nonzero(dist_graph.edges[etype[1]].data['val_mask']))
+            assert th.all(val_idxs[etype] == get_nonzero(dist_graph.edges[etype[1]].data['val_mask']))
 
-    # train etypes does not cover all etypes.
-    assert len(tr_data3.train_idxs) == len(tr_single_etype)
-    for etype in tr_single_etype:
-        assert th.all(tr_data3.train_idxs[etype] == get_nonzero(dist_graph.edges[etype[1]].data['train_mask']))
-    for etype in tr_single_etype:
-        assert th.all(tr_data3.val_idxs[etype] == get_nonzero(dist_graph.edges[etype[1]].data['val_mask']))
-    for etype in tr_single_etype:
-        assert th.all(tr_data3.test_idxs[etype] == get_nonzero(dist_graph.edges[etype[1]].data['test_mask']))
+        test_idxs = gdata.get_edge_test_set()
+        for etype in ts_etypes:
+            assert th.all(gdata.get_edge_test_set(etype)[etype] == get_nonzero(dist_graph.edges[etype[1]].data['test_mask']))
+            assert th.all(test_idxs[etype] == get_nonzero(dist_graph.edges[etype[1]].data['test_mask']))
 
-    # pass eval etypes as None
-    assert len(ev_data2.test_idxs) == 2
-    assert len(ev_data2.infer_idxs) == 2
-    for etype in dist_graph.canonical_etypes:
-        assert th.all(ev_data2.test_idxs[etype] == get_nonzero(dist_graph.edges[etype[1]].data['test_mask']))
-        assert th.all(ev_data2.infer_idxs[etype] == get_nonzero(dist_graph.edges[etype[1]].data['test_mask']))
+        infer_idxs = gdata.get_edge_infer_set()
+        assert len(infer_idxs) == 2
+        for etype in if_etypes:
+            assert th.all(gdata.get_edge_infer_set(etype)[etype] == get_nonzero(dist_graph.edges[etype[1]].data['test_mask']))
+            assert th.all(infer_idxs[etype] == get_nonzero(dist_graph.edges[etype[1]].data['test_mask']))
 
-    labels = tr_data.get_labels({('n0', 'r1', 'n1'): [0, 1]})
-    assert len(labels.keys()) == 1
-    assert ('n0', 'r1', 'n1') in labels
-    try:
-        labels = tr_data.get_labels({('n0', 'r0', 'n1'): [0, 1]})
-        no_label = False
-    except:
-        no_label = True
-    assert no_label
-    try:
-        labels = tr_data1.get_labels({('n0', 'r1', 'n1'): [0, 1]})
-        no_label = False
-    except:
-        no_label = True
-    assert no_label
+        # check edge label
+        labels = gdata.get_edge_feats({('n0', 'r1', 'n1'): th.tensor([0, 1])}, 'label')
+        assert len(labels.keys()) == 1
+        assert ('n0', 'r1', 'n1') in labels
+        try:
+            labels = gdata.get_edge_feats({('n0', 'r0', 'n1'): th.tensor([0, 1])}, 'label')
+            no_label = False
+        except:
+            no_label = True
+        assert no_label
+
+        ##################################
+        # provide node feat and edge feat
+        gdata = GSgnnData(part_config=part_config, node_feat_field='feat', edge_feat_field='feat', lm_feat_ntypes=['n0'], lm_feat_etypes=[('n0', 'r0', 'n1')])
+
+        assert gdata.graph_name == 'dummy'
+        assert gdata.node_feat_field == 'feat'
+        assert gdata.edge_feat_field == 'feat'
+        assert gdata.has_node_feats('n0') is True
+        assert gdata.has_node_feats(('n0', 'r0', 'n1')) is True
+        assert gdata.has_node_feats('n1') is True
+        assert gdata.has_node_feats(('n0', 'r1', 'n1')) is True
+        assert gdata.has_node_lm_feats('n0') is True
+        assert gdata.has_edge_lm_feats(('n0', 'r0', 'n1')) is True
+        assert gdata.has_node_lm_feats('n1') is False
+        assert gdata.has_edge_lm_feats(('n0', 'r1', 'n1')) is False
+
+        feat = gdata.get_node_feats({'n0': th.tensor([0, 1])}, 'feat')
+        assert th.all(feat['n0'] == dist_graph.nodes['n0'].data['feat'][th.tensor([0, 1])])
+        feat = gdata.get_node_feats({'n0': th.tensor([0, 1])}, {'n0':['feat', 'feat1']})
+        assert th.all(feat['n0'] == \
+                      th.cat([dist_graph.nodes['n0'].data['feat'][th.tensor([0, 1])],
+                             dist_graph.nodes['n0'].data['feat1'][th.tensor([0, 1])]], dim=1))
+        try:
+            feat = gdata.get_node_feats({'n0': th.tensor([0, 1])}, "feat2")
+            no_feat = False
+        except:
+            no_feat = True
+        assert no_feat
+
+        feat = gdata.get_node_feats({'n0': th.tensor([0, 1]),
+                                     'n1': th.tensor([0, 1])},
+                                     {'n0':['feat', 'feat1'],
+                                      'n1':['feat1']})
+        assert len(feat) == 2
+        assert th.all(feat['n0'] == \
+            th.cat([dist_graph.nodes['n0'].data['feat'][th.tensor([0, 1])],
+                   dist_graph.nodes['n0'].data['feat1'][th.tensor([0, 1])]], dim=1))
+        assert th.all(feat['n1'] == dist_graph.nodes['n1'].data['feat1'][th.tensor([0, 1])])
+
+        feat = gdata.get_edge_feats({('n0', 'r0', 'n1'): th.tensor([0, 1])}, 'feat')
+        assert th.all(feat[('n0', 'r0', 'n1')] == dist_graph.edges[('n0', 'r0', 'n1')].data['feat'][th.tensor([0, 1])])
+        feat = gdata.get_edge_feats({('n0', 'r0', 'n1'): th.tensor([0, 1])}, {('n0', 'r0', 'n1'): ['feat']})
+        assert th.all(feat[('n0', 'r0', 'n1')] == dist_graph.edges[('n0', 'r0', 'n1')].data['feat'][th.tensor([0, 1])])
+        try:
+            feat = gdata.get_edge_feats({('n0', 'r0', 'n1'): th.tensor([0, 1])}, "fea2")
+            no_feat = False
+        except:
+            no_feat = True
+        assert no_feat
+        feat = gdata.get_edge_feats({('n0', 'r0', 'n1'): th.tensor([0, 1]),
+                                     ('n0', 'r1', 'n1'): th.tensor([0, 1])},
+                                     'feat')
+        assert len(feat) == 2
+        assert th.all(feat[('n0', 'r0', 'n1')] == dist_graph.edges[('n0', 'r0', 'n1')].data['feat'][th.tensor([0, 1])])
+        assert th.all(feat[('n0', 'r1', 'n1')] == dist_graph.edges[('n0', 'r1', 'n1')].data['feat'][th.tensor([0, 1])])
+        try:
+            feat = gdata.get_edge_feats({('n0', 'r0', 'n1'): th.tensor([0, 1]),
+                                         ('n0', 'r1', 'n1'): th.tensor([0, 1])},
+                                        {('n0', 'r0', 'n1'):'feat',
+                                         ('n0', 'r1', 'n1'):'feat1'})
+            no_feat = False
+        except:
+            no_feat = True
+        assert no_feat
+
+        ########################
+        # Test internal functions
+        # test _check_ntypes
+        ntypes = None
+        try:
+            ntypes = gdata._check_ntypes(ntypes)
+            err_check = False
+        except:
+            err_check = True
+        assert err_check
+        ntypes = 'n0'
+        ntypes = gdata._check_ntypes(ntypes)
+        assert len(ntypes) == 1
+        assert ntypes[0] == 'n0'
+        ntypes = ['n0', 'n1']
+        ntypes = gdata._check_ntypes(ntypes)
+        assert len(ntypes) == 2
+        assert ntypes[0] == 'n0'
+        assert ntypes[1] == 'n1'
+        ntypes = {'n1':0}
+        try:
+            ntypes = gdata._check_ntypes(ntypes)
+            err_check = False
+        except:
+            err_check = True
+        assert err_check
+
+        # test _check_node_mask
+        ntypes = 'n0'
+        masks = gdata._check_node_mask(ntypes, 'train_m')
+        assert len(masks) == 1
+        assert masks[0] == 'train_m'
+        ntypes = ['n0', 'n1']
+        masks = gdata._check_node_mask(ntypes, 'train_m')
+        assert len(masks) == 2
+        assert masks[0] == 'train_m'
+        assert masks[1] == 'train_m'
+        ntypes = ['n0', 'n1']
+        masks = gdata._check_node_mask(ntypes, ['train_m0', 'train_m1'])
+        assert len(masks) == 2
+        assert masks[0] == 'train_m0'
+        assert masks[1] == 'train_m1'
+        ntypes = ['n0', 'n1']
+        try:
+            masks = gdata._check_node_mask(ntypes, ['train_m0'])
+            err_mask = False
+        except:
+            err_mask = True
+        assert err_mask
+
+        # test _check_etypes
+        etypes = None
+        try:
+            etypes = gdata._check_etypes(etypes)
+            err_check = False
+        except:
+            err_check = True
+        assert err_check
+        etypes = ('n0', 'r0', 'n1')
+        etypes = gdata._check_etypes(etypes)
+        assert len(etypes) == 1
+        assert etypes[0] == ('n0', 'r0', 'n1')
+        etypes = [('n0', 'r0', 'n1'), ('n0', 'r0', 'n2')]
+        etypes = gdata._check_etypes(etypes)
+        assert len(etypes) == 2
+        assert etypes[0] == ('n0', 'r0', 'n1')
+        assert etypes[1] == ('n0', 'r0', 'n2')
+        etypes = {('n0', 'r0', 'n2'):0}
+        try:
+            etypes = gdata._check_etypes(etypes)
+            err_check = False
+        except:
+            err_check = True
+        assert err_check
+
+        # test _check_edge_mask
+        etypes = ('n0', 'r0', 'n1')
+        masks = gdata._check_edge_mask(etypes, 'train_m')
+        assert len(masks) == 1
+        assert masks[0] == 'train_m'
+        etypes = [('n0', 'r0', 'n1'), ('n0', 'r0', 'n2')]
+        masks = gdata._check_edge_mask(etypes, 'train_m')
+        assert len(masks) == 2
+        assert masks[0] == 'train_m'
+        assert masks[1] == 'train_m'
+        etypes = [('n0', 'r0', 'n1'), ('n0', 'r0', 'n2')]
+        masks = gdata._check_edge_mask(etypes, ['train_m0', 'train_m1'])
+        assert len(masks) == 2
+        assert masks[0] == 'train_m0'
+        assert masks[1] == 'train_m1'
+        etypes = [('n0', 'r0', 'n1'), ('n0', 'r0', 'n2')]
+        try:
+            masks = gdata._check_edge_mask(etypes, ['train_m0'])
+            err_mask = False
+        except:
+            err_mask = True
+        assert err_mask
+
+        # test _exclude_reverse_etype
+        etypes = [('n0', 'r0', 'n1'), ('n0', 'r0', 'n2'), ('n1', 'r2', 'n0'), ('n2', 'r3', 'n0')]
+        new_etypes = gdata._exclude_reverse_etype(etypes)
+        assert len(new_etypes) == 4
+        assert set(etypes) == set(new_etypes)
+
+        new_etypes = gdata._exclude_reverse_etype(etypes, reverse_edge_types_map={('n0', 'r0', 'n2'): ('n2', 'r3', 'n0')})
+        assert len(new_etypes) == 3
+        assert set(etypes[:3]) == set(new_etypes)
+
+        new_etypes = gdata._exclude_reverse_etype(etypes, reverse_edge_types_map={('n2', 'r3', 'n0'): ('n0', 'r0', 'n2'),
+            ('n1', 'r2', 'n0'):('n0', 'r0', 'n1')})
+        assert len(new_etypes) == 2
+        assert set(etypes[2:]) == set(new_etypes)
 
     # after test pass, destroy all process group
     th.distributed.destroy_process_group()
 
-def test_GSgnnNodeData():
+def test_GSgnnData2():
+    # Create dist graph with reverse edges
     # initialize the torch distributed environment
     th.distributed.init_process_group(backend='gloo',
                                       init_method='tcp://127.0.0.1:23456',
                                       rank=0,
                                       world_size=1)
-    tr_ntypes = ["n1"]
-    va_ntypes = ["n1"]
-    ts_ntypes = ["n1"]
 
     with tempfile.TemporaryDirectory() as tmpdirname:
         # get the test dummy distributed graph
         dist_graph, part_config = generate_dummy_dist_graph(graph_name='dummy',
-                                                            dirname=tmpdirname)
-        tr_data = GSgnnNodeTrainData(graph_name='dummy', part_config=part_config,
-                                     train_ntypes=tr_ntypes, eval_ntypes=va_ntypes,
-                                     label_field='label')
-        tr_data1 = GSgnnNodeTrainData(graph_name='dummy', part_config=part_config,
-                                      train_ntypes=tr_ntypes)
-        ev_data = GSgnnNodeInferData(graph_name='dummy', part_config=part_config,
-                                     eval_ntypes=va_ntypes)
+                                                            dirname=tmpdirname, add_reverse=True)
+        # there will be three etypes:
+        # ('n0', 'r1', 'n1'), ('n0', 'r0', 'n1'), ("n1", "r2", "n0")
+        gdata = GSgnnData(part_config=part_config)
 
-    # successful initialization with default setting
-    assert tr_data.train_ntypes == tr_ntypes
-    assert tr_data.eval_ntypes == va_ntypes
-    assert tr_data1.train_ntypes == tr_ntypes
-    assert tr_data1.eval_ntypes == tr_ntypes
-    assert ev_data.eval_ntypes == va_ntypes
+        # There are reverse edges
+        tr_etypes = [('n0', 'r1', 'n1'), ('n0', 'r0', 'n1')]
+        va_etypes = [('n0', 'r1', 'n1'), ('n0', 'r0', 'n1')]
+        ts_etypes = [('n0', 'r1', 'n1'), ('n0', 'r0', 'n1')]
+        if_etypes = [('n0', 'r1', 'n1'), ('n0', 'r0', 'n1')]
+        extra_etype = ("n1", "r2", "n0")
+        # test edge train/val/test idxs
+        train_idxs = gdata.get_edge_train_set()
+        assert len(train_idxs) == 3
+        for etype in tr_etypes:
+            assert th.all(gdata.get_edge_train_set(etype)[etype] == get_nonzero(dist_graph.edges[etype[1]].data['train_mask']))
+            assert th.all(train_idxs[etype] == get_nonzero(dist_graph.edges[etype[1]].data['train_mask']))
+        # extra_etype does not have train_mask
+        assert th.all(gdata.get_edge_train_set(extra_etype)[extra_etype] == \
+            th.arange(dist_graph.num_edges(extra_etype)))
+        assert th.all(train_idxs[extra_etype] == \
+            th.arange(dist_graph.num_edges(extra_etype)))
 
-    # sucessfully split train/val/test idxs
-    assert len(tr_data.train_idxs) == len(tr_ntypes)
-    for ntype in tr_ntypes:
-        assert th.all(tr_data.train_idxs[ntype] == get_nonzero(dist_graph.nodes[ntype].data['train_mask']))
-    assert len(ev_data.train_idxs) == 0
+        # extra_etype does not have val_mask
+        # will skip it.
+        val_idxs = gdata.get_edge_val_set()
+        assert len(val_idxs) == 2
+        for etype in va_etypes:
+            assert th.all(gdata.get_edge_val_set(etype)[etype] == get_nonzero(dist_graph.edges[etype[1]].data['val_mask']))
+            assert th.all(val_idxs[etype] == get_nonzero(dist_graph.edges[etype[1]].data['val_mask']))
 
-    assert len(tr_data.val_idxs) == len(va_ntypes)
-    for ntype in va_ntypes:
-        assert th.all(tr_data.val_idxs[ntype] == get_nonzero(dist_graph.nodes[ntype].data['val_mask']))
-    assert len(tr_data1.val_idxs) == len(tr_ntypes)
-    for ntype in tr_ntypes:
-        assert th.all(tr_data1.val_idxs[ntype] == get_nonzero(dist_graph.nodes[ntype].data['val_mask']))
-    assert len(ev_data.val_idxs) == 0
+        # extra_etype does not have test_mask
+        # will skip it.
+        test_idxs = gdata.get_edge_test_set()
+        for etype in ts_etypes:
+            assert th.all(gdata.get_edge_test_set(etype)[etype] == get_nonzero(dist_graph.edges[etype[1]].data['test_mask']))
+            assert th.all(test_idxs[etype] == get_nonzero(dist_graph.edges[etype[1]].data['test_mask']))
 
-    assert len(tr_data.test_idxs) == len(ts_ntypes)
-    for ntype in ts_ntypes:
-        assert th.all(tr_data.test_idxs[ntype] == get_nonzero(dist_graph.nodes[ntype].data['test_mask']))
-    assert len(tr_data1.test_idxs) == len(tr_ntypes)
-    for ntype in tr_ntypes:
-        assert th.all(tr_data1.test_idxs[ntype] == get_nonzero(dist_graph.nodes[ntype].data['test_mask']))
-    assert len(ev_data.test_idxs) == len(va_ntypes)
-    assert len(ev_data.infer_idxs) == len(va_ntypes)
-    for ntype in va_ntypes:
-        assert th.all(ev_data.test_idxs[ntype] == get_nonzero(dist_graph.nodes[ntype].data['test_mask']))
-        assert th.all(ev_data.infer_idxs[ntype] == get_nonzero(dist_graph.nodes[ntype].data['test_mask']))
+        infer_idxs = gdata.get_edge_infer_set()
+        assert len(infer_idxs) == 3
+        for etype in if_etypes:
+            assert th.all(gdata.get_edge_infer_set(etype)[etype] == get_nonzero(dist_graph.edges[etype[1]].data['test_mask']))
+            assert th.all(infer_idxs[etype] == get_nonzero(dist_graph.edges[etype[1]].data['test_mask']))
+        # extra_etype does not have test_mask
+        assert th.all(gdata.get_edge_infer_set(extra_etype)[extra_etype] == \
+            th.arange(dist_graph.num_edges(extra_etype)))
+        assert th.all(infer_idxs[extra_etype] ==
+            th.arange(dist_graph.num_edges(extra_etype)))
 
-    labels = tr_data.get_labels({'n1': [0, 1]})
-    assert len(labels.keys()) == 1
-    assert 'n1' in labels
-    try:
-        labels = tr_data.get_labels({'n0': [0, 1]})
-        no_label = False
-    except:
-        no_label = True
-    assert no_label
-    try:
-        labels = tr_data1.get_labels({'n1': [0, 1]})
-        no_label = False
-    except:
-        no_label = True
-    assert no_label
+        # with reverse edges
+        train_idxs = gdata.get_edge_train_set(reverse_edge_types_map={
+            ('n0', 'r1', 'n1'): ("n1", "r2", "n0")
+        })
+        assert len(train_idxs) == 2
+        for etype in tr_etypes:
+            assert th.all(train_idxs[etype] == get_nonzero(dist_graph.edges[etype[1]].data['train_mask']))
+        infer_idxs = gdata.get_edge_infer_set(reverse_edge_types_map={
+            ('n0', 'r1', 'n1'): ("n1", "r2", "n0")
+        })
+        assert len(infer_idxs) == 2
+        for etype in if_etypes:
+            assert th.all(infer_idxs[etype] == get_nonzero(dist_graph.edges[etype[1]].data['test_mask']))
 
-    # test get feature size when node_feat_field is None
-    feat_size = tr_data.get_node_feat_size()
-    assert feat_size['n0'] == 0
-    assert feat_size['n1'] == 0
-
-    # test get feature size when node_feat_field is given in construction
-    with tempfile.TemporaryDirectory() as tmpdirname:
-        # get the test dummy distributed graph
-        dist_graph, part_config = generate_dummy_dist_graph(graph_name='dummy',
-                                                            dirname=tmpdirname)
-        data = GSgnnNodeTrainData(graph_name='dummy', part_config=part_config,
-                                  node_feat_field={'n0': ['feat','feat1'], 'n1': ['feat1']},
-                                  train_ntypes=tr_ntypes, eval_ntypes=va_ntypes,
-                                  label_field='label')
-    feat_size = data.get_node_feat_size()
-    assert feat_size['n0'] == 6
-    assert feat_size['n1'] == 4
+        train_idxs = gdata.get_edge_train_set(reverse_edge_types_map={
+            ('n0', 'r1', 'n1'): ("n1", "r2", "n0"),
+            ('n0', 'r0', 'n1'): ('n0', 'r0', 'n1') # fake reverse etype
+        })
+        assert len(train_idxs) == 1
+        val_idxs = gdata.get_edge_val_set(reverse_edge_types_map={
+            ('n0', 'r1', 'n1'): ("n1", "r2", "n0"),
+            ('n0', 'r0', 'n1'): ('n0', 'r0', 'n1') # fake reverse etype
+        })
+        assert len(val_idxs) == 1
+        test_idxs = gdata.get_edge_test_set(reverse_edge_types_map={
+            ('n0', 'r1', 'n1'): ("n1", "r2", "n0"),
+            ('n0', 'r0', 'n1'): ('n0', 'r0', 'n1') # fake reverse etype
+        })
+        assert len(test_idxs) == 1
+        infer_idxs = gdata.get_edge_infer_set(reverse_edge_types_map={
+            ('n0', 'r1', 'n1'): ("n1", "r2", "n0"),
+            ('n0', 'r0', 'n1'): ('n0', 'r0', 'n1') # fake reverse etype
+        })
+        assert len(infer_idxs) == 1
 
     # after test pass, destroy all process group
     th.distributed.destroy_process_group()
@@ -360,14 +457,13 @@ def test_GSgnnAllEtypeLinkPredictionDataLoader(batch_size):
     with tempfile.TemporaryDirectory() as tmpdirname:
         # get the test dummy distributed graph
         _, part_config = generate_dummy_dist_graph(graph_name='dummy', dirname=tmpdirname)
-        lp_data = GSgnnEdgeTrainData(graph_name='dummy', part_config=part_config,
-                                     train_etypes=tr_etypes, label_field='label')
+        lp_data = GSgnnData(part_config=part_config)
 
     # successful initialization with default setting
-    assert lp_data.train_etypes == tr_etypes
+    train_idxs = lp_data.get_edge_train_set(tr_etypes)
     dataloader = GSgnnAllEtypeLinkPredictionDataLoader(
         lp_data,
-        target_idx=lp_data.train_idxs,
+        target_idx=train_idxs,
         fanout=[],
         batch_size=batch_size,
         num_negative_edges=4,
@@ -396,13 +492,15 @@ def test_node_dataloader():
     with tempfile.TemporaryDirectory() as tmpdirname:
         # get the test dummy distributed graph
         _, part_config = generate_dummy_dist_graph(graph_name='dummy', dirname=tmpdirname)
-        np_data = GSgnnNodeTrainData(graph_name='dummy', part_config=part_config,
-                                     train_ntypes=['n1'], label_field='label')
+        np_data = GSgnnData(part_config=part_config)
 
     setup_device(0)
     # Without shuffling, the seed nodes should have the same order as the target nodes.
     target_idx = {'n1': th.arange(np_data.g.number_of_nodes('n1'))}
     dataloader = GSgnnNodeDataLoader(np_data, target_idx, [10], 10,
+                                     label_field='label',
+                                     node_feats='feat',
+                                     edge_feats='feat',
                                      train_task=False)
     all_nodes = []
     for input_nodes, seeds, blocks in dataloader:
@@ -410,10 +508,13 @@ def test_node_dataloader():
         all_nodes.append(seeds['n1'])
     all_nodes = th.cat(all_nodes)
     assert_equal(all_nodes.numpy(), target_idx['n1'])
+    assert dataloader.node_feat_fields == 'feat'
+    assert dataloader.edge_feat_fields == 'feat'
 
     # With data shuffling, the seed nodes should have different orders
     # whenever the data loader is called.
     dataloader = GSgnnNodeDataLoader(np_data, target_idx, [10], 10,
+                                     label_field='label',
                                      train_task=True)
     all_nodes1 = []
     for input_nodes, seeds, blocks in dataloader:
@@ -421,13 +522,27 @@ def test_node_dataloader():
         all_nodes1.append(seeds['n1'])
     all_nodes1 = th.cat(all_nodes1)
     dataloader = GSgnnNodeDataLoader(np_data, target_idx, [10], 10,
+                                     label_field='label',
                                      train_task=True)
+    assert dataloader.node_feat_fields == None
+    assert dataloader.edge_feat_fields == None
+
     all_nodes2 = []
     for input_nodes, seeds, blocks in dataloader:
         assert 'n1' in seeds
         all_nodes2.append(seeds['n1'])
     all_nodes2 = th.cat(all_nodes2)
     assert not np.all(all_nodes1.numpy() == all_nodes2.numpy())
+
+    # fail to create GSgnnNodeDataLoader when label field is set to None.
+    try:
+        dataloader = GSgnnNodeDataLoader(np_data, target_idx, [10], 10,
+                                         label_field=None,
+                                         train_task=True)
+        init_loader_fail = False
+    except:
+        init_loader_fail = True
+    assert init_loader_fail
 
     # after test pass, destroy all process group
     th.distributed.destroy_process_group()
@@ -443,23 +558,26 @@ def test_node_dataloader_reconstruct():
         # get the test dummy distributed graph
         _, part_config = generate_dummy_dist_graph_reconstruct(graph_name='dummy',
                                                                dirname=tmpdirname)
-        np_data = GSgnnNodeTrainData(graph_name='dummy', part_config=part_config,
-                                     train_ntypes=['n0'], label_field='label',
-                                     node_feat_field={'n0': ['feat'], 'n4': ['feat']})
+        np_data = GSgnnData(part_config=part_config,
+                            node_feat_field={'n0': ['feat'], 'n4': ['feat']})
     setup_device(0)
     feat_sizes = gs.get_node_feat_size(np_data.g, {'n0': 'feat', 'n4': 'feat'})
     target_idx = {'n0': th.arange(np_data.g.number_of_nodes('n0'))}
     # Test the case that we cannot construct all node features.
     try:
-        dataloader = GSgnnNodeDataLoader(np_data, target_idx, [10], 10,
-                                         train_task=False, construct_feat_ntype=['n1', 'n2'])
+        dataloader = GSgnnNodeDataLoader(np_data, target_idx, [10], 10, label_field='label',
+                                         train_task=False,
+                                         node_feats={'n0': ['feat'], 'n4': ['feat']},
+                                         construct_feat_ntype=['n1', 'n2'])
         assert False
     except:
         pass
 
     # Test the case that we construct node features for one-layer GNN.
-    dataloader = GSgnnNodeDataLoader(np_data, target_idx, [10], 10,
-                                     train_task=False, construct_feat_ntype=['n2'])
+    dataloader = GSgnnNodeDataLoader(np_data, target_idx, [10], 10, label_field='label',
+                                     train_task=False,
+                                     node_feats={'n0': ['feat'], 'n4': ['feat']},
+                                     construct_feat_ntype=['n2'])
     all_nodes = []
     rel_names_for_reconstruct = gs.gsf.get_rel_names_for_reconstruct(np_data.g,
                                                                      ['n1', 'n2'], feat_sizes)
@@ -482,8 +600,10 @@ def test_node_dataloader_reconstruct():
     assert_equal(all_nodes.numpy(), target_idx['n0'])
 
     # Test the case that we construct node features for two-layer GNN.
-    dataloader = GSgnnNodeDataLoader(np_data, target_idx, [10, 10], 10,
-                                     train_task=False, construct_feat_ntype=['n3'])
+    dataloader = GSgnnNodeDataLoader(np_data, target_idx, [10, 10], 10, label_field='label',
+                                     train_task=False,
+                                     node_feats={'n0': ['feat'], 'n4': ['feat']},
+                                     construct_feat_ntype=['n3'])
     all_nodes = []
     rel_names_for_reconstruct = gs.gsf.get_rel_names_for_reconstruct(np_data.g,
                                                                      ['n3'], feat_sizes)
@@ -518,17 +638,17 @@ def test_edge_dataloader():
     with tempfile.TemporaryDirectory() as tmpdirname:
         # get the test dummy distributed graph
         _, part_config = generate_dummy_dist_graph(graph_name='dummy', dirname=tmpdirname)
-        ep_data = GSgnnEdgeTrainData(graph_name='dummy', part_config=part_config,
-                                     train_etypes=[('n0', 'r1', 'n1')], label_field='label')
+        ep_data = GSgnnData(part_config=part_config)
 
     ################### Test train_task #######################
 
     # Without shuffling, the seed nodes should have the same order as the target nodes.
     target_idx = {('n0', 'r1', 'n1'): th.arange(ep_data.g.number_of_edges('r1'))}
     dataloader = GSgnnEdgeDataLoader(ep_data, target_idx, [10], 10,
+                                     label_field='label',
                                      train_task=False, remove_target_edge_type=False)
     all_edges = []
-    for input_nodes, batch_graph, blocks in dataloader:
+    for _, batch_graph, blocks in dataloader:
         assert len(batch_graph.etypes) == 1
         assert 'r1' in batch_graph.etypes
         all_edges.append(batch_graph.edata[dgl.EID])
@@ -538,15 +658,16 @@ def test_edge_dataloader():
     # With data shuffling, the seed edges should have different orders
     # whenever the data loader is called.
     dataloader = GSgnnEdgeDataLoader(ep_data, target_idx, [10], 10,
+                                     label_field='label',
                                      train_task=True, remove_target_edge_type=False)
     all_edges1 = []
-    for input_nodes, batch_graph, blocks in dataloader:
+    for _, batch_graph, blocks in dataloader:
         assert len(batch_graph.etypes) == 1
         assert 'r1' in batch_graph.etypes
         all_edges1.append(batch_graph.edata[dgl.EID])
     all_edges1 = th.cat(all_edges1)
     all_edges2 = []
-    for input_nodes, batch_graph, blocks in dataloader:
+    for _, batch_graph, blocks in dataloader:
         assert len(batch_graph.etypes) == 1
         assert 'r1' in batch_graph.etypes
         all_edges2.append(batch_graph.edata[dgl.EID])
@@ -555,6 +676,7 @@ def test_edge_dataloader():
 
     ################### Test removing target edges #######################
     dataloader = GSgnnEdgeDataLoader(ep_data, target_idx, [10], 10,
+                                     label_field='label',
                                      train_task=False, remove_target_edge_type=True,
                                      reverse_edge_types_map={('n0', 'r1', 'n1'): ('n0', 'r0', 'n1')})
     all_edges = []
@@ -575,8 +697,7 @@ def test_lp_dataloader():
     with tempfile.TemporaryDirectory() as tmpdirname:
         # get the test dummy distributed graph
         _, part_config = generate_dummy_dist_graph(graph_name='dummy', dirname=tmpdirname)
-        ep_data = GSgnnEdgeTrainData(graph_name='dummy', part_config=part_config,
-                                     train_etypes=[('n0', 'r1', 'n1')])
+        ep_data = GSgnnData(part_config=part_config)
 
     ################### Test train_task #######################
 
@@ -625,17 +746,16 @@ def test_GSgnnLinkPredictionTestDataLoader(batch_size, num_negative_edges):
     with tempfile.TemporaryDirectory() as tmpdirname:
         # get the test dummy distributed graph
         _, part_config = generate_dummy_dist_graph(graph_name='dummy', dirname=tmpdirname)
-        lp_data = GSgnnEdgeTrainData(graph_name='dummy', part_config=part_config,
-                                     train_etypes=test_etypes, label_field='label')
+        lp_data = GSgnnData(part_config=part_config)
         g = lp_data.g
-
+        train_idxs = lp_data.get_edge_train_set(test_etypes)
         dataloader = GSgnnLinkPredictionTestDataLoader(
             lp_data,
-            target_idx=lp_data.train_idxs, # use train edges as val or test edges
+            target_idx=train_idxs, # use train edges as val or test edges
             batch_size=batch_size,
             num_negative_edges=num_negative_edges)
 
-        total_edges = {etype: len(lp_data.train_idxs[etype]) for etype in test_etypes}
+        total_edges = {etype: len(train_idxs[etype]) for etype in test_etypes}
         num_pos_edges = {etype: 0 for etype in test_etypes}
         for pos_neg_tuple, sample_type in dataloader:
             assert sample_type == BUILTIN_LP_UNIFORM_NEG_SAMPLER
@@ -648,10 +768,10 @@ def test_GSgnnLinkPredictionTestDataLoader(batch_size, num_negative_edges):
                 assert pos_src.shape[0] == batch_size \
                     if num_pos_edges[canonical_etype] + batch_size < total_edges[canonical_etype] \
                     else total_edges[canonical_etype] - num_pos_edges[canonical_etype]
-                eid = lp_data.train_idxs[canonical_etype][num_pos_edges[canonical_etype]: \
+                eid = train_idxs[canonical_etype][num_pos_edges[canonical_etype]: \
                     num_pos_edges[canonical_etype]+batch_size] \
                     if num_pos_edges[canonical_etype]+batch_size < total_edges[canonical_etype] \
-                    else lp_data.train_idxs[canonical_etype] \
+                    else train_idxs[canonical_etype] \
                         [num_pos_edges[canonical_etype]:]
                 src, dst = g.find_edges(eid, etype=canonical_etype)
 
@@ -671,7 +791,7 @@ def test_GSgnnLinkPredictionTestDataLoader(batch_size, num_negative_edges):
         fixed_test_size = 10
         dataloader = GSgnnLinkPredictionTestDataLoader(
             lp_data,
-            target_idx=lp_data.train_idxs, # use train edges as val or test edges
+            target_idx=train_idxs, # use train edges as val or test edges
             batch_size=batch_size,
             num_negative_edges=num_negative_edges,fixed_test_size=fixed_test_size)
         num_samples = 0
@@ -688,7 +808,7 @@ def test_GSgnnLinkPredictionTestDataLoader(batch_size, num_negative_edges):
 
         expected_samples = 0
         expected_pos_pairs = 0
-        for _, t_idx in lp_data.train_idxs.items():
+        for _, t_idx in train_idxs.items():
             expected_idx_len = fixed_test_size if fixed_test_size < len(t_idx) else len(t_idx)
             expected_samples += -(-expected_idx_len // batch_size)
             expected_pos_pairs += expected_idx_len
@@ -709,21 +829,21 @@ def test_GSgnnLinkPredictionPredefinedTestDataLoader(batch_size):
     with tempfile.TemporaryDirectory() as tmpdirname:
         # get the test dummy distributed graph
         _, part_config = generate_dummy_dist_graph(graph_name='dummy', dirname=tmpdirname)
-        lp_data = GSgnnEdgeInferData(graph_name='dummy', part_config=part_config,
-                                     eval_etypes=test_etypes)
+        lp_data = GSgnnData(part_config=part_config)
         g = lp_data.g
         g.edges[("n0", "r1", "n1")].data["neg"] = th.randint(g.num_nodes("n1"),
                                                              (g.num_edges(("n0", "r1", "n1")), 10))
         g.edges[("n0", "r0", "n1")].data["neg"] = th.randint(g.num_nodes("n1"),
                                                              (g.num_edges(("n0", "r0", "n1")), 10))
 
+        infer_idxs = lp_data.get_edge_infer_set(test_etypes)
         dataloader = GSgnnLinkPredictionPredefinedTestDataLoader(
             lp_data,
-            target_idx=lp_data.infer_idxs, # use train edges as val or test edges
+            target_idx=infer_idxs, # use train edges as val or test edges
             batch_size=batch_size,
             fixed_edge_dst_negative_field="neg")
 
-        total_edges = {etype: len(lp_data.infer_idxs[etype]) for etype in test_etypes}
+        total_edges = {etype: len(infer_idxs[etype]) for etype in test_etypes}
         num_pos_edges = {etype: 0 for etype in test_etypes}
         for pos_neg_tuple, sample_type in dataloader:
             assert sample_type == BUILTIN_LP_FIXED_NEG_SAMPLER
@@ -736,10 +856,10 @@ def test_GSgnnLinkPredictionPredefinedTestDataLoader(batch_size):
                 assert pos_src.shape[0] == batch_size \
                     if num_pos_edges[canonical_etype] + batch_size < total_edges[canonical_etype] \
                     else total_edges[canonical_etype] - num_pos_edges[canonical_etype]
-                eid = lp_data.infer_idxs[canonical_etype][num_pos_edges[canonical_etype]: \
+                eid = infer_idxs[canonical_etype][num_pos_edges[canonical_etype]: \
                     num_pos_edges[canonical_etype]+batch_size] \
                     if num_pos_edges[canonical_etype]+batch_size < total_edges[canonical_etype] \
-                    else lp_data.infer_idxs[canonical_etype] \
+                    else infer_idxs[canonical_etype] \
                         [num_pos_edges[canonical_etype]:]
                 src, dst = g.find_edges(eid, etype=canonical_etype)
                 assert_equal(pos_src.numpy(), src.numpy())
@@ -764,17 +884,16 @@ def test_GSgnnLinkPredictionJointTestDataLoader(batch_size, num_negative_edges):
     with tempfile.TemporaryDirectory() as tmpdirname:
         # get the test dummy distributed graph
         _, part_config = generate_dummy_dist_graph(graph_name='dummy', dirname=tmpdirname)
-        lp_data = GSgnnEdgeTrainData(graph_name='dummy', part_config=part_config,
-                                     train_etypes=test_etypes, label_field='label')
+        lp_data = GSgnnData(part_config=part_config)
         g = lp_data.g
-
+        train_idxs = lp_data.get_edge_train_set(test_etypes)
         dataloader = GSgnnLinkPredictionJointTestDataLoader(
             lp_data,
-            target_idx=lp_data.train_idxs, # use train edges as val or test edges
+            target_idx=train_idxs, # use train edges as val or test edges
             batch_size=batch_size,
             num_negative_edges=num_negative_edges)
 
-        total_edges = {etype: len(lp_data.train_idxs[etype]) for etype in test_etypes}
+        total_edges = {etype: len(train_idxs[etype]) for etype in test_etypes}
         num_pos_edges = {etype: 0 for etype in test_etypes}
         for pos_neg_tuple, sample_type in dataloader:
             assert sample_type == BUILTIN_LP_JOINT_NEG_SAMPLER
@@ -787,10 +906,10 @@ def test_GSgnnLinkPredictionJointTestDataLoader(batch_size, num_negative_edges):
                 assert pos_src.shape[0] == batch_size \
                     if num_pos_edges[canonical_etype] + batch_size < total_edges[canonical_etype] \
                     else total_edges[canonical_etype] - num_pos_edges[canonical_etype]
-                eid = lp_data.train_idxs[canonical_etype][num_pos_edges[canonical_etype]: \
+                eid = train_idxs[canonical_etype][num_pos_edges[canonical_etype]: \
                     num_pos_edges[canonical_etype]+batch_size] \
                     if num_pos_edges[canonical_etype]+batch_size < total_edges[canonical_etype] \
-                    else lp_data.train_idxs[canonical_etype] \
+                    else train_idxs[canonical_etype] \
                         [num_pos_edges[canonical_etype]:]
                 src, dst = g.find_edges(eid, etype=canonical_etype)
                 assert_equal(pos_src.numpy(), src.numpy())
@@ -816,8 +935,7 @@ def test_prepare_input():
     with tempfile.TemporaryDirectory() as tmpdirname:
         # get the test dummy distributed graph
         _, part_config = generate_dummy_dist_graph(graph_name='dummy', dirname=tmpdirname)
-        lp_data = GSgnnEdgeTrainData(graph_name='dummy', part_config=part_config,
-                                     train_etypes=test_etypes, label_field='label')
+        lp_data = GSgnnData(part_config=part_config)
         lp_data.g.nodes['n1'].data['feat2'] = \
             lp_data.g.nodes['n1'].data['feat'][th.arange(lp_data.g.num_nodes('n1'))] * 2
         lp_data.g.edges['r0'].data['feat2'] = \
@@ -946,8 +1064,7 @@ def test_np_dataloader_trim_data(dataloader):
     with tempfile.TemporaryDirectory() as tmpdirname:
         # get the test dummy distributed graph
         _, part_config = generate_dummy_dist_graph(graph_name='dummy', dirname=tmpdirname)
-        np_data = GSgnnNodeTrainData(graph_name='dummy', part_config=part_config,
-                                     train_ntypes=['n1'], label_field='label')
+        np_data = GSgnnData(part_config=part_config)
 
         target_idx = {'n1': th.arange(np_data.g.number_of_nodes('n1'))}
         @patch("graphstorm.dataloading.dataloading.trim_data")
@@ -958,13 +1075,13 @@ def test_np_dataloader_trim_data(dataloader):
             ]
 
             loader = dataloader(np_data, dict(target_idx),
-                                [10], 10,
+                                [10], 10, label_field='label',
                                 train_task=True)
             assert len(loader.dataloader.collator.nids) == 1
             assert len(loader.dataloader.collator.nids["n1"]) == np_data.g.number_of_nodes('n1') - 2
 
             loader = dataloader(np_data, dict(target_idx),
-                                [10], 10,
+                                [10], 10, label_field='label',
                                 train_task=False)
             assert len(loader.dataloader.collator.nids) == 1
             assert len(loader.dataloader.collator.nids["n1"]) == np_data.g.number_of_nodes('n1')
@@ -986,8 +1103,7 @@ def test_np_dataloader_trim_data_device(dataloader, backend):
     with tempfile.TemporaryDirectory() as tmpdirname:
         # get the test dummy distributed graph
         _, part_config = generate_dummy_dist_graph(graph_name='dummy', dirname=tmpdirname)
-        np_data = GSgnnNodeTrainData(graph_name='dummy', part_config=part_config,
-                                     train_ntypes=['n1'], label_field='label')
+        np_data = GSgnnData(part_config=part_config)
 
         target_idx = {'n1': th.arange(np_data.g.number_of_nodes('n1'))}
         @patch("graphstorm.dataloading.dataloading.trim_data")
@@ -997,8 +1113,10 @@ def test_np_dataloader_trim_data_device(dataloader, backend):
                 target_idx["n1"][:len(target_idx["n1"])-2],
             ]
 
-            dataloader(np_data, dict(target_idx), [10], 10, train_task=True)
-            dataloader(np_data, dict(target_idx), [10], 10, train_task=False)
+            dataloader(np_data, dict(target_idx), [10], 10,
+                       label_field='label', train_task=True)
+            dataloader(np_data, dict(target_idx), [10], 10,
+                       label_field='label', train_task=False)
 
             args, _ = mock_trim_data.call_args
             assert args[1] == th.device('cpu') if backend == 'gloo' else th.device(0)
@@ -1019,42 +1137,41 @@ def test_edge_dataloader_trim_data(dataloader):
     with tempfile.TemporaryDirectory() as tmpdirname:
         # get the test dummy distributed graph
         _, part_config = generate_dummy_dist_graph(graph_name='dummy', dirname=tmpdirname)
-        lp_data = GSgnnEdgeTrainData(graph_name='dummy', part_config=part_config,
-                                     train_etypes=test_etypes, label_field='label')
-
+        lp_data = GSgnnData(part_config=part_config)
+        train_idxs = lp_data.get_edge_train_set(test_etypes)
         @patch("graphstorm.dataloading.dataloading.trim_data")
         def check_dataloader_trim(mock_trim_data):
             mock_trim_data.side_effect = [
-                lp_data.train_idxs[("n0", "r1", "n1")][:len(lp_data.train_idxs[("n0", "r1", "n1")])-1],
-                lp_data.train_idxs[("n0", "r0", "n1")][:len(lp_data.train_idxs[("n0", "r0", "n1")])-1],
+                train_idxs[("n0", "r1", "n1")][:len(train_idxs[("n0", "r1", "n1")])-1],
+                train_idxs[("n0", "r0", "n1")][:len(train_idxs[("n0", "r0", "n1")])-1],
 
-                lp_data.train_idxs[("n0", "r1", "n1")][:len(lp_data.train_idxs[("n0", "r1", "n1")])-1],
-                lp_data.train_idxs[("n0", "r0", "n1")][:len(lp_data.train_idxs[("n0", "r0", "n1")])-1],
+                train_idxs[("n0", "r1", "n1")][:len(train_idxs[("n0", "r1", "n1")])-1],
+                train_idxs[("n0", "r0", "n1")][:len(train_idxs[("n0", "r0", "n1")])-1],
             ]
 
             loader = dataloader(
                 lp_data,
                 fanout=[],
-                target_idx=dict(lp_data.train_idxs), # test train_idxs
+                target_idx=dict(train_idxs), # test train_idxs
                 batch_size=16,
                 num_negative_edges=4)
 
-            assert len(loader.dataloader.collator.eids) == len(lp_data.train_idxs)
-            for etype in lp_data.train_idxs.keys():
-                assert len(loader.dataloader.collator.eids[etype]) == len(lp_data.train_idxs[etype]) - 1
+            assert len(loader.dataloader.collator.eids) == len(train_idxs)
+            for etype in train_idxs.keys():
+                assert len(loader.dataloader.collator.eids[etype]) == len(train_idxs[etype]) - 1
 
             # test task, trim_data should not be called.
             loader = dataloader(
                 lp_data,
-                target_idx=dict(lp_data.train_idxs), # use train edges as val or test edges
+                target_idx=dict(train_idxs), # use train edges as val or test edges
                 fanout=[],
                 batch_size=16,
                 num_negative_edges=4,
                 train_task=False)
 
-            assert len(loader.dataloader.collator.eids) == len(lp_data.train_idxs)
-            for etype in lp_data.train_idxs.keys():
-                assert len(loader.dataloader.collator.eids[etype]) == len(lp_data.train_idxs[etype])
+            assert len(loader.dataloader.collator.eids) == len(train_idxs)
+            for etype in train_idxs.keys():
+                assert len(loader.dataloader.collator.eids[etype]) == len(train_idxs[etype])
 
         check_dataloader_trim()
 
@@ -1077,32 +1194,33 @@ def test_edge_dataloader_trim_data_device(dataloader, backend):
     with tempfile.TemporaryDirectory() as tmpdirname:
         # get the test dummy distributed graph
         _, part_config = generate_dummy_dist_graph(graph_name='dummy', dirname=tmpdirname)
-        edge_data = GSgnnEdgeTrainData(graph_name='dummy', part_config=part_config,
-                                     train_etypes=test_etypes, label_field='label')
+        edge_data = GSgnnData(part_config=part_config)
+        train_idxs = edge_data.get_edge_train_set([("n0", "r1", "n1"), ("n0", "r0", "n1")])
 
         @patch("graphstorm.dataloading.dataloading.trim_data")
         def check_dataloader_trim(mock_trim_data):
             mock_trim_data.side_effect = [
-                edge_data.train_idxs[("n0", "r1", "n1")][:len(edge_data.train_idxs[("n0", "r1", "n1")])-1],
-                edge_data.train_idxs[("n0", "r0", "n1")][:len(edge_data.train_idxs[("n0", "r0", "n1")])-1],
+                train_idxs[("n0", "r1", "n1")][:len(train_idxs[("n0", "r1", "n1")])-1],
+                train_idxs[("n0", "r0", "n1")][:len(train_idxs[("n0", "r0", "n1")])-1],
 
-                edge_data.train_idxs[("n0", "r1", "n1")][:len(edge_data.train_idxs[("n0", "r1", "n1")])-1],
-                edge_data.train_idxs[("n0", "r0", "n1")][:len(edge_data.train_idxs[("n0", "r0", "n1")])-1],
+                train_idxs[("n0", "r1", "n1")][:len(train_idxs[("n0", "r1", "n1")])-1],
+                train_idxs[("n0", "r0", "n1")][:len(train_idxs[("n0", "r0", "n1")])-1],
             ]
 
             if issubclass(dataloader, GSgnnLinkPredictionDataLoaderBase):
                 dataloader(
                     edge_data,
                     fanout=[],
-                    target_idx=dict(edge_data.train_idxs), # test train_idxs
+                    target_idx=dict(train_idxs), # test train_idxs
                     num_negative_edges=4,
                     batch_size=16)
             else:
                 dataloader(
                     edge_data,
                     fanout=[],
-                    target_idx=dict(edge_data.train_idxs), # test train_idxs
+                    target_idx=dict(train_idxs), # test train_idxs
                     batch_size=16,
+                    label_field='label',
                     remove_target_edge_type=False)
 
             args, _ = mock_trim_data.call_args
@@ -1144,6 +1262,7 @@ def test_distill_sampler_get_file(num_files):
     with tempfile.TemporaryDirectory() as tmpdirname:
         create_distill_data(tmpdirname, num_files)
         file_list = os.listdir(tmpdirname)
+        file_list.sort()
         tracker = {
             "global_start": [],
             "global_end": [],
@@ -1372,37 +1491,42 @@ def test_np_dataloader_len(batch_size):
     with tempfile.TemporaryDirectory() as tmpdirname:
         # get the test dummy distributed graph
         _, part_config = generate_dummy_dist_graph(graph_name='dummy', dirname=tmpdirname)
-        np_data = GSgnnNodeTrainData(graph_name='dummy', part_config=part_config,
-                                     train_ntypes=['n1'], label_field='label')
+        np_data = GSgnnData(part_config=part_config)
 
     setup_device(0)
     # Without shuffling, the seed nodes should have the same order as the target nodes.
     target_idx = {'n1': th.arange(np_data.g.number_of_nodes('n1'))}
     dataloader = GSgnnNodeDataLoader(np_data, target_idx, [10], batch_size,
+                                     label_field='label',
                                      train_task=False)
     assert len(dataloader) == len(list(dataloader))
 
     dataloader = GSgnnNodeDataLoader(np_data, target_idx, [10], batch_size,
+                                     label_field='label',
                                      train_task=True)
     assert len(dataloader) == len(list(dataloader))
 
     target_idx_2 = {'n1': th.arange(np_data.g.number_of_nodes('n1')//2)}
     # target_idx > unlabeled_idx
-    dataloader = GSgnnNodeSemiSupDataLoader(np_data, target_idx, target_idx_2, [10], batch_size,
-                                     train_task=False)
+    dataloader = GSgnnNodeSemiSupDataLoader(np_data, target_idx, target_idx_2, [10],
+                                            batch_size, label_field='label',
+                                            train_task=False)
     assert len(dataloader) == len(list(dataloader))
 
-    dataloader = GSgnnNodeSemiSupDataLoader(np_data, target_idx, target_idx_2, [10], batch_size,
-                                     train_task=True)
+    dataloader = GSgnnNodeSemiSupDataLoader(np_data, target_idx, target_idx_2, [10],
+                                            batch_size, label_field='label',
+                                            train_task=True)
     assert len(dataloader) == len(list(dataloader))
 
     # target_idx < unlabeled_idx
-    dataloader = GSgnnNodeSemiSupDataLoader(np_data, target_idx_2, target_idx, [10], batch_size,
-                                     train_task=False)
+    dataloader = GSgnnNodeSemiSupDataLoader(np_data, target_idx_2, target_idx, [10],
+                                            batch_size, label_field='label',
+                                            train_task=False)
     assert len(dataloader) == len(list(dataloader))
 
-    dataloader = GSgnnNodeSemiSupDataLoader(np_data, target_idx_2, target_idx, [10], batch_size,
-                                     train_task=True)
+    dataloader = GSgnnNodeSemiSupDataLoader(np_data, target_idx_2, target_idx, [10],
+                                            batch_size, label_field='label',
+                                            train_task=True)
     assert len(dataloader) == len(list(dataloader))
 
 @pytest.mark.parametrize("batch_size", [10, 11])
@@ -1410,18 +1534,19 @@ def test_ep_dataloader_len(batch_size):
     with tempfile.TemporaryDirectory() as tmpdirname:
         # get the test dummy distributed graph
         _, part_config = generate_dummy_dist_graph(graph_name='dummy', dirname=tmpdirname)
-        ep_data = GSgnnEdgeTrainData(graph_name='dummy', part_config=part_config,
-                                     train_etypes=[('n0', 'r1', 'n1')], label_field='label')
+        ep_data = GSgnnData(part_config=part_config)
 
     ################### Test train_task #######################
 
     # Without shuffling, the seed nodes should have the same order as the target nodes.
     target_idx = {('n0', 'r1', 'n1'): th.arange(ep_data.g.number_of_edges('r1'))}
     dataloader = GSgnnEdgeDataLoader(ep_data, target_idx, [10], batch_size,
+                                     label_field='label',
                                      train_task=False, remove_target_edge_type=False)
     assert len(dataloader) == len(list(dataloader))
 
     dataloader = GSgnnEdgeDataLoader(ep_data, target_idx, [10], batch_size,
+                                     label_field='label',
                                      train_task=True, remove_target_edge_type=False)
     assert len(dataloader) == len(list(dataloader))
 
@@ -1430,8 +1555,7 @@ def test_lp_dataloader_len(batch_size):
     with tempfile.TemporaryDirectory() as tmpdirname:
         # get the test dummy distributed graph
         _, part_config = generate_dummy_dist_graph(graph_name='dummy', dirname=tmpdirname)
-        ep_data = GSgnnEdgeTrainData(graph_name='dummy', part_config=part_config,
-                                     train_etypes=[('n0', 'r1', 'n1')])
+        ep_data = GSgnnData(part_config=part_config)
 
     ################### Test train_task #######################
 
@@ -1976,42 +2100,38 @@ def test_GSgnnTrainData_homogeneous():
     with tempfile.TemporaryDirectory() as tmpdirname:
         # generate the test dummy homogeneous distributed graph and
         # test if it is possible to create GSgnnNodeTrainData on homogeneous graph
-        dist_graph, part_config = generate_dummy_dist_graph(graph_name='dummy',
+        _, part_config = generate_dummy_dist_graph(graph_name='dummy',
                                                             dirname=tmpdirname,
                                                             is_homo=True)
-        _ = GSgnnNodeTrainData(graph_name='dummy', part_config=part_config,
-                                     train_ntypes=tr_ntypes, eval_ntypes=va_ntypes,
-                                     label_field='label')
+        data = GSgnnData(part_config=part_config)
+        _ = data.get_node_train_set(tr_ntypes)
+        _ = data.get_node_val_set(va_ntypes)
+        _ = data.get_node_test_set(va_ntypes)
+        _ = data.get_node_infer_set(va_ntypes)
 
         # generate the test dummy distributed graph with "_N" node type. As it is expected to be
         # a homogeneous graph with "_N" as node type and ("_N", "_E", "_N") as edge type.
         # It should throw an error to clarify that.
-        dist_graph, part_config = generate_dummy_dist_graph_homogeneous_failure_graph(graph_name='dummy',
+        _, part_config = generate_dummy_dist_graph_homogeneous_failure_graph(graph_name='dummy',
                                                             dirname=tmpdirname)
+        data = GSgnnData(part_config=part_config)
         try:
-            _ = GSgnnNodeTrainData(graph_name='dummy', part_config=part_config,
-                                         train_ntypes=tr_ntypes, eval_ntypes=va_ntypes,
-                                         label_field='label')
+            _ = data.get_node_train_set(tr_ntypes)
             assert False, "expected Error raised for non-homogeneous graph input"
         except AssertionError as _:
             pass
-
-        # generate the test dummy homogeneous distributed graph and
-        # test if it is possible to create GSgnnNodeInferData on homogeneous graph
-        dist_graph, part_config = generate_dummy_dist_graph(graph_name='dummy',
-                                                            dirname=tmpdirname,
-                                                            is_homo=True)
-        _ = GSgnnNodeInferData(graph_name='dummy', part_config=part_config,
-                                     eval_ntypes=va_ntypes)
-
-        # generate the test dummy distributed graph with "_N" node type. As it is expected to be
-        # a homogeneous graph with "_N" as node type and ("_N", "_E", "_N") as edge type.
-        # It should throw an error to clarify that.
-        dist_graph, part_config = generate_dummy_dist_graph_homogeneous_failure_graph(graph_name='dummy',
-                                                            dirname=tmpdirname)
         try:
-            _ = GSgnnNodeInferData(graph_name='dummy', part_config=part_config,
-                                        eval_ntypes=va_ntypes)
+            _ = data.get_node_val_set(va_ntypes)
+            assert False, "expected Error raised for non-homogeneous graph input"
+        except AssertionError as _:
+            pass
+        try:
+            _ = data.get_node_test_set(va_ntypes)
+            assert False, "expected Error raised for non-homogeneous graph input"
+        except AssertionError as _:
+            pass
+        try:
+            _ = data.get_node_infer_set(va_ntypes)
             assert False, "expected Error raised for non-homogeneous graph input"
         except AssertionError as _:
             pass
@@ -2021,43 +2141,39 @@ def test_GSgnnTrainData_homogeneous():
 
     with tempfile.TemporaryDirectory() as tmpdirname:
         # generate the test dummy homogeneous distributed graph and
-        # test if it is possible to create GSgnnEdgeTrainData on homogeneous graph
-        dist_graph, part_config = generate_dummy_dist_graph(graph_name='dummy',
+        # test if it is possible to create GSgnnData on homogeneous graph
+        _, part_config = generate_dummy_dist_graph(graph_name='dummy',
                                                             dirname=os.path.join(tmpdirname, 'dummy'),
                                                             is_homo=True)
-        _ = GSgnnEdgeTrainData(graph_name='dummy', part_config=part_config,
-                                     train_etypes=tr_etypes, eval_etypes=va_etypes,
-                                     label_field='label')
+        data = GSgnnData(part_config=part_config)
+        _ = data.get_edge_train_set(tr_etypes)
+        _ = data.get_edge_val_set(va_etypes)
+        _ = data.get_edge_test_set(va_etypes)
+        _ = data.get_edge_infer_set(va_etypes)
 
         # generate the test dummy distributed graph with "_N" node type. As it is expected to be
         # a homogeneous graph with "_N" as node type and ("_N", "_E", "_N") as edge type.
         # It should throw an error to clarify that.
         dist_graph, part_config = generate_dummy_dist_graph_homogeneous_failure_graph(graph_name='dummy',
                                                             dirname=os.path.join(tmpdirname, 'dummy'))
+        data = GSgnnData(part_config=part_config)
         try:
-            _ = GSgnnEdgeTrainData(graph_name='dummy', part_config=part_config,
-                                       train_etypes=tr_etypes, eval_etypes=va_etypes,
-                                       label_field='label')
+            _ = data.get_edge_train_set(tr_etypes)
             assert False, "expected Error raised for non-homogeneous graph input"
         except AssertionError as _:
             pass
-
-        # generate the test dummy homogeneous distributed graph and
-        # test if it is possible to create GSgnnEdgeInferData on homogeneous graph
-        dist_graph, part_config = generate_dummy_dist_graph(graph_name='dummy',
-                                                            dirname=os.path.join(tmpdirname, 'dummy'),
-                                                            is_homo=True)
-        _ = GSgnnEdgeInferData(graph_name='dummy', part_config=part_config,
-                                    eval_etypes=va_etypes)
-
-        # generate the test dummy distributed graph with "_N" node type. As it is expected to be
-        # a homogeneous graph with "_N" as node type and ("_N", "_E", "_N") as edge type.
-        # It should throw an error to clarify that.
-        dist_graph, part_config = generate_dummy_dist_graph_homogeneous_failure_graph(graph_name='dummy',
-                                                            dirname=os.path.join(tmpdirname, 'dummy'))
         try:
-            _ = GSgnnEdgeInferData(graph_name='dummy', part_config=part_config,
-                                    eval_etypes=va_etypes)
+            _ = data.get_edge_val_set(va_etypes)
+            assert False, "expected Error raised for non-homogeneous graph input"
+        except AssertionError as _:
+            pass
+        try:
+            _ = data.get_edge_test_set(va_etypes)
+            assert False, "expected Error raised for non-homogeneous graph input"
+        except AssertionError as _:
+            pass
+        try:
+            _ = data.get_edge_infer_set(va_etypes)
             assert False, "expected Error raised for non-homogeneous graph input"
         except AssertionError as _:
             pass
@@ -2080,10 +2196,8 @@ if __name__ == '__main__':
     test_np_dataloader_trim_data(GSgnnNodeDataLoader)
     test_edge_dataloader_trim_data(GSgnnLinkPredictionDataLoader)
     test_edge_dataloader_trim_data(FastGSgnnLinkPredictionDataLoader)
-    test_GSgnnEdgeData_wo_test_mask()
-    test_GSgnnNodeData_wo_test_mask()
-    test_GSgnnEdgeData()
-    test_GSgnnNodeData()
+    test_GSgnnData()
+    test_GSgnnData2()
     test_lp_dataloader()
     test_edge_dataloader()
     test_node_dataloader()

--- a/tests/unit-tests/test_dataloading.py
+++ b/tests/unit-tests/test_dataloading.py
@@ -2099,7 +2099,7 @@ def test_GSgnnTrainData_homogeneous():
 
     with tempfile.TemporaryDirectory() as tmpdirname:
         # generate the test dummy homogeneous distributed graph and
-        # test if it is possible to create GSgnnNodeTrainData on homogeneous graph
+        # test if it is possible to create GSgnnData on homogeneous graph
         _, part_config = generate_dummy_dist_graph(graph_name='dummy',
                                                             dirname=tmpdirname,
                                                             is_homo=True)

--- a/tests/unit-tests/test_gnn.py
+++ b/tests/unit-tests/test_gnn.py
@@ -235,7 +235,7 @@ def check_node_prediction(model, data, is_homo=False):
     ----------
     model: GSgnnNodeModel
         Node model
-    data: GSgnnNodeTrainData
+    data: GSgnnData
         Train data
     """
     g = data.g
@@ -311,7 +311,7 @@ def check_node_prediction_with_reconstruct(model, data, construct_feat_ntype, tr
     ----------
     model: GSgnnNodeModel
         Node model
-    data: GSgnnNodeTrainData
+    data: GSgnnData
         Train data
     """
     target_ntype = train_ntypes[0]
@@ -390,7 +390,7 @@ def check_mlp_node_prediction(model, data):
     ----------
     model: GSgnnNodeModel
         Node model
-    data: GSgnnNodeTrainData
+    data: GSgnnData
         Train data
     """
     g = data.g

--- a/tests/unit-tests/test_gnn.py
+++ b/tests/unit-tests/test_gnn.py
@@ -34,7 +34,6 @@ import dgl
 
 from graphstorm.config import GSConfig
 from graphstorm.config import BUILTIN_LP_DOT_DECODER
-from graphstorm.utils import setup_device
 from graphstorm.model import GSNodeEncoderInputLayer, RelationalGCNEncoder
 from graphstorm.model import GSgnnNodeModel, GSgnnEdgeModel
 from graphstorm.model import GSLMNodeEncoderInputLayer, GSPureLMNodeInputLayer
@@ -53,7 +52,7 @@ from graphstorm.model.edge_decoder import (DenseBiDecoder,
                                            LinkPredictWeightedDotDecoder,
                                            LinkPredictWeightedDistMultDecoder)
 from graphstorm.model.node_decoder import EntityRegression, EntityClassifier
-from graphstorm.dataloading import GSgnnNodeTrainData, GSgnnEdgeTrainData
+from graphstorm.dataloading import GSgnnData
 from graphstorm.dataloading import GSgnnNodeDataLoader, GSgnnEdgeDataLoader
 from graphstorm.dataloading.dataset import prepare_batch_input
 from graphstorm import create_builtin_edge_gnn_model, create_builtin_node_gnn_model
@@ -270,10 +269,12 @@ def check_node_prediction(model, data, is_homo=False):
     target_nidx = {"n1": th.arange(g.number_of_nodes("n0"))} \
         if not is_homo else {DEFAULT_NTYPE: th.arange(g.number_of_nodes(DEFAULT_NTYPE))}
     dataloader1 = GSgnnNodeDataLoader(data, target_nidx, fanout=[],
-                                      batch_size=10, train_task=False)
+                                      batch_size=10, label_field='label',
+                                      node_feats='feat', train_task=False)
     pred1, labels1 = node_mini_batch_predict(model, embs, dataloader1, return_label=True)
     dataloader2 = GSgnnNodeDataLoader(data, target_nidx, fanout=[-1, -1],
-                                      batch_size=10, train_task=False)
+                                      batch_size=10, label_field='label',
+                                      node_feats='feat', train_task=False)
     pred2, _, labels2 = node_mini_batch_gnn_predict(model, dataloader2, return_label=True)
     if isinstance(pred1,dict):
         assert len(pred1) == len(pred2) and len(labels1) == len(labels2)
@@ -302,7 +303,7 @@ def check_node_prediction(model, data, is_homo=False):
         assert(is_int(pred4))
         assert(th.equal(pred3.argmax(dim=1), pred4))
 
-def check_node_prediction_with_reconstruct(model, data, construct_feat_ntype):
+def check_node_prediction_with_reconstruct(model, data, construct_feat_ntype, train_ntypes, node_feat_field=None):
     """ Check whether full graph inference and mini batch inference generate the same
         prediction result for GSgnnNodeModel with GNN layers.
 
@@ -313,7 +314,7 @@ def check_node_prediction_with_reconstruct(model, data, construct_feat_ntype):
     data: GSgnnNodeTrainData
         Train data
     """
-    target_ntype = data.train_ntypes[0]
+    target_ntype = train_ntypes[0]
     device = "cuda:0"
     g = data.g
     if data.node_feat_field is None:
@@ -354,10 +355,10 @@ def check_node_prediction_with_reconstruct(model, data, construct_feat_ntype):
     embs = embs[0:len(embs)].numpy()
 
     # Verify the internal of mini-batch inference.
-    assert len(data.train_ntypes) == 1
     target_nidx = {target_ntype: th.arange(g.number_of_nodes(target_ntype))}
     dataloader = GSgnnNodeDataLoader(data, target_nidx, fanout=[-1],
-                                     batch_size=10, train_task=False,
+                                     batch_size=10, label_field='label',
+                                     node_feats=node_feat_field, train_task=False,
                                      construct_feat_ntype=construct_feat_ntype)
     for input_nodes, seeds, blocks in dataloader:
         assert len(blocks) == 2
@@ -396,10 +397,12 @@ def check_mlp_node_prediction(model, data):
     embs = do_full_graph_inference(model, data)
     target_nidx = {"n1": th.arange(g.number_of_nodes("n0"))}
     dataloader1 = GSgnnNodeDataLoader(data, target_nidx, fanout=[],
-                                      batch_size=10, train_task=False)
+                                      batch_size=10, label_field='label',
+                                      node_feats='feat', train_task=False)
     pred1, labels1 = node_mini_batch_predict(model, embs, dataloader1, return_label=True)
     dataloader2 = GSgnnNodeDataLoader(data, target_nidx, fanout=[],
-                                      batch_size=10, train_task=False)
+                                      batch_size=10, label_field='label',
+                                      node_feats='feat', train_task=False)
     pred2, _, labels2 = node_mini_batch_gnn_predict(model, dataloader2, return_label=True)
     if isinstance(pred1, dict):
         assert len(pred1) == len(pred2) and len(labels1) == len(labels2)
@@ -444,9 +447,8 @@ def test_rgcn_node_prediction(norm):
     with tempfile.TemporaryDirectory() as tmpdirname:
         # get the test dummy distributed graph
         _, part_config = generate_dummy_dist_graph(tmpdirname)
-        np_data = GSgnnNodeTrainData(graph_name='dummy', part_config=part_config,
-                                     train_ntypes=['n1'], label_field='label',
-                                     node_feat_field='feat')
+        np_data = GSgnnData(part_config=part_config,
+                            node_feat_field='feat')
     model = create_rgcn_node_model(np_data.g, norm)
     check_node_prediction(model, np_data)
     th.distributed.destroy_process_group()
@@ -467,9 +469,8 @@ def test_rgcn_node_prediction_multi_target_ntypes():
     with tempfile.TemporaryDirectory() as tmpdirname:
         # get the test dummy distributed graph
         _, part_config = generate_dummy_dist_graph_multi_target_ntypes(tmpdirname)
-        np_data = GSgnnNodeTrainData(graph_name='dummy', part_config=part_config,
-                                     train_ntypes=['n0', 'n1'], label_field='label',
-                                     node_feat_field='feat')
+        np_data = GSgnnData(part_config=part_config,
+                            node_feat_field='feat')
     model = create_rgcn_node_model(np_data.g, None)
     check_node_prediction(model, np_data)
     th.distributed.destroy_process_group()
@@ -492,11 +493,11 @@ def test_rgcn_node_prediction_with_reconstruct(cache_embed):
         # get the test dummy distributed graph
         _, part_config = generate_dummy_dist_graph_reconstruct(graph_name='dummy',
                                                                dirname=tmpdirname)
-        np_data = GSgnnNodeTrainData(graph_name='dummy', part_config=part_config,
-                                     train_ntypes=['n0'], label_field='label',
-                                     node_feat_field={'n0': ['feat'], 'n4': ['feat']})
+        node_feat_field = {'n0': ['feat'], 'n4': ['feat']}
+        np_data = GSgnnData(part_config=part_config,
+                            node_feat_field=node_feat_field)
     model = create_rgcn_node_model_with_reconstruct(np_data, ['n2'], cache_embed=cache_embed)
-    check_node_prediction_with_reconstruct(model, np_data, ['n2'])
+    check_node_prediction_with_reconstruct(model, np_data, ['n2'], ['n0'], node_feat_field)
 
     th.distributed.destroy_process_group()
     dgl.distributed.kvstore.close_kvstore()
@@ -516,12 +517,11 @@ def test_lm_rgcn_node_prediction_with_reconstruct():
     with tempfile.TemporaryDirectory() as tmpdirname:
         # get the test dummy distributed graph
         lm_configs, _, _, _, g, part_config = create_lm_graph(tmpdirname, text_ntype='n1')
-        np_data = GSgnnNodeTrainData(graph_name='dummy', part_config=part_config,
-                                     train_ntypes=['n1'], label_field='label',
-                                     lm_feat_ntypes=['n1'])
+        np_data = GSgnnData(part_config=part_config,
+                            lm_feat_ntypes=['n1'])
         np_data._g = g
     model = create_rgcn_node_model_with_reconstruct(np_data, ['n0'], lm_configs=lm_configs)
-    check_node_prediction_with_reconstruct(model, np_data, ['n0'])
+    check_node_prediction_with_reconstruct(model, np_data, ['n0'], ['n1'])
 
     th.distributed.destroy_process_group()
     dgl.distributed.kvstore.close_kvstore()
@@ -542,8 +542,8 @@ def test_rgat_node_prediction(norm):
     with tempfile.TemporaryDirectory() as tmpdirname:
         # get the test dummy distributed graph
         _, part_config = generate_dummy_dist_graph(tmpdirname)
-        np_data = GSgnnNodeTrainData(graph_name='dummy', part_config=part_config,
-                                     train_ntypes=['n1'], label_field='label',
+        np_data = GSgnnData(part_config=part_config,
+
                                      node_feat_field='feat')
     model = create_rgat_node_model(np_data.g, norm)
     check_node_prediction(model, np_data)
@@ -565,9 +565,8 @@ def test_hgt_node_prediction():
     with tempfile.TemporaryDirectory() as tmpdirname:
         # get the test dummy distributed graph
         _, part_config = generate_dummy_dist_graph(tmpdirname)
-        np_data = GSgnnNodeTrainData(graph_name='dummy', part_config=part_config,
-                                     train_ntypes=['n1'], label_field='label',
-                                     node_feat_field='feat')
+        np_data = GSgnnData(part_config=part_config,
+                            node_feat_field='feat')
     model=create_hgt_node_model(np_data.g)
     check_node_prediction(model, np_data)
     th.distributed.destroy_process_group()
@@ -588,9 +587,8 @@ def test_rgat_node_prediction_multi_target_ntypes():
     with tempfile.TemporaryDirectory() as tmpdirname:
         # get the test dummy distributed graph
         _, part_config = generate_dummy_dist_graph_multi_target_ntypes(tmpdirname)
-        np_data = GSgnnNodeTrainData(graph_name='dummy', part_config=part_config,
-                                     train_ntypes=['n0', 'n1'], label_field='label',
-                                     node_feat_field='feat')
+        np_data = GSgnnData(part_config=part_config,
+                            node_feat_field='feat')
     model = create_rgat_node_model(np_data.g)
     check_node_prediction(model, np_data)
     th.distributed.destroy_process_group()
@@ -612,10 +610,8 @@ def test_sage_node_prediction(norm):
     with tempfile.TemporaryDirectory() as tmpdirname:
         # get the test dummy distributed graph
         _, part_config = generate_dummy_dist_graph(tmpdirname, is_homo=True)
-        np_data = GSgnnNodeTrainData(graph_name='dummy', part_config=part_config,
-                                     train_ntypes=[DEFAULT_NTYPE],
-                                     label_field='label',
-                                     node_feat_field='feat')
+        np_data = GSgnnData(part_config=part_config,
+                            node_feat_field='feat')
     model = create_sage_node_model(np_data.g, norm)
     check_node_prediction(model, np_data, is_homo=True)
     th.distributed.destroy_process_group()
@@ -637,10 +633,8 @@ def test_gatv2_node_prediction(device):
     with tempfile.TemporaryDirectory() as tmpdirname:
         # get the test dummy distributed graph
         _, part_config = generate_dummy_dist_graph(tmpdirname, is_homo=True)
-        np_data = GSgnnNodeTrainData(graph_name='dummy', part_config=part_config,
-                                     train_ntypes=[DEFAULT_NTYPE],
-                                     label_field='label',
-                                     node_feat_field='feat')
+        np_data = GSgnnData(part_config=part_config,
+                            node_feat_field='feat')
     model = create_gatv2_node_model(np_data.g)
     model = model.to(device)
     check_node_prediction(model, np_data, is_homo=True)
@@ -663,10 +657,8 @@ def test_gat_node_prediction(device):
     with tempfile.TemporaryDirectory() as tmpdirname:
         # get the test dummy distributed graph
         _, part_config = generate_dummy_dist_graph(tmpdirname, is_homo=True)
-        np_data = GSgnnNodeTrainData(graph_name='dummy', part_config=part_config,
-                                     train_ntypes=[DEFAULT_NTYPE],
-                                     label_field='label',
-                                     node_feat_field='feat')
+        np_data = GSgnnData(part_config=part_config,
+                            node_feat_field='feat')
     model = create_gat_node_model(np_data.g)
     model = model.to(device)
     check_node_prediction(model, np_data, is_homo=True)
@@ -724,7 +716,7 @@ def check_edge_prediction(model, data):
     ----------
     model: GSgnnEdgeModel
         Node model
-    data: GSgnnEdgeTrainData
+    data: GSgnnData
         Train data
     """
     g = data.g
@@ -732,11 +724,15 @@ def check_edge_prediction(model, data):
     target_idx = {("n0", "r1", "n1"): th.arange(g.number_of_edges("r1"))}
     dataloader1 = GSgnnEdgeDataLoader(data, target_idx, fanout=[],
                                       batch_size=10,
+                                      label_field='label',
+                                      node_feats='feat',
                                       train_task=False,
                                       remove_target_edge_type=False)
     pred1, labels1 = edge_mini_batch_predict(model, embs, dataloader1, return_label=True)
     dataloader2 = GSgnnEdgeDataLoader(data, target_idx, fanout=[-1, -1],
                                       batch_size=10,
+                                      label_field='label',
+                                      node_feats='feat',
                                       train_task=False,
                                       remove_target_edge_type=False)
     pred2, labels2 = edge_mini_batch_gnn_predict(model, dataloader2, return_label=True)
@@ -761,7 +757,7 @@ def check_mlp_edge_prediction(model, data):
     ----------
     model: GSgnnEdgeModel
         Node model
-    data: GSgnnEdgeTrainData
+    data: GSgnnData
         Train data
     """
     g = data.g
@@ -769,11 +765,15 @@ def check_mlp_edge_prediction(model, data):
     target_idx = {("n0", "r1", "n1"): th.arange(g.number_of_edges("r1"))}
     dataloader1 = GSgnnEdgeDataLoader(data, target_idx, fanout=[],
                                       batch_size=10,
+                                      label_field='label',
+                                      node_feats='feat',
                                       train_task=False,
                                       remove_target_edge_type=False)
     pred1, labels1 = edge_mini_batch_predict(model, embs, dataloader1, return_label=True)
     dataloader2 = GSgnnEdgeDataLoader(data, target_idx, fanout=[],
                                       batch_size=10,
+                                      label_field='label',
+                                      node_feats='feat',
                                       train_task=False,
                                       remove_target_edge_type=False)
     pred2, labels2 = edge_mini_batch_gnn_predict(model, dataloader2, return_label=True)
@@ -806,9 +806,7 @@ def test_rgcn_edge_prediction(num_ffn_layers):
     with tempfile.TemporaryDirectory() as tmpdirname:
         # get the test dummy distributed graph
         _, part_config = generate_dummy_dist_graph(tmpdirname)
-        ep_data = GSgnnEdgeTrainData(graph_name='dummy', part_config=part_config,
-                                     train_etypes=[('n0', 'r1', 'n1')], label_field='label',
-                                     node_feat_field='feat')
+        ep_data = GSgnnData(part_config=part_config, node_feat_field="feat")
     model = create_rgcn_edge_model(ep_data.g, num_ffn_layers=num_ffn_layers)
     check_edge_prediction(model, ep_data)
     th.distributed.destroy_process_group()
@@ -830,9 +828,8 @@ def test_hgt_edge_prediction(num_ffn_layers):
     with tempfile.TemporaryDirectory() as tmpdirname:
         # get the test dummy distributed graph
         _, part_config = generate_dummy_dist_graph(tmpdirname)
-        ep_data = GSgnnEdgeTrainData(graph_name='dummy', part_config=part_config,
-                                     train_etypes=[('n0', 'r1', 'n1')], label_field='label',
-                                     node_feat_field='feat')
+        ep_data = GSgnnData(part_config=part_config,
+                            node_feat_field='feat')
     model = create_hgt_edge_model(ep_data.g, num_ffn_layers=num_ffn_layers)
     check_edge_prediction(model, ep_data)
     th.distributed.destroy_process_group()
@@ -880,9 +877,8 @@ def test_mlp_edge_prediction(num_ffn_layers):
 
     with tempfile.TemporaryDirectory() as tmpdirname:
         lm_config, _, _, _, g, part_config = create_lm_graph(tmpdirname)
-        ep_data = GSgnnEdgeTrainData(graph_name='dummy', part_config=part_config,
-                                        train_etypes=[('n0', 'r1', 'n1')], label_field='label',
-                                        node_feat_field='feat')
+        ep_data = GSgnnData(part_config=part_config,
+                            node_feat_field='feat')
         g.edges['r1'].data['label']= ep_data.g.edges['r1'].data['label']
     model = create_mlp_edge_model(g, lm_config, num_ffn_layers=num_ffn_layers)
     assert model.gnn_encoder is None
@@ -950,10 +946,8 @@ def test_mlp_node_prediction():
                                       world_size=1)
     with tempfile.TemporaryDirectory() as tmpdirname:
         lm_config, _, _, _, g, part_config = create_lm_graph(tmpdirname)
-        np_data = GSgnnNodeTrainData(graph_name='dummy', part_config=part_config,
-                                        train_ntypes=['n1'],
-                                        label_field='label',
-                                        node_feat_field='feat')
+        np_data = GSgnnData(part_config=part_config,
+                            node_feat_field='feat')
         g.nodes['n1'].data['label'] = np_data.g.nodes['n1'].data['label']
     model = create_mlp_node_model(g, lm_config)
     assert model.gnn_encoder is None
@@ -969,10 +963,8 @@ def test_gnn_model_load_save():
                                       world_size=1)
     with tempfile.TemporaryDirectory() as tmpdirname:
         lm_config, _, _, _, g, part_config = create_lm_graph(tmpdirname)
-        np_data = GSgnnNodeTrainData(graph_name='dummy', part_config=part_config,
-                                        train_ntypes=['n1'],
-                                        label_field='label',
-                                        node_feat_field='feat')
+        np_data = GSgnnData(part_config=part_config,
+                            node_feat_field='feat')
     model = create_mlp_node_model(g, lm_config)
     dense_params = {name: param.data[:] for name, param in model.node_input_encoder.named_parameters()}
     sparse_params = [param[0:len(param)] for param in model.node_input_encoder.get_sparse_params()]
@@ -1089,10 +1081,8 @@ def test_mlp_link_prediction():
                                       world_size=1)
     with tempfile.TemporaryDirectory() as tmpdirname:
         lm_config, _, _, _, g, part_config = create_lm_graph(tmpdirname)
-        np_data = GSgnnEdgeTrainData(graph_name='dummy', part_config=part_config,
-                                        train_etypes=[('n0', 'r1', 'n1')],
-                                        eval_etypes=[('n0', 'r1', 'n1')],
-                                        node_feat_field='feat')
+        np_data = GSgnnData(part_config=part_config,
+                            node_feat_field='feat')
     model = create_mlp_lp_model(g, lm_config)
     assert model.gnn_encoder is None
     embs = do_full_graph_inference(model, np_data)
@@ -1475,9 +1465,8 @@ def test_mini_batch_full_graph_inference(num_ffn_layers):
     with tempfile.TemporaryDirectory() as tmpdirname:
         # get the test dummy distributed graph
         _, part_config = generate_dummy_dist_graph(tmpdirname)
-        data = GSgnnEdgeTrainData(graph_name='dummy', part_config=part_config,
-                                  train_etypes=[('n0', 'r1', 'n1')], label_field='label',
-                                  node_feat_field='feat')
+        data = GSgnnData(part_config=part_config,
+                         node_feat_field='feat')
     model = create_rgcn_edge_model(data.g, num_ffn_layers=num_ffn_layers)
 
     embs_layer = do_full_graph_inference(model, data, fanout=[-1, -1])
@@ -1535,24 +1524,23 @@ def test_edge_mini_batch_gnn_predict():
     with tempfile.TemporaryDirectory() as tmpdirname:
         target_type = ("n0", "r1", "n1")
         _, part_config = generate_dummy_dist_graph(tmpdirname)
-        ep_data = GSgnnEdgeTrainData(graph_name='dummy',
-                                     part_config=part_config,
-                                     train_etypes=[target_type], label_field='label',
-                                     node_feat_field='feat')
-        g = ep_data.g
-        embs = {
-            "n0": th.rand((g.number_of_nodes("n0"), 10)),
-            "n1": th.rand((g.number_of_nodes("n1"), 10))
-        }
-        target_idx = {target_type: th.arange(g.number_of_edges("r1"))}
 
-        @patch.object(GSgnnEdgeTrainData, 'get_labels')
-        def check_predict(mock_get_labels):
-            mock_get_labels.side_effect = \
+        @patch.object(GSgnnData, 'get_edge_feats')
+        def check_predict(mock_get_edge_feats):
+            ep_data = GSgnnData(part_config=part_config)
+            g = ep_data.g
+            embs = {
+                "n0": th.rand((g.number_of_nodes("n0"), 10)),
+                "n1": th.rand((g.number_of_nodes("n1"), 10))
+            }
+            target_idx = {target_type: th.arange(g.number_of_edges("r1"))}
+            mock_get_edge_feats.side_effect = \
                 [{target_type: th.arange(10)}] * (ep_data.g.number_of_edges(target_type) // 10)
             model = Dummy_GSEdgeModel()
             dataloader = GSgnnEdgeDataLoader(ep_data, target_idx, fanout=[],
                                              batch_size=10,
+                                             node_feats='feat',
+                                             label_field='label',
                                              train_task=False,
                                              remove_target_edge_type=False)
             pred, labels = edge_mini_batch_predict(model, embs, dataloader, return_label=True)
@@ -1601,18 +1589,19 @@ def test_node_mini_batch_gnn_predict():
     with tempfile.TemporaryDirectory() as tmpdirname:
         # get the test dummy distributed graph
         _, part_config = generate_dummy_dist_graph(tmpdirname)
-        data = GSgnnNodeTrainData(graph_name='dummy', part_config=part_config,
-                                   train_ntypes=['n1'], label_field='label',
-                                   node_feat_field='feat')
+        data = GSgnnData(part_config=part_config)
         target_nidx = {"n1": th.arange(data.g.number_of_nodes("n0"))}
         dataloader = GSgnnNodeDataLoader(data, target_nidx, fanout=[],
-                                        batch_size=10,
-                                        train_task=False)
+                                        batch_size=10, label_field='label',
+                                        node_feats=None, train_task=False)
 
-        @patch.object(GSgnnNodeTrainData, 'get_labels')
+        @patch.object(GSgnnData, 'get_node_feats')
         def check_predict(mock_get_labels, return_dict):
             model = Dummy_GSNodeModel(return_dict=return_dict)
-            mock_get_labels.side_effect = [{"n1": th.arange(10)}] * 10
+            # Data.get_node_feats is called twice in
+            # a minibatch, once for get node feature
+            # and once for get labels
+            mock_get_labels.side_effect = [{"n1": th.arange(10)}] * 20
 
             pred, embs, labels = node_mini_batch_gnn_predict(model, dataloader, return_label=True)
             assert isinstance(pred, dict)
@@ -1644,7 +1633,8 @@ if __name__ == '__main__':
     test_lm_model_load_save()
     test_node_mini_batch_gnn_predict()
     test_edge_mini_batch_gnn_predict()
-    test_hgt_edge_prediction()
+    test_hgt_edge_prediction(0)
+    test_hgt_edge_prediction(2)
     test_hgt_node_prediction()
     test_rgcn_edge_prediction(2)
     test_rgcn_node_prediction(None)


### PR DESCRIPTION
*Issue #, if available:*
#755 
#756 

*Description of changes:*
This PR include the code refactoring of GraphStorm ``DataLoader`` and ``GraphStorm`` Dataset. All related codes, examples and docs are updated accordingly.

The key changes are:
1. Unify the implementation of different ``GSgnnData`` sub classes (``GSgnnNodeTrainData``, ``GSgnnNodeInferData``, ``GSgnnEdgeTrainData``,  ``GSgnnEdgeInferData``) into ``GSgnnData``.  ``GSgnnData`` now only provides interfaces for accessing graph data, e.g., node features, edge features, labels, train masks, etc.
2. Changes of ``GSgnnData`` API
  * Update the init arguments of ``GSgnnData`` from ``(graph_name, part_config, node_feat_field, edge_feat_field, decoder_edge_feat, lm_feat_ntypes, lm_feat_etypes)`` to ``(part_config, node_feat_field, edge_feat_field, lm_feat_ntypes, lm_feat_etypes)``.
  * Add property functions:
    * ``graph_name()``, return a string of the graph name value in config json.
  * Add new functions:
    * ``get_node_feats(self, input_nodes, nfeat_fields, device='cpu')``, given the node ids (``input_nodes``) and node features to retrieve from the graph data (``nfeat_fields``), return the corresponding node features.
     * ``get_edge_feats(self, input_edges, efeat_fields, device='cpu')``, given the edge ids (``input_edges``) and edge features to retrieve from the graph data (``efeat_fields``), return the corresponding edge features.
     * ``get_node_train_set(self, ntypes, mask)``, return the node training set.
     * ``get_node_val_set(self, ntypes, mask)``, return the node validation set.
     * ``get_node_test_set(self, ntypes, mask)``, return the node test set.
     * ``get_node_infer_set(self, ntypes, mask)``, return the node inference set.
     *  ``get_edge_train_set(self, etypes, mask, reverse_edge_types_map)``, return the edge training set.
     * ``get_node_val_set(self, etypes, mask, reverse_edge_types_map)``, return the edge validation set.
     * ``get_node_test_set(self, etypes, mask, reverse_edge_types_map)``, return the edge test set.
     * ``get_node_infer_set(self, etypes, mask, reverse_edge_types_map)``, return the edge inference set.
  * Update some functions:
    * ``get_node_feats(self, input_nodes, nfeat_fields, device='cpu')``, requires the caller to provide the node feature fields to access
    * ``get_edge_feats(self, input_edges, efeat_fields, device='cpu')``, requires the caller to provide the edge feature fields to access
    * ``get_labels`` function is replaced with ``get_node_feats`` and ``get_edge_feats`` with label field names.
3. Change of GSgnn Dataloaders API:
  * ``GSgnnNodeDataLoaderBase`` and its subclasses, requires three new init arguments:
    * ``label_field``: Label field of the node task.
    * ``node_feats``: Node feature fields used by the node task.
    * ``edge_feats``: Edge feature fields used by the node task.
  * ``GSgnnEdgeDataLoader`` and its subclasses, requires four new init arguments:
    * ``label_field``: Label field of the edge task.
    * ``node_feats``: Node feature fields used by the edge task.
    * ``edge_feats``: Edge feature fields used by the edge task.
    * ``decoder_edge_feats``: Edge feature fields used in the edge task decoder.
  * ``GSgnnLinkPredictionDataLoader `` and its subclasses, requires three new init arguments:
    * ``node_feats``: Node feature fields used by the link prediction task.
    * ``edge_feats``: Edge feature fields used by the link prediction task.
    * ``pos_graph_edge_feats``: The field of the edge features used by positive graph in link prediction.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
