### PR TITLE
[Enhancement] Change save new gconstruct configuration file behavior

### DIFF
--- a/docs/source/configuration/configuration-gconstruction.rst
+++ b/docs/source/configuration/configuration-gconstruction.rst
@@ -19,6 +19,7 @@ Graph Construction
 * **-\-skip-nonexist-edges**: boolean value to decide whether skip edges whose endpoint nodes don't exist. Default is true.
 * **-\-ext-mem-workspace**: the directory where the tool can store data during graph construction. Suggest to use high-speed SSD as the external memory workspace.
 * **-\-ext-mem-feat-size**: the minimal number of feature dimensions that features can be stored in external memory. Default is 64.
+* **-\-output-conf-file**: The output file with the updated configurations that records the details of data transformation, e.g., one-hot encoding maps, max-min normalization ranges. If not specified, will save the updated configuration file in the **-\-output-dir** with name `data_transform_new.json`.
 
 .. _gconstruction-json:
 

--- a/python/graphstorm/gconstruct/construct_graph.py
+++ b/python/graphstorm/gconstruct/construct_graph.py
@@ -770,6 +770,9 @@ def process_graph(args):
                           skip_nonexist_edges=args.skip_nonexist_edges)
     sys_tracker.check('Process the edge data')
     num_nodes = {ntype: len(raw_node_id_maps[ntype]) for ntype in raw_node_id_maps}
+
+    os.makedirs(args.output_dir, exist_ok=True)
+
     if args.output_conf_file is not None:
         outfile_path = args.output_conf_file
     else:
@@ -819,7 +822,6 @@ def process_graph(args):
     g = dgl.heterograph(edges, num_nodes_dict=num_nodes)
     print_graph_info(g, node_data, edge_data, node_label_stats, edge_label_stats,
                      node_label_masks, edge_label_masks)
-    os.makedirs(args.output_dir, exist_ok=True)
     sys_tracker.check('Construct DGL graph')
 
     # reshape customized mask

--- a/python/graphstorm/gconstruct/construct_graph.py
+++ b/python/graphstorm/gconstruct/construct_graph.py
@@ -771,9 +771,13 @@ def process_graph(args):
     sys_tracker.check('Process the edge data')
     num_nodes = {ntype: len(raw_node_id_maps[ntype]) for ntype in raw_node_id_maps}
     if args.output_conf_file is not None:
-        # Save the new config file.
-        with open(args.output_conf_file, "w", encoding="utf8") as outfile:
-            json.dump(process_confs, outfile, indent=4)
+        outfile_path = args.output_conf_file
+    else:
+        outfile_path = os.path.join(args.output_dir, 'data_transform_new.json')
+
+    # Save the new config file.
+    with open(outfile_path, "w", encoding="utf8") as outfile:
+        json.dump(process_confs, outfile, indent=4)
 
     if args.add_reverse_edges:
         edges1 = {}

--- a/python/graphstorm/gconstruct/construct_graph.py
+++ b/python/graphstorm/gconstruct/construct_graph.py
@@ -776,7 +776,15 @@ def process_graph(args):
     if args.output_conf_file is not None:
         outfile_path = args.output_conf_file
     else:
-        outfile_path = os.path.join(args.output_dir, 'data_transform_new.json')
+        new_file_name = 'data_transform_new.json'
+        outfile_path = os.path.join(args.output_dir,new_file_name )
+
+    # check if the output configuration file exists. Overwrite it with a warning.
+    if os.path.exists(outfile_path):
+        logging.warning(f'Overwrote the existing {outfile_path} file, which was generated in ' + \
+                        'the previous graph construction command. Use the --output-conf-file ' + \
+                        'argument to specify a different location if not want to overwrite the ' + \
+                        'existing configuration file.')
 
     # Save the new config file.
     with open(outfile_path, "w", encoding="utf8") as outfile:

--- a/python/graphstorm/gconstruct/construct_graph.py
+++ b/python/graphstorm/gconstruct/construct_graph.py
@@ -781,10 +781,10 @@ def process_graph(args):
 
     # check if the output configuration file exists. Overwrite it with a warning.
     if os.path.exists(outfile_path):
-        logging.warning(f'Overwrote the existing {outfile_path} file, which was generated in ' + \
+        logging.warning('Overwrote the existing %s file, which was generated in ' + \
                         'the previous graph construction command. Use the --output-conf-file ' + \
                         'argument to specify a different location if not want to overwrite the ' + \
-                        'existing configuration file.')
+                        'existing configuration file.', outfile_path)
 
     # Save the new config file.
     with open(outfile_path, "w", encoding="utf8") as outfile:


### PR DESCRIPTION
*Issue #796 , if available:*

*Description of changes:*
This PR changed the behavior of saving the new gconstruct configuration file. If users do not specify the `--output-conf-file` argument, we will automatically save it to the `output-dir` folder with the name "data_transform_new.json".
This PR also update the Configuration documents, adding explanations of the `--output-conf-file` argument.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
