### PR TITLE
Refactor gsf.py to make the code of creating decoders and creating link prediction dataloders reusable.

### DIFF
--- a/python/graphstorm/__init__.py
+++ b/python/graphstorm/__init__.py
@@ -28,5 +28,5 @@ from .gsf import create_builtin_lp_gnn_model
 from .gsf import create_builtin_lp_model
 from .gsf import create_builtin_edge_model
 from .gsf import create_builtin_node_model
-from .gsf import (get_builtin_lp_train_sampler,
-                  get_builtin_lp_eval_dataloader)
+from .gsf import (get_builtin_lp_train_dataloader_class,
+                  get_builtin_lp_eval_dataloader_class)

--- a/python/graphstorm/__init__.py
+++ b/python/graphstorm/__init__.py
@@ -28,3 +28,5 @@ from .gsf import create_builtin_lp_gnn_model
 from .gsf import create_builtin_lp_model
 from .gsf import create_builtin_edge_model
 from .gsf import create_builtin_node_model
+from .gsf import (get_builtin_lp_train_sampler,
+                  get_builtin_lp_eval_dataloader)

--- a/python/graphstorm/gsf.py
+++ b/python/graphstorm/gsf.py
@@ -312,7 +312,7 @@ def create_builtin_node_model(g, config, train_task):
     encoder_out_dims = model.gnn_encoder.out_dims \
         if model.gnn_encoder is not None \
             else model.node_input_encoder.out_dims
-    decoder, loss_func = create_builtin_node_decoder(g, encoder_out_dims, config)
+    decoder, loss_func = create_builtin_node_decoder(g, encoder_out_dims, config, train_task)
     model.set_decoder(decoder)
     model.set_loss_func(loss_func)
 

--- a/python/graphstorm/gsf.py
+++ b/python/graphstorm/gsf.py
@@ -766,10 +766,25 @@ def check_homo(g):
 
 
 def create_builtin_task_tracker(config):
+    """ Create a builtin task tracker
+
+    Parameters
+    ----------
+    config: GSConfig
+        Configurations
+    """
     tracker_class = get_task_tracker_class(config.task_tracker)
     return tracker_class(config.eval_frequency)
 
-def get_lp_eval_sampler(config):
+def get_builtin_lp_eval_dataloader(config):
+    """ Return a builtin link prediction evaluation dataloader
+        based on input config
+
+    Parameters
+    ----------
+    config: GSConfig
+        Configurations
+    """
     test_dataloader_cls = None
     if config.eval_etypes_negative_dstnode is not None:
         test_dataloader_cls = GSgnnLinkPredictionPredefinedTestDataLoader
@@ -783,7 +798,15 @@ def get_lp_eval_sampler(config):
             f'[{BUILTIN_LP_UNIFORM_NEG_SAMPLER}, {BUILTIN_LP_JOINT_NEG_SAMPLER}]')
     return test_dataloader_cls
 
-def get_lp_train_sampler(config):
+def get_builtin_lp_train_sampler(config):
+    """ Return a builtin link prediction training dataloader
+        based on input config
+
+    Parameters
+    ----------
+    config: GSConfig
+        Configurations
+    """
     dataloader_cls = None
     if config.train_negative_sampler == BUILTIN_LP_UNIFORM_NEG_SAMPLER:
         dataloader_cls = GSgnnLinkPredictionDataLoader

--- a/python/graphstorm/gsf.py
+++ b/python/graphstorm/gsf.py
@@ -776,7 +776,7 @@ def create_builtin_task_tracker(config):
     tracker_class = get_task_tracker_class(config.task_tracker)
     return tracker_class(config.eval_frequency)
 
-def get_builtin_lp_eval_dataloader(config):
+def get_builtin_lp_eval_dataloader_class(config):
     """ Return a builtin link prediction evaluation dataloader
         based on input config
 
@@ -798,7 +798,7 @@ def get_builtin_lp_eval_dataloader(config):
             f'[{BUILTIN_LP_UNIFORM_NEG_SAMPLER}, {BUILTIN_LP_JOINT_NEG_SAMPLER}]')
     return test_dataloader_cls
 
-def get_builtin_lp_train_sampler(config):
+def get_builtin_lp_train_dataloader_class(config):
     """ Return a builtin link prediction training dataloader
         based on input config
 

