### PR TITLE
[Multi-task Learning] Refactor graphstorm.model for multi-task learning.

### DIFF
--- a/python/graphstorm/model/__init__.py
+++ b/python/graphstorm/model/__init__.py
@@ -24,12 +24,17 @@ from .gnn import GSgnnModel, GSgnnModelBase, GSOptimizer
 from .gnn import do_full_graph_inference
 from .gnn import do_mini_batch_inference
 from .node_gnn import GSgnnNodeModel, GSgnnNodeModelBase, GSgnnNodeModelInterface
-from .node_gnn import node_mini_batch_gnn_predict, node_mini_batch_predict
+from .node_gnn import (node_mini_batch_gnn_predict,
+                       node_mini_batch_predict,
+                       run_node_mini_batch_predict)
 from .edge_gnn import GSgnnEdgeModel, GSgnnEdgeModelBase, GSgnnEdgeModelInterface
-from .edge_gnn import edge_mini_batch_gnn_predict, edge_mini_batch_predict
+from .edge_gnn import (edge_mini_batch_gnn_predict,
+                       edge_mini_batch_predict,
+                       run_edge_mini_batch_predict)
 from .lp_gnn import (GSgnnLinkPredictionModel,
                      GSgnnLinkPredictionModelBase,
-                     GSgnnLinkPredictionModelInterface)
+                     GSgnnLinkPredictionModelInterface,
+                     run_lp_mini_batch_predict)
 from .rgcn_encoder import RelationalGCNEncoder, RelGraphConvLayer
 from .rgat_encoder import RelationalGATEncoder, RelationalAttLayer
 from .sage_encoder import SAGEEncoder, SAGEConv

