### PR TITLE
[Multi-task Learning] Add GSgnnMultiTaskSharedEncoderModel

### DIFF
--- a/python/graphstorm/dataloading/dataloading.py
+++ b/python/graphstorm/dataloading/dataloading.py
@@ -1707,7 +1707,7 @@ class GSgnnMultiTaskDataLoader:
         lens = []
         for task_info, dataloader in zip(task_infos, task_dataloaders):
             # For evaluation and testing, we allow some of the val_dataloaders or test_dataloaders
-            # are empty (None).
+            # to be empty (None).
             assert isinstance(dataloader, (GSgnnEdgeDataLoaderBase,
                                            GSgnnLinkPredictionDataLoaderBase,
                                            GSgnnNodeDataLoaderBase)) or dataloader is None, \
@@ -1812,7 +1812,7 @@ class GSgnnMultiTaskDataLoader:
 
         Returns
         -------
-        list or a dict of list : the fanouts for each GNN layer.
+        list of list or list of dict of list : the fanouts for each GNN layer.
         """
         fanouts = [dataloader.fanout if dataloader is not None \
                    else None for dataloader in self.dataloaders]

--- a/python/graphstorm/dataloading/dataloading.py
+++ b/python/graphstorm/dataloading/dataloading.py
@@ -1814,7 +1814,8 @@ class GSgnnMultiTaskDataLoader:
         -------
         list or a dict of list : the fanouts for each GNN layer.
         """
-        fanouts = [dataloader.fanout if dataloader is not None else None for dataloader in self.dataloaders]
+        fanouts = [dataloader.fanout if dataloader is not None \
+                   else None for dataloader in self.dataloaders]
         return fanouts
 
 

--- a/python/graphstorm/dataloading/dataloading.py
+++ b/python/graphstorm/dataloading/dataloading.py
@@ -1706,12 +1706,15 @@ class GSgnnMultiTaskDataLoader:
         # check dataloaders
         lens = []
         for task_info, dataloader in zip(task_infos, task_dataloaders):
+            # For evaluation and testing, we allow some of the val_dataloaders or test_dataloaders
+            # are empty (None).
             assert isinstance(dataloader, (GSgnnEdgeDataLoaderBase,
                                            GSgnnLinkPredictionDataLoaderBase,
-                                           GSgnnNodeDataLoaderBase)), \
+                                           GSgnnNodeDataLoaderBase)) or dataloader is None, \
                 "The task data loader should be an instance of GSgnnEdgeDataLoaderBase, " \
-                "GSgnnLinkPredictionDataLoaderBase or GSgnnNodeDataLoaderBase"
-            num_iters = len(dataloader)
+                "GSgnnLinkPredictionDataLoaderBase or GSgnnNodeDataLoaderBase" \
+                f"But get {type(dataloader)}"
+            num_iters = len(dataloader) if dataloader is not None else 0
             lens.append(num_iters)
             logging.debug("Task %s has number of iterations of %d",
                           task_info, num_iters)
@@ -1728,7 +1731,8 @@ class GSgnnMultiTaskDataLoader:
         """ reset the dataloaders
         """
         for dataloader in self._dataloaders:
-            iter(dataloader)
+            if dataloader is not None:
+                iter(dataloader)
         self._num_iters = 0
 
     def __iter__(self):
@@ -1747,6 +1751,19 @@ class GSgnnMultiTaskDataLoader:
         # call __next__ of each dataloader
         mini_batches = []
         for task_info, dataloader in zip(self._task_infos, self._dataloaders):
+            if dataloader is None:
+                # The dataloader is None
+                logging.warning("The dataloader of %s is None. "
+                                "Please check whether the coresponding "
+                                "train/val/test mask(s) are missing."
+                                "If you are calling iter(mt_dataloader) for validation "
+                                "or testing, we suggest you to use "
+                                "mt_dataloader.dataloaders to get task specific "
+                                "dataloaders and call the corresponding evaluators "
+                                "task by task", task_info.task_id)
+                mini_batches.append((task_info, None))
+                continue
+
             try:
                 mini_batch = next(dataloader)
             except StopIteration:
@@ -1788,6 +1805,17 @@ class GSgnnMultiTaskDataLoader:
         """
         # useful for conducting validation scores and test scores.
         return self._task_infos
+
+    @property
+    def fanout(self):
+        """ The fanout of each GNN layers of each dataloader
+
+        Returns
+        -------
+        list or a dict of list : the fanouts for each GNN layer.
+        """
+        fanouts = [dataloader.fanout if dataloader is not None else None for dataloader in self.dataloaders]
+        return fanouts
 
 
 ####################### Distillation #############################

--- a/python/graphstorm/model/__init__.py
+++ b/python/graphstorm/model/__init__.py
@@ -35,6 +35,9 @@ from .lp_gnn import (GSgnnLinkPredictionModel,
                      GSgnnLinkPredictionModelBase,
                      GSgnnLinkPredictionModelInterface,
                      run_lp_mini_batch_predict)
+from .multitask_gnn import (GSgnnMultiTaskModelInterface,
+                            GSgnnMultiTaskSharedEncoderModel)
+from .multitask_gnn import multi_task_mini_batch_predict
 from .rgcn_encoder import RelationalGCNEncoder, RelGraphConvLayer
 from .rgat_encoder import RelationalGATEncoder, RelationalAttLayer
 from .sage_encoder import SAGEEncoder, SAGEConv

--- a/python/graphstorm/model/multitask_gnn.py
+++ b/python/graphstorm/model/multitask_gnn.py
@@ -1,0 +1,335 @@
+"""
+    Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+    Licensed under the Apache License, Version 2.0 (the "License").
+    You may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+    GNN model for multi-task learning in GraphStorm
+"""
+import abc
+import logging
+import torch as th
+from torch import nn
+
+from ..config import (BUILTIN_TASK_NODE_CLASSIFICATION,
+                      BUILTIN_TASK_NODE_REGRESSION,
+                      BUILTIN_TASK_EDGE_CLASSIFICATION,
+                      BUILTIN_TASK_EDGE_REGRESSION,
+                      BUILTIN_TASK_LINK_PREDICTION)
+from .gnn import GSgnnModel
+
+
+from .node_gnn import run_node_mini_batch_predict
+from .edge_gnn import run_edge_mini_batch_predict
+from .lp_gnn import run_lp_mini_batch_predict
+
+
+class GSgnnMultiTaskModelInterface:
+    """ The interface for GraphStorm multi-task learning.
+
+    This interface defines two main methods for training and inference.
+    """
+    @abc.abstractmethod
+    def forward(self, task_id, mini_batch):
+        """ The forward function for multi-task learning
+
+        This method is used for training, It runs model forword
+        on a mini-batch for one task at a time.
+        The loss of the model in the mini-batch is returned.
+
+        Parameters
+        ----------
+        task_id: str
+            ID of the task.
+        mini_batch: tuple
+            Mini-batch info
+
+
+        Return
+        ------
+        The loss of prediction.
+        """
+
+    @abc.abstractmethod
+    def predict(self, task_info, mini_batch):
+        """ The forward function for multi-task prediction.
+
+        This method is used for inference, It runs model forword
+        on a mini-batch for one task at a time.
+        The prediction result is returned.
+
+        Parameters
+        ----------
+        task_info: TaskInfo
+            task meta information
+        mini_batch: tuple
+            mini-batch info
+
+        Returns
+        -------
+        Tensor or dict of Tensor:
+            the prediction results.
+        """
+
+class GSgnnMultiTaskSharedEncoderModel(GSgnnModel, GSgnnMultiTaskModelInterface):
+    """ GraphStorm GNN model for multi-task learning
+    with a shared encoder model and separate decoder models.
+
+    Parameters
+    ----------
+    alpha_l2norm : float
+        The alpha for L2 normalization.
+    """
+    def __init__(self, alpha_l2norm):
+        super(GSgnnMultiTaskSharedEncoderModel, self).__init__()
+        self._alpha_l2norm = alpha_l2norm
+        self._task_pool = {}
+        self._decoder = nn.ModuleDict()
+
+    def add_task(self, task_id, task_type,
+                 decoder, loss_func):
+        """ Add a task into the multi-task pool
+
+        Parameters
+        ----------
+        task_id: str
+            Task ID.
+        task_type: str
+            Task type.
+        decoder: GSNodeDecoder or
+                 GSEdgeDecoder or
+                 LinkPredictNoParamDecoder or
+                 LinkPredictLearnableDecoder
+            Task decoder.
+        loss_func: func
+            Loss function.
+        """
+        assert task_id not in self._task_pool, \
+            f"Task {task_id} already exists"
+        logging.info("Setup task %s", task_id)
+        self._task_pool[task_id] = (task_type, loss_func)
+        self._decoder[task_id] = decoder
+
+    @property
+    def alpha_l2norm(self):
+        """Get parameter norm params
+        """
+        return self._alpha_l2norm
+
+    @property
+    def task_pool(self):
+        """ Get task pool
+        """
+        return self._task_pool
+
+    @property
+    def task_decoders(self):
+        """ Get task decoders
+        """
+        return self._decoder
+
+    # pylint: disable=unused-argument
+    def forward(self, task_id, mini_batch):
+        """ The forward function for multi-task learning
+        """
+        assert task_id in self.task_pool, \
+            f"Unknown task: {task_id} in multi-task learning." \
+            f"Existing tasks are {self.task_pool.keys()}"
+
+        encoder_data, decoder_data = mini_batch
+        # message passing graph, node features, edge features, seed nodes
+        blocks, node_feats, _, input_nodes = encoder_data
+        if blocks is None or len(blocks) == 0:
+            # no GNN message passing
+            encode_embs = self.comput_input_embed(input_nodes, node_feats)
+        else:
+            # GNN message passing
+            encode_embs = self.compute_embed_step(blocks, node_feats, input_nodes)
+
+        # Call emb normalization.
+        encode_embs = self.normalize_node_embs(encode_embs)
+
+        task_type, loss_func = self.task_pool[task_id]
+        task_decoder = self.decoder[task_id]
+
+        if task_type in [BUILTIN_TASK_NODE_CLASSIFICATION, BUILTIN_TASK_NODE_REGRESSION]:
+            labels = decoder_data
+            assert len(labels) == 1, \
+                "In multi-task learning, only support do prediction " \
+                "on one node type for a single node task."
+            pred_loss = 0
+            target_ntype = list(labels.keys())[0]
+
+            assert target_ntype in encode_embs, f"Node type {target_ntype} not in encode_embs"
+            assert target_ntype in labels, f"Node type {target_ntype} not in labels"
+            emb = encode_embs[target_ntype]
+            ntype_labels = labels[target_ntype]
+            ntype_logits = task_decoder(emb)
+            pred_loss = loss_func(ntype_logits, ntype_labels)
+
+            return pred_loss
+        elif task_type in [BUILTIN_TASK_EDGE_CLASSIFICATION, BUILTIN_TASK_EDGE_REGRESSION]:
+            batch_graph, target_edge_feats, labels = decoder_data
+            assert len(labels) == 1, \
+                "In multi-task learning, only support do prediction " \
+                "on one edge type for a single edge task."
+            pred_loss = 0
+            target_etype = list(labels.keys())[0]
+            logits = task_decoder(batch_graph, encode_embs, target_edge_feats)
+            pred_loss = loss_func(logits, labels[target_etype])
+
+            return pred_loss
+        elif task_type == BUILTIN_TASK_LINK_PREDICTION:
+            pos_graph, neg_graph, pos_edge_feats, neg_edge_feats = decoder_data
+
+            pos_score = task_decoder(pos_graph, encode_embs, pos_edge_feats)
+            neg_score = task_decoder(neg_graph, encode_embs, neg_edge_feats)
+            assert pos_score.keys() == neg_score.keys(), \
+                "Positive scores and Negative scores must have edges of same" \
+                f"edge types, but get {pos_score.keys()} and {neg_score.keys()}"
+            pred_loss = loss_func(pos_score, neg_score)
+            return pred_loss
+        else:
+            raise TypeError("Unknow task type %s", task_type)
+
+
+    def predict(self, task_id, mini_batch, return_proba=False):
+        """ The forward function for multi-task inference
+        """
+        assert task_id in self.task_pool, \
+            f"Unknown task: {task_id} in multi-task learning." \
+            f"Existing tasks are {self.task_pool.keys()}"
+
+        encoder_data, decoder_data = mini_batch
+        # message passing graph, node features, edge features, seed nodes
+        blocks, node_feats, _, input_nodes = encoder_data
+        if blocks is None or len(blocks) == 0:
+            # no GNN message passing
+            encode_embs = self.comput_input_embed(input_nodes, node_feats)
+        else:
+            # GNN message passing
+            encode_embs = self.compute_embed_step(blocks, node_feats, input_nodes)
+
+        # Call emb normalization.
+        encode_embs = self.normalize_node_embs(encode_embs)
+
+        task_type, _ = self.task_pool[task_id]
+        task_decoder = self.decoder[task_id]
+
+        if task_type in [BUILTIN_TASK_NODE_CLASSIFICATION, BUILTIN_TASK_NODE_REGRESSION]:
+            assert len(encode_embs) == 1, \
+                "In multi-task learning, only support do prediction " \
+                "on one node type for a single node task."
+            target_ntype = list(encode_embs.keys())[0]
+            predicts = {}
+            if return_proba:
+                predicts[target_ntype] = task_decoder.predict_proba(encode_embs[target_ntype])
+            else:
+                predicts[target_ntype] = task_decoder.predict(encode_embs[target_ntype])
+            return predicts
+        elif task_type in [BUILTIN_TASK_EDGE_CLASSIFICATION, BUILTIN_TASK_EDGE_REGRESSION]:
+            batch_graph, target_edge_feats, _ = decoder_data
+            if return_proba:
+                return task_decoder.predict_proba(batch_graph, encode_embs, target_edge_feats)
+            return task_decoder.predict(batch_graph, encode_embs, target_edge_feats)
+        elif task_type == BUILTIN_TASK_LINK_PREDICTION:
+            logging.warning("Prediction for link prediction is not implemented")
+            return None
+        else:
+            raise TypeError("Unknow task type %s", task_type)
+
+def multi_task_mini_batch_predict(
+    model, emb, loader, device, return_proba=True, return_label=False):
+    """ conduct mini batch prediction on multiple tasks
+
+    Parameters
+    ----------
+    model: GSgnnMultiTaskModelInterface, GSgnnModel
+        Multi-task learning model
+    emb : dict of Tensor
+        The GNN embeddings
+    loader: GSgnnMultiTaskDataLoader
+        The mini-batch dataloader.
+    device: th.device
+        Device used to compute test scores.
+    return_proba: bool
+        Whether to return all the predictions or the maximum prediction.
+    return_label : bool
+        Whether or not to return labels.
+
+    Returns
+    -------
+    dict: prediction results of each task
+    """
+    dataloaders = loader.dataloaders
+    task_infos = loader.task_infos
+    task_decoders = model.task_decoders
+    res = {}
+    with th.no_grad():
+        for dataloader, task_info in zip(dataloaders, task_infos):
+            if task_info.task_type in \
+            [BUILTIN_TASK_NODE_CLASSIFICATION, BUILTIN_TASK_NODE_REGRESSION]:
+                if dataloader is None:
+                    # In cases when there is no validation or test set.
+                    # set pred and labels to None
+                    res[task_info.task_id] = (None, None)
+                else:
+                    decoder = task_decoders[task_info.task_id]
+                    preds, labels = \
+                        run_node_mini_batch_predict(decoder,
+                                                    emb,
+                                                    dataloader,
+                                                    device,
+                                                    return_proba,
+                                                    return_label)
+                    assert labels is None or len(labels) == 1, \
+                        "In multi-task learning, for each training task, " \
+                        "we only support prediction on one node type." \
+                        "For multiple node types, please treat them as " \
+                        "different training tasks."
+                    ntype = list(preds.keys())[0]
+                    res[task_info.task_id] = (preds[ntype], labels[ntype] if labels is not None else None)
+            elif task_info.task_type in \
+            [BUILTIN_TASK_EDGE_CLASSIFICATION, BUILTIN_TASK_EDGE_REGRESSION]:
+                if dataloader is None:
+                    # In cases when there is no validation or test set.
+                    # set pred and labels to None
+                    res[task_info.task_id] = (None, None)
+                else:
+                    decoder = task_decoders[task_info.task_id]
+                    preds, labels = \
+                        run_edge_mini_batch_predict(decoder,
+                                                    emb,
+                                                    dataloader,
+                                                    device,
+                                                    return_proba,
+                                                    return_label)
+                    assert labels is None or len(labels) == 1, \
+                        "In multi-task learning, for each training task, " \
+                        "we only support prediction on one edge type." \
+                        "For multiple edge types, please treat them as " \
+                        "different training tasks."
+                    etype = list(preds.keys())[0]
+                    res[task_info.task_id] = (preds[etype], labels[etype] if labels is not None else None)
+            elif task_info.task_type == BUILTIN_TASK_LINK_PREDICTION:
+                if dataloader is None:
+                    # In cases when there is no validation or test set.
+                    res[task_info.task_id] = None
+                else:
+                    decoder = task_decoders[task_info.task_id]
+                    ranking = run_lp_mini_batch_predict(decoder, emb, dataloader, device)
+                    res[task_info.task_id] = ranking
+            else:
+                raise TypeError("Unknown task %s", task_info)
+
+    return res
+

--- a/python/graphstorm/model/multitask_gnn.py
+++ b/python/graphstorm/model/multitask_gnn.py
@@ -39,7 +39,7 @@ class GSgnnMultiTaskModelInterface:
     This interface defines two main methods for training and inference.
     """
     @abc.abstractmethod