--- a/python/graphstorm/run/gsgnn_lp/gsgnn_lm_lp.py
+++ b/python/graphstorm/run/gsgnn_lp/gsgnn_lm_lp.py
@@ -86,7 +86,7 @@ def main(config_args):
         tracker.log_params(config.__dict__)
     trainer.setup_task_tracker(tracker)
 
-    dataloader_cls = gs.get_lp_train_sampler(config)
+    dataloader_cls = gs.get_builtin_lp_train_sampler(config)
     train_idxs = train_data.get_edge_train_set(config.train_etype)
     dataloader = dataloader_cls(train_data,
                                 train_idxs, [],
@@ -98,7 +98,7 @@ def main(config_args):
                                 num_hard_negs=config.num_train_hard_negatives)
 
     # TODO(zhengda) let's use full-graph inference for now.
-    test_dataloader_cls = gs.get_lp_eval_sampler(config)
+    test_dataloader_cls = gs.get_builtin_lp_eval_dataloader(config)
     val_dataloader = None
     test_dataloader = None
 

--- a/python/graphstorm/run/gsgnn_lp/gsgnn_lm_lp.py
+++ b/python/graphstorm/run/gsgnn_lp/gsgnn_lm_lp.py
@@ -23,23 +23,6 @@ from graphstorm.config import get_argument_parser
 from graphstorm.config import GSConfig
 from graphstorm.trainer import GSgnnLinkPredictionTrainer
 from graphstorm.dataloading import GSgnnData
-from graphstorm.dataloading import GSgnnLinkPredictionDataLoader
-from graphstorm.dataloading import (GSgnnLPJointNegDataLoader,
-                                    GSgnnLPLocalUniformNegDataLoader,
-                                    GSgnnLPLocalJointNegDataLoader,
-                                    GSgnnLPInBatchJointNegDataLoader)
-from graphstorm.dataloading import GSgnnAllEtypeLPJointNegDataLoader
-from graphstorm.dataloading import GSgnnAllEtypeLinkPredictionDataLoader
-from graphstorm.dataloading import (GSgnnLinkPredictionTestDataLoader,
-                                    GSgnnLinkPredictionJointTestDataLoader,
-                                    GSgnnLinkPredictionPredefinedTestDataLoader)
-from graphstorm.dataloading import (BUILTIN_LP_UNIFORM_NEG_SAMPLER,
-                                    BUILTIN_LP_JOINT_NEG_SAMPLER,
-                                    BUILTIN_LP_INBATCH_JOINT_NEG_SAMPLER,
-                                    BUILTIN_LP_LOCALUNIFORM_NEG_SAMPLER,
-                                    BUILTIN_LP_LOCALJOINT_NEG_SAMPLER)
-from graphstorm.dataloading import BUILTIN_LP_ALL_ETYPE_UNIFORM_NEG_SAMPLER
-from graphstorm.dataloading import BUILTIN_LP_ALL_ETYPE_JOINT_NEG_SAMPLER
 from graphstorm.eval import GSgnnMrrLPEvaluator, GSgnnPerEtypeMrrLPEvaluator
 from graphstorm.model.utils import save_full_node_embeddings
 from graphstorm.model import do_full_graph_inference
@@ -103,22 +86,7 @@ def main(config_args):
         tracker.log_params(config.__dict__)
     trainer.setup_task_tracker(tracker)
 