--- a/python/graphstorm/model/edge_gnn.py
+++ b/python/graphstorm/model/edge_gnn.py
@@ -313,6 +313,7 @@ def edge_mini_batch_predict(model, emb, loader, return_proba=True, return_label=
     device = model.device
 
     preds, labels = run_edge_mini_batch_predict(decoder,
+                                                emb,
                                                 loader,
                                                 device,
                                                 return_proba,

--- a/python/graphstorm/model/edge_gnn.py
+++ b/python/graphstorm/model/edge_gnn.py
@@ -323,13 +323,13 @@ def edge_mini_batch_predict(model, emb, loader, return_proba=True, return_label=
 
 def run_edge_mini_batch_predict(decoder, emb, loader, device,
                                 return_proba=True, return_label=False):
-    """ Perform mini-batch prediction with the given decoder.
+    """ Perform mini-batch edge prediction with the given decoder.
 
-    This function usually follows full-grain GNN embedding inference. After having
+    This function usually follows full-graph GNN embedding inference. After having
     the GNN embeddings, we need to perform mini-batch computation to make predictions
     on the GNN embeddings.
 
-    Note: caller should call model.eval() before calling this function
+    Note: callers should call model.eval() before calling this function
     and call model.train() after when doing training.
 
     Parameters

--- a/python/graphstorm/model/edge_gnn.py
+++ b/python/graphstorm/model/edge_gnn.py
@@ -322,11 +322,14 @@ def edge_mini_batch_predict(model, emb, loader, return_proba=True, return_label=
 
 def run_edge_mini_batch_predict(decoder, emb, loader, device,
                                 return_proba=True, return_label=False):
-    """ Perform mini-batch prediction using edge decoder
+    """ Perform mini-batch prediction with the given decoder.
 
     This function usually follows full-grain GNN embedding inference. After having
     the GNN embeddings, we need to perform mini-batch computation to make predictions
     on the GNN embeddings.
+
+    Note: caller should call model.eval() before calling this function
+    and call model.train() after when doing training.
 
     Parameters
     ----------

--- a/python/graphstorm/model/edge_gnn.py
+++ b/python/graphstorm/model/edge_gnn.py
@@ -311,6 +311,44 @@ def edge_mini_batch_predict(model, emb, loader, return_proba=True, return_label=
     model.eval()
     decoder = model.decoder
     device = model.device
+
+    preds, labels = run_edge_mini_batch_predict(decoder,
+                                                loader,
+                                                device,
+                                                return_proba,
+                                                return_label)
+    model.train()
+    return preds, labels
+
+def run_edge_mini_batch_predict(decoder, emb, loader, device,
+                                return_proba=True, return_label=False):
+    """ Perform mini-batch prediction using edge decoder
+
+    This function usually follows full-grain GNN embedding inference. After having
+    the GNN embeddings, we need to perform mini-batch computation to make predictions
+    on the GNN embeddings.
+
+    Parameters
+    ----------
+    decoder : GSEdgeDecoder
+        The GraphStorm edge decoder
+    emb : dict of Tensor
+        The GNN embeddings
+    loader : GSgnnEdgeDataLoader
+        The GraphStorm dataloader
+    device: th.device
+        Device used to compute prediction result
+    return_proba: bool
+        Whether to return all the predictions or the maximum prediction
+    return_label : bool
+        Whether or not to return labels
+
+    Returns
+    -------
+    dict of Tensor : GNN prediction results. Return all the results when return_proba is true
+        otherwise return the maximum result.
+    dict of Tensor : labels if return_labels is True
+    """
     data = loader.data
     g = data.g
     preds = {}
@@ -379,7 +417,6 @@ def edge_mini_batch_predict(model, emb, loader, return_proba=True, return_label=
                 append_to_dict(lbl, labels)
     barrier()
 
-    model.train()
     for target_etype, pred in preds.items():
         preds[target_etype] = th.cat(pred)
     if return_label:

--- a/python/graphstorm/model/lp_gnn.py
+++ b/python/graphstorm/model/lp_gnn.py
@@ -137,6 +137,9 @@ def lp_mini_batch_predict(model, emb, loader, device):
         After having the GNN embeddings, we need to perform mini-batch
         computation to make predictions on the GNN embeddings.
 
+        Note: callers should call model.eval() before calling this function
+        and call model.train() after when doing training.
+
         Parameters
         ----------
         model : GSgnnModel
@@ -166,7 +169,7 @@ def run_lp_mini_batch_predict(decoder, emb, loader, device):
         After having the GNN embeddings, we need to perform mini-batch
         computation to make predictions on the GNN embeddings.
 
-        Note: caller should call model.eval() before calling this function
+        Note: callers should call model.eval() before calling this function
         and call model.train() after when doing training.
 
         Parameters

--- a/python/graphstorm/model/lp_gnn.py
+++ b/python/graphstorm/model/lp_gnn.py
@@ -154,6 +154,30 @@ def lp_mini_batch_predict(model, emb, loader, device):
             Rankings of positive scores in format of {etype: ranking}
     """
     decoder = model.decoder
+    return run_lp_mini_batch_predict(decoder,
+                                     emb,
+                                     loader,
+                                     device)
+
+def run_lp_mini_batch_predict(decoder, emb, loader, device):
+    """ Perform mini-batch link prediction.
+
+        Parameters
+        ----------
+        decoder : LinkPredictNoParamDecoder or LinkPredictLearnableDecoder
+            The GraphStorm link prediction decoder model
+        emb : dict of Tensor
+            The GNN embeddings
+        loader : GSgnnEdgeDataLoader
+            The GraphStorm dataloader
+        device: th.device
+            Device used to compute test scores
+
+        Returns
+        -------
+        rankings: dict of tensors
+            Rankings of positive scores in format of {etype: ranking}
+    """
     with th.no_grad():
         ranking = {}
         for pos_neg_tuple, neg_sample_type in loader:

--- a/python/graphstorm/model/lp_gnn.py
+++ b/python/graphstorm/model/lp_gnn.py
@@ -133,7 +133,7 @@ class GSgnnLinkPredictionModel(GSgnnModel, GSgnnLinkPredictionModelInterface):
 def lp_mini_batch_predict(model, emb, loader, device):
     """ Perform mini-batch prediction.
 
-        This function follows full-grain GNN embedding inference.
+        This function follows full-graph GNN embedding inference.
         After having the GNN embeddings, we need to perform mini-batch
         computation to make predictions on the GNN embeddings.
 
@@ -160,7 +160,14 @@ def lp_mini_batch_predict(model, emb, loader, device):
                                      device)
 
 def run_lp_mini_batch_predict(decoder, emb, loader, device):
-    """ Perform mini-batch link prediction.
+    """ Perform mini-batch link prediction with the given decoder.
+
+        This function follows full-graph GNN embedding inference.
+        After having the GNN embeddings, we need to perform mini-batch
+        computation to make predictions on the GNN embeddings.
+
+        Note: caller should call model.eval() before calling this function
+        and call model.train() after when doing training.
 
         Parameters
         ----------

--- a/python/graphstorm/model/node_gnn.py
+++ b/python/graphstorm/model/node_gnn.py
@@ -325,9 +325,9 @@ def node_mini_batch_predict(model, emb, loader, return_proba=True, return_label=
 
 def run_node_mini_batch_predict(decoder, emb, loader, device,
                                 return_proba=True, return_label=False):
-    """ Perform mini-batch prediction with the given decoder.
+    """ Perform mini-batch node prediction with the given decoder.
 
-        Note: caller should call model.eval() before calling this function
+        Note: callers should call model.eval() before calling this function
         and call model.train() after when doing training.
 
     Parameters

--- a/python/graphstorm/model/node_gnn.py
+++ b/python/graphstorm/model/node_gnn.py
@@ -365,11 +365,10 @@ def run_node_mini_batch_predict(decoder, emb, loader, device,
     with th.no_grad():
         for _, seeds, _ in loader: # seeds are target nodes
             for ntype, seed_nodes in seeds.items():
-                if isinstance(model.decoder, th.nn.ModuleDict):
-                    assert ntype in model.decoder, f"Node type {ntype} not in decoder"
-                    decoder = model.decoder[ntype]
-                else:
-                    decoder = model.decoder
+                if isinstance(decoder, th.nn.ModuleDict):
+                    assert ntype in decoder, f"Node type {ntype} not in decoder"
+                    decoder = decoder[ntype]
+
                 if return_proba:
                     pred = decoder.predict_proba(emb[ntype][seed_nodes].to(device))
                 else:

--- a/python/graphstorm/model/node_gnn.py
+++ b/python/graphstorm/model/node_gnn.py
@@ -332,8 +332,9 @@ def run_node_mini_batch_predict(decoder, emb, loader, device,
 
     Parameters
     ----------
-    decoder : GSNodeDecoder
-        The GraphStorm node decoder
+    decoder : GSNodeDecoder or th.nn.ModuleDict
+        The GraphStorm node decoder.
+        It can be a GSNodeDecoder or a dict of GSNodeDecoders
     emb : dict of Tensor
         The GNN embeddings
     loader : GSgnnNodeDataLoader

--- a/tests/unit-tests/test_gnn.py
+++ b/tests/unit-tests/test_gnn.py
@@ -313,10 +313,10 @@ def check_node_prediction(model, data, is_homo=False):
 
     # Test the return_proba argument.
     pred3, labels3 = node_mini_batch_predict(model, embs, dataloader1, return_proba=True, return_label=True)
-    pred3_d, labels3_d = node_mini_batch_predict(model.decoder, embs, dataloader1, model.device, return_proba=True, return_label=True)
+    pred3_d, labels3_d = run_node_mini_batch_predict(model.decoder, embs, dataloader1, model.device, return_proba=True, return_label=True)
 
     pred4, labels4 = node_mini_batch_predict(model, embs, dataloader1, return_proba=False, return_label=True)
-    pred4_d, labels4_d = node_mini_batch_predict(model.decoder, embs, dataloader1, model.device, return_proba=False, return_label=True)
+    pred4_d, labels4_d = run_node_mini_batch_predict(model.decoder, embs, dataloader1, model.device, return_proba=False, return_label=True)
     if isinstance(pred3, dict):
         assert len(pred3) == len(pred4) and len(labels3) == len(labels4)
         assert len(pred3) == len(pred3_d) and len(labels3) == len(labels3_d)
@@ -445,7 +445,7 @@ def check_mlp_node_prediction(model, data):
                                       batch_size=10, label_field='label',
                                       node_feats='feat', train_task=False)
     pred2, _, labels2 = node_mini_batch_gnn_predict(model, dataloader2, return_label=True)
-    pred1_d, labels1_d = node_mini_batch_predict(model.decoder, embs, dataloader1, model.device, return_label=True)
+    pred1_d, labels1_d = run_node_mini_batch_predict(model.decoder, embs, dataloader1, model.device, return_label=True)
     if isinstance(pred1, dict):
         assert len(pred1) == len(pred2) and len(labels1) == len(labels2)
         assert len(pred1) == len(pred1_d) and len(labels1) == len(labels1_d)
@@ -463,8 +463,8 @@ def check_mlp_node_prediction(model, data):
     # Test the return_proba argument.
     pred3, _ = node_mini_batch_predict(model, embs, dataloader1, return_proba=True, return_label=True)
     pred4, _ = node_mini_batch_predict(model, embs, dataloader1, return_proba=False, return_label=True)
-    pred3_d, _ = node_mini_batch_predict(model.decoder, embs, dataloader1, model.device, return_proba=True, return_label=True)
-    pred4_d, _ = node_mini_batch_predict(model.decoder, embs, dataloader1, model.device, return_proba=False, return_label=True)
+    pred3_d, _ = run_node_mini_batch_predict(model.decoder, embs, dataloader1, model.device, return_proba=True, return_label=True)
+    pred4_d, _ = run_node_mini_batch_predict(model.decoder, embs, dataloader1, model.device, return_proba=False, return_label=True)
     if isinstance(pred3, dict):
         assert len(pred3) == len(pred4)
         assert len(pred3) == len(pred3_d)


### PR DESCRIPTION
*Issue #, if available:*
#789 

*Description of changes:*
As multi-task learning trainer will invoke edge_mini_batch_predict, lp_mini_batch_predict and node_mini_batch_predict when conducting evaluation or testing, refactor the code to allow the functions to work with different decoders.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