-    def forward(self, task_id, mini_batch):
+    def forward(self, task_mini_batches):
         """ The forward function for multi-task learning
 
         This method is used for training, It runs model forword
@@ -48,11 +48,8 @@ class GSgnnMultiTaskModelInterface:
 
         Parameters
         ----------
-        task_id: str
-            ID of the task.
-        mini_batch: tuple
-            Mini-batch info.
-
+        task_mini_batches: list
+            Mini-batches.
 
         Return
         ------
@@ -166,7 +163,7 @@ class GSgnnMultiTaskSharedEncoderModel(GSgnnModel, GSgnnMultiTaskModelInterface)
                                  (blocks, node_feats, edge_feats, input_nodes),
                                  (pos_graph, neg_graph, pos_edge_feats, neg_edge_feats))
         else:
-            raise TypeError("Unknown task %s", task_info)
+            raise TypeError(f"Unknown task {task_info}")
 
         return loss, task_info.task_config.task_weight
 

--- a/python/graphstorm/model/multitask_gnn.py
+++ b/python/graphstorm/model/multitask_gnn.py
@@ -79,7 +79,7 @@ class GSgnnMultiTaskModelInterface:
 
 class GSgnnMultiTaskSharedEncoderModel(GSgnnModel, GSgnnMultiTaskModelInterface):
     """ GraphStorm GNN model for multi-task learning