-    if config.train_negative_sampler == BUILTIN_LP_UNIFORM_NEG_SAMPLER:
-        dataloader_cls = GSgnnLinkPredictionDataLoader
-    elif config.train_negative_sampler == BUILTIN_LP_JOINT_NEG_SAMPLER:
-        dataloader_cls = GSgnnLPJointNegDataLoader
-    elif config.train_negative_sampler == BUILTIN_LP_INBATCH_JOINT_NEG_SAMPLER:
-        dataloader_cls = GSgnnLPInBatchJointNegDataLoader
-    elif config.train_negative_sampler == BUILTIN_LP_LOCALUNIFORM_NEG_SAMPLER:
-        dataloader_cls = GSgnnLPLocalUniformNegDataLoader
-    elif config.train_negative_sampler == BUILTIN_LP_LOCALJOINT_NEG_SAMPLER:
-        dataloader_cls = GSgnnLPLocalJointNegDataLoader
-    elif config.train_negative_sampler == BUILTIN_LP_ALL_ETYPE_UNIFORM_NEG_SAMPLER:
-        dataloader_cls = GSgnnAllEtypeLinkPredictionDataLoader
-    elif config.train_negative_sampler == BUILTIN_LP_ALL_ETYPE_JOINT_NEG_SAMPLER:
-        dataloader_cls = GSgnnAllEtypeLPJointNegDataLoader
-    else:
-        raise ValueError('Unknown negative sampler')
+    dataloader_cls = gs.get_lp_train_sampler(config)
     train_idxs = train_data.get_edge_train_set(config.train_etype)
     dataloader = dataloader_cls(train_data,
                                 train_idxs, [],
@@ -130,16 +98,7 @@ def main(config_args):
                                 num_hard_negs=config.num_train_hard_negatives)
 
     # TODO(zhengda) let's use full-graph inference for now.
-    if config.eval_etypes_negative_dstnode is not None:
-        test_dataloader_cls = GSgnnLinkPredictionPredefinedTestDataLoader
-    elif config.eval_negative_sampler == BUILTIN_LP_UNIFORM_NEG_SAMPLER:
-        test_dataloader_cls = GSgnnLinkPredictionTestDataLoader
-    elif config.eval_negative_sampler == BUILTIN_LP_JOINT_NEG_SAMPLER:
-        test_dataloader_cls = GSgnnLinkPredictionJointTestDataLoader
-    else:
-        raise ValueError('Unknown test negative sampler.'
-            'Supported test negative samplers include '
-            f'[{BUILTIN_LP_UNIFORM_NEG_SAMPLER}, {BUILTIN_LP_JOINT_NEG_SAMPLER}]')
+    test_dataloader_cls = gs.get_lp_eval_sampler(config)
     val_dataloader = None
     test_dataloader = None
 

--- a/python/graphstorm/run/gsgnn_lp/gsgnn_lm_lp.py
+++ b/python/graphstorm/run/gsgnn_lp/gsgnn_lm_lp.py
@@ -86,7 +86,7 @@ def main(config_args):
         tracker.log_params(config.__dict__)
     trainer.setup_task_tracker(tracker)
 
-    dataloader_cls = gs.get_builtin_lp_train_sampler(config)
+    dataloader_cls = gs.get_builtin_lp_train_dataloader_class(config)
     train_idxs = train_data.get_edge_train_set(config.train_etype)
     dataloader = dataloader_cls(train_data,
                                 train_idxs, [],
@@ -98,7 +98,7 @@ def main(config_args):
                                 num_hard_negs=config.num_train_hard_negatives)
 
     # TODO(zhengda) let's use full-graph inference for now.
-    test_dataloader_cls = gs.get_builtin_lp_eval_dataloader(config)
+    test_dataloader_cls = gs.get_builtin_lp_eval_dataloader_class(config)
     val_dataloader = None
     test_dataloader = None
 

--- a/python/graphstorm/run/gsgnn_lp/gsgnn_lp.py
+++ b/python/graphstorm/run/gsgnn_lp/gsgnn_lp.py
@@ -23,31 +23,6 @@ from graphstorm.config import get_argument_parser
 from graphstorm.config import GSConfig
 from graphstorm.trainer import GSgnnLinkPredictionTrainer
 from graphstorm.dataloading import GSgnnData