-    with a shared encoder model and separate decoder models.
+    with a shared encoder model and separate decoder models for each task.
 
     Parameters
     ----------
@@ -135,7 +135,7 @@ class GSgnnMultiTaskSharedEncoderModel(GSgnnModel, GSgnnMultiTaskModelInterface)
         return self._decoder
 
     def _run_mini_batch(self, task_info, mini_batch):
-        """ Run mini_batch forward
+        """ Run mini_batch forward.
         """
         if task_info.task_type in \
             [BUILTIN_TASK_NODE_CLASSIFICATION, BUILTIN_TASK_NODE_REGRESSION]:
@@ -168,6 +168,10 @@ class GSgnnMultiTaskSharedEncoderModel(GSgnnModel, GSgnnMultiTaskModelInterface)
         return loss, task_info.task_config.task_weight
 
     def forward(self, task_mini_batches):
+        """ The forward function for multi-task learning
+            It will iterate over the mini-batches and call
+            forward for each task.
+        """
         losses = []
         for (task_info, mini_batch) in task_mini_batches:
             loss, weight = self._run_mini_batch(task_info, mini_batch)
@@ -185,7 +189,17 @@ class GSgnnMultiTaskSharedEncoderModel(GSgnnModel, GSgnnMultiTaskModelInterface)
 
     # pylint: disable=unused-argument
     def _forward(self, task_id, encoder_data, decoder_data):
-        """ The forward function for multi-task learning
+        """ The forward function to run forward for a specific
+            task with task_id.
+
+        Parameters
+        ----------
+        task_id: str
+            Task ID.
+        encoder_data: tuple
+            The input data for the encoder.
+        decoder_data: tuple
+            The input for the decoder.
         """
         assert task_id in self.task_pool, \
             f"Unknown task: {task_id} in multi-task learning." \

--- a/python/graphstorm/model/multitask_gnn.py
+++ b/python/graphstorm/model/multitask_gnn.py
@@ -51,7 +51,7 @@ class GSgnnMultiTaskModelInterface:
         task_id: str
             ID of the task.
         mini_batch: tuple
-            Mini-batch info
+            Mini-batch info.
 
 
         Return
@@ -60,7 +60,7 @@ class GSgnnMultiTaskModelInterface:
         """
 
     @abc.abstractmethod
-    def predict(self, task_info, mini_batch):
+    def predict(self, task_id, mini_batch):
         """ The forward function for multi-task prediction.
 
         This method is used for inference, It runs model forword
@@ -69,10 +69,10 @@ class GSgnnMultiTaskModelInterface:
 
         Parameters
         ----------
-        task_info: TaskInfo
-            task meta information
+        task_id: str
+            Task ID.
         mini_batch: tuple
-            mini-batch info
+            Mini-batch info.
 
         Returns
         -------
@@ -199,8 +199,7 @@ class GSgnnMultiTaskSharedEncoderModel(GSgnnModel, GSgnnMultiTaskModelInterface)
             pred_loss = loss_func(pos_score, neg_score)
             return pred_loss
         else:
-            raise TypeError("Unknow task type %s", task_type)
-
+            raise TypeError(f"Unknow task type {task_type}")
 
     def predict(self, task_id, mini_batch, return_proba=False):
         """ The forward function for multi-task inference
@@ -245,7 +244,7 @@ class GSgnnMultiTaskSharedEncoderModel(GSgnnModel, GSgnnMultiTaskModelInterface)
             logging.warning("Prediction for link prediction is not implemented")
             return None
         else:
-            raise TypeError("Unknow task type %s", task_type)
+            raise TypeError(f"Unknow task type {task_type}")
 
 def multi_task_mini_batch_predict(
     model, emb, loader, device, return_proba=True, return_label=False):
@@ -297,7 +296,8 @@ def multi_task_mini_batch_predict(
                         "For multiple node types, please treat them as " \
                         "different training tasks."
                     ntype = list(preds.keys())[0]
-                    res[task_info.task_id] = (preds[ntype], labels[ntype] if labels is not None else None)
+                    res[task_info.task_id] = (preds[ntype], labels[ntype] \
+                        if labels is not None else None)
             elif task_info.task_type in \
             [BUILTIN_TASK_EDGE_CLASSIFICATION, BUILTIN_TASK_EDGE_REGRESSION]:
                 if dataloader is None:
@@ -319,7 +319,8 @@ def multi_task_mini_batch_predict(
                         "For multiple edge types, please treat them as " \
                         "different training tasks."
                     etype = list(preds.keys())[0]
-                    res[task_info.task_id] = (preds[etype], labels[etype] if labels is not None else None)
+                    res[task_info.task_id] = (preds[etype], labels[etype] \
+                        if labels is not None else None)
             elif task_info.task_type == BUILTIN_TASK_LINK_PREDICTION:
                 if dataloader is None:
                     # In cases when there is no validation or test set.
@@ -329,7 +330,6 @@ def multi_task_mini_batch_predict(
                     ranking = run_lp_mini_batch_predict(decoder, emb, dataloader, device)
                     res[task_info.task_id] = ranking
             else:
-                raise TypeError("Unknown task %s", task_info)
+                raise TypeError(f"Unknown task {task_info}")
 
     return res
-

--- a/tests/unit-tests/test_gnn.py
+++ b/tests/unit-tests/test_gnn.py
@@ -77,8 +77,8 @@ from graphstorm.model.gnn_with_reconstruct import construct_node_feat, get_input
 from graphstorm.model.utils import load_model, save_model
 from graphstorm.model import GSgnnMultiTaskSharedEncoderModel
 from graphstorm.dataloading import (GSgnnEdgeDataLoaderBase,
-                                         GSgnnLinkPredictionDataLoaderBase,
-                                         GSgnnNodeDataLoaderBase)
+                                    GSgnnLinkPredictionDataLoaderBase,
+                                    GSgnnNodeDataLoaderBase)
 
 from data_utils import generate_dummy_dist_graph, generate_dummy_dist_graph_multi_target_ntypes
 from data_utils import generate_dummy_dist_graph_reconstruct

--- a/tests/unit-tests/test_gnn.py
+++ b/tests/unit-tests/test_gnn.py
@@ -1832,8 +1832,7 @@ def test_multi_task_forward():
         blocks = None
         input_nodes = {"n0": th.randint(5, (10,))}
         labels = {"n0": th.randint(5, (10,))}
-        mini_batch = ((blocks, None, None, input_nodes), labels)
-        loss = mt_model(task_id, mini_batch)
+        loss = mt_model._forward(task_id, (blocks, None, None, input_nodes), labels)
         assert_equal(loss.numpy(), (input_nodes["n0"]-labels["n0"]).numpy())
 
         # NR task
@@ -1841,8 +1840,7 @@ def test_multi_task_forward():
         blocks = None
         input_nodes = {"n0": th.rand((10,))}
         labels = {"n0": th.rand((10,))}
-        mini_batch = ((blocks, None, None, input_nodes), labels)
-        loss = mt_model(task_id, mini_batch)
+        loss = mt_model._forward(task_id, (blocks, None, None, input_nodes), labels)
         assert_equal(loss.numpy(), (input_nodes["n0"]-labels["n0"]).numpy())
 
         # EC task
@@ -1850,8 +1848,7 @@ def test_multi_task_forward():
         blocks = None
         input_nodes = {"n0": th.randint(5, (10,))}
         labels = {("n0", "r1", "n1"): th.randint(5, (10,))}
-        mini_batch = ((blocks, None, None, input_nodes), (None, None, labels))
-        loss = mt_model(task_id, mini_batch)
+        loss = mt_model._forward(task_id, (blocks, None, None, input_nodes), (None, None, labels))
         assert_equal(loss.numpy(), (input_nodes["n0"]-labels[("n0", "r1", "n1")]).numpy())
 
         # ER task
@@ -1859,16 +1856,14 @@ def test_multi_task_forward():
         blocks = None
         input_nodes = {"n0": th.rand((10,))}
         labels = {("n0", "r1", "n1"): th.rand((10,))}
-        mini_batch = ((blocks, None, None, input_nodes), (None, None, labels))
-        loss = mt_model(task_id, mini_batch)
+        loss = mt_model._forward(task_id, (blocks, None, None, input_nodes), (None, None, labels))
         assert_equal(loss.numpy(), (input_nodes["n0"]*2-labels[("n0", "r1", "n1")]).numpy())
 
         # LP task
         task_id = "lp_task"
         blocks = None
         input_nodes = {"n0": th.rand((10,))}
-        mini_batch = mini_batch = ((blocks, None, None, input_nodes), (None, None, None, None))
-        loss = mt_model(task_id, mini_batch)
+        loss = mt_model._forward(task_id, (blocks, None, None, input_nodes), (None, None, None, None))
         assert_equal(loss.numpy(), (input_nodes["n0"]*2).numpy())
 
         ### blocks is a list (GNN setting)
@@ -1877,8 +1872,7 @@ def test_multi_task_forward():
         blocks = [None, None] # trick mt_model there are two gnn layers.
         input_nodes = {"n0": th.randint(5, (10,))}
         labels = {"n0": th.randint(5, (10,))}
-        mini_batch = ((blocks, None, None, input_nodes), labels)
-        loss = mt_model(task_id, mini_batch)
+        loss = mt_model._forward(task_id, (blocks, None, None, input_nodes), labels)
         assert_equal(loss.numpy(), (input_nodes["n0"]-labels["n0"]).numpy())
 
         # NR task
@@ -1886,8 +1880,7 @@ def test_multi_task_forward():
         blocks = [None, None] # trick mt_model there are two gnn layers.
         input_nodes = {"n0": th.rand((10,))}
         labels = {"n0": th.rand((10,))}
-        mini_batch = ((blocks, None, None, input_nodes), labels)
-        loss = mt_model(task_id, mini_batch)
+        loss = mt_model._forward(task_id, (blocks, None, None, input_nodes), labels)
         assert_equal(loss.numpy(), (input_nodes["n0"]-labels["n0"]).numpy())
 
         # EC task
@@ -1895,8 +1888,7 @@ def test_multi_task_forward():
         blocks = [None, None] # trick mt_model there are two gnn layers.
         input_nodes = {"n0": th.randint(5, (10,))}
         labels = {("n0", "r1", "n1"): th.randint(5, (10,))}
-        mini_batch = ((blocks, None, None, input_nodes), (None, None, labels))
-        loss = mt_model(task_id, mini_batch)
+        loss = mt_model._forward(task_id, (blocks, None, None, input_nodes), (None, None, labels))
         assert_equal(loss.numpy(), (input_nodes["n0"]-labels[("n0", "r1", "n1")]).numpy())
 
         # ER task
@@ -1904,16 +1896,14 @@ def test_multi_task_forward():
         blocks = [None, None] # trick mt_model there are two gnn layers.
         input_nodes = {"n0": th.rand((10,))}
         labels = {("n0", "r1", "n1"): th.rand((10,))}
-        mini_batch = ((blocks, None, None, input_nodes), (None, None, labels))
-        loss = mt_model(task_id, mini_batch)
+        loss = mt_model._forward(task_id, (blocks, None, None, input_nodes), (None, None, labels))
         assert_equal(loss.numpy(), (input_nodes["n0"]*2-labels[("n0", "r1", "n1")]).numpy())
 
         # LP task
         task_id = "lp_task"
         blocks = [None, None] # trick mt_model there are two gnn layers.
         input_nodes = {"n0": th.rand((10,))}
-        mini_batch = mini_batch = ((blocks, None, None, input_nodes), (None, None, None, None))
-        loss = mt_model(task_id, mini_batch)
+        loss = mt_model._forward(task_id, (blocks, None, None, input_nodes), (None, None, None, None))
         assert_equal(loss.numpy(), (input_nodes["n0"]*2).numpy())
 
 


### PR DESCRIPTION
*Issue #, if available:*
#789 

*Description of changes:*
GSgnnMultiTaskSharedEncoderModel allows multiple tasks to share the same GNN encoder but have separate decoders for each task.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