-from graphstorm.dataloading import GSgnnLinkPredictionDataLoader
-from graphstorm.dataloading import (GSgnnLPJointNegDataLoader,
-                                    GSgnnLPLocalUniformNegDataLoader,
-                                    GSgnnLPLocalJointNegDataLoader,
-                                    GSgnnLPInBatchJointNegDataLoader)
-from graphstorm.dataloading import GSgnnAllEtypeLPJointNegDataLoader
-from graphstorm.dataloading import GSgnnAllEtypeLinkPredictionDataLoader
-from graphstorm.dataloading import (GSgnnLinkPredictionTestDataLoader,
-                                    GSgnnLinkPredictionJointTestDataLoader,
-                                    GSgnnLinkPredictionPredefinedTestDataLoader)
-from graphstorm.dataloading import (BUILTIN_LP_UNIFORM_NEG_SAMPLER,
-                                    BUILTIN_LP_JOINT_NEG_SAMPLER,
-                                    BUILTIN_LP_INBATCH_JOINT_NEG_SAMPLER,
-                                    BUILTIN_LP_LOCALUNIFORM_NEG_SAMPLER,
-                                    BUILTIN_LP_LOCALJOINT_NEG_SAMPLER)
-from graphstorm.dataloading import BUILTIN_LP_ALL_ETYPE_UNIFORM_NEG_SAMPLER
-from graphstorm.dataloading import BUILTIN_LP_ALL_ETYPE_JOINT_NEG_SAMPLER
-from graphstorm.dataloading import (BUILTIN_FAST_LP_UNIFORM_NEG_SAMPLER,
-                                    BUILTIN_FAST_LP_JOINT_NEG_SAMPLER,
-                                    BUILTIN_FAST_LP_LOCALUNIFORM_NEG_SAMPLER,
-                                    BUILTIN_FAST_LP_LOCALJOINT_NEG_SAMPLER)
-from graphstorm.dataloading import (FastGSgnnLinkPredictionDataLoader,
-                                    FastGSgnnLPJointNegDataLoader,
-                                    FastGSgnnLPLocalUniformNegDataLoader,
-                                    FastGSgnnLPLocalJointNegDataLoader)
 from graphstorm.eval import GSgnnMrrLPEvaluator, GSgnnPerEtypeMrrLPEvaluator
 from graphstorm.model.utils import save_full_node_embeddings
 from graphstorm.model import do_full_graph_inference
@@ -119,30 +94,7 @@ def main(config_args):
         tracker.log_params(config.__dict__)
     trainer.setup_task_tracker(tracker)
 
-    if config.train_negative_sampler == BUILTIN_LP_UNIFORM_NEG_SAMPLER:
-        dataloader_cls = GSgnnLinkPredictionDataLoader
-    elif config.train_negative_sampler == BUILTIN_LP_JOINT_NEG_SAMPLER:
-        dataloader_cls = GSgnnLPJointNegDataLoader
-    elif config.train_negative_sampler == BUILTIN_LP_INBATCH_JOINT_NEG_SAMPLER:
-        dataloader_cls = GSgnnLPInBatchJointNegDataLoader
-    elif config.train_negative_sampler == BUILTIN_LP_LOCALUNIFORM_NEG_SAMPLER:
-        dataloader_cls = GSgnnLPLocalUniformNegDataLoader
-    elif config.train_negative_sampler == BUILTIN_LP_LOCALJOINT_NEG_SAMPLER:
-        dataloader_cls = GSgnnLPLocalJointNegDataLoader
-    elif config.train_negative_sampler == BUILTIN_LP_ALL_ETYPE_UNIFORM_NEG_SAMPLER:
-        dataloader_cls = GSgnnAllEtypeLinkPredictionDataLoader
-    elif config.train_negative_sampler == BUILTIN_LP_ALL_ETYPE_JOINT_NEG_SAMPLER:
-        dataloader_cls = GSgnnAllEtypeLPJointNegDataLoader
-    elif config.train_negative_sampler == BUILTIN_FAST_LP_UNIFORM_NEG_SAMPLER:
-        dataloader_cls = FastGSgnnLinkPredictionDataLoader
-    elif config.train_negative_sampler == BUILTIN_FAST_LP_JOINT_NEG_SAMPLER:
-        dataloader_cls = FastGSgnnLPJointNegDataLoader
-    elif config.train_negative_sampler == BUILTIN_FAST_LP_LOCALUNIFORM_NEG_SAMPLER:
-        dataloader_cls = FastGSgnnLPLocalUniformNegDataLoader
-    elif config.train_negative_sampler == BUILTIN_FAST_LP_LOCALJOINT_NEG_SAMPLER:
-        dataloader_cls = FastGSgnnLPLocalJointNegDataLoader
-    else:
-        raise ValueError('Unknown negative sampler')
+    dataloader_cls = gs.get_lp_train_sampler(config)
     train_idxs = train_data.get_edge_train_set(config.train_etype)
     dataloader = dataloader_cls(train_data, train_idxs, config.fanout,
                                 config.batch_size, config.num_negative_edges,
@@ -157,16 +109,7 @@ def main(config_args):
                                 num_hard_negs=config.num_train_hard_negatives)
 
     # TODO(zhengda) let's use full-graph inference for now.
-    if config.eval_etypes_negative_dstnode is not None:
-        test_dataloader_cls = GSgnnLinkPredictionPredefinedTestDataLoader
-    elif config.eval_negative_sampler == BUILTIN_LP_UNIFORM_NEG_SAMPLER:
-        test_dataloader_cls = GSgnnLinkPredictionTestDataLoader
-    elif config.eval_negative_sampler == BUILTIN_LP_JOINT_NEG_SAMPLER:
-        test_dataloader_cls = GSgnnLinkPredictionJointTestDataLoader
-    else:
-        raise ValueError('Unknown test negative sampler.'
-            'Supported test negative samplers include '
-            f'[{BUILTIN_LP_UNIFORM_NEG_SAMPLER}, {BUILTIN_LP_JOINT_NEG_SAMPLER}]')
+    test_dataloader_cls = gs.get_lp_eval_sampler(config)
     val_dataloader = None
     test_dataloader = None
     val_idxs = train_data.get_edge_val_set(config.eval_etype)

--- a/python/graphstorm/run/gsgnn_lp/gsgnn_lp.py
+++ b/python/graphstorm/run/gsgnn_lp/gsgnn_lp.py
@@ -94,7 +94,7 @@ def main(config_args):
         tracker.log_params(config.__dict__)
     trainer.setup_task_tracker(tracker)
 
-    dataloader_cls = gs.get_builtin_lp_train_sampler(config)
+    dataloader_cls = gs.get_builtin_lp_train_dataloader_class(config)
     train_idxs = train_data.get_edge_train_set(config.train_etype)
     dataloader = dataloader_cls(train_data, train_idxs, config.fanout,
                                 config.batch_size, config.num_negative_edges,
@@ -109,7 +109,7 @@ def main(config_args):
                                 num_hard_negs=config.num_train_hard_negatives)
 
     # TODO(zhengda) let's use full-graph inference for now.
-    test_dataloader_cls = gs.get_builtin_lp_eval_dataloader(config)
+    test_dataloader_cls = gs.get_builtin_lp_eval_dataloader_class(config)
     val_dataloader = None
     test_dataloader = None
     val_idxs = train_data.get_edge_val_set(config.eval_etype)

--- a/python/graphstorm/run/gsgnn_lp/gsgnn_lp.py
+++ b/python/graphstorm/run/gsgnn_lp/gsgnn_lp.py
@@ -94,7 +94,7 @@ def main(config_args):
         tracker.log_params(config.__dict__)
     trainer.setup_task_tracker(tracker)
 
-    dataloader_cls = gs.get_lp_train_sampler(config)
+    dataloader_cls = gs.get_builtin_lp_train_sampler(config)
     train_idxs = train_data.get_edge_train_set(config.train_etype)
     dataloader = dataloader_cls(train_data, train_idxs, config.fanout,
                                 config.batch_size, config.num_negative_edges,
@@ -109,7 +109,7 @@ def main(config_args):
                                 num_hard_negs=config.num_train_hard_negatives)
 
     # TODO(zhengda) let's use full-graph inference for now.
-    test_dataloader_cls = gs.get_lp_eval_sampler(config)
+    test_dataloader_cls = gs.get_builtin_lp_eval_dataloader(config)
     val_dataloader = None
     test_dataloader = None
     val_idxs = train_data.get_edge_val_set(config.eval_etype)


### PR DESCRIPTION
*Issue #, if available:*
Related to #789 

*Description of changes:*
1. decouple the code of creating decoders from the code of creating built-in models to make the code of creating decoders more reusable. 
2. add `get_builtin_lp_train_dataloader_class` and `get_builtin_lp_eval_dataloader_class` in gsf.py


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
