### PR TITLE
[Doc] Fix notebook 2 is not listed in index page issue

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -44,6 +44,7 @@ Welcome to the GraphStorm Documentation and Tutorials
 
    notebooks/Notebook_0_Data_Prepare
    notebooks/Notebook_1_NC_Pipeline
+   notebooks/Notebook_2_LP_Pipeline
 
 .. toctree::
    :maxdepth: 1


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This PR add the link in the document index page to let the new API example Notebook 2 appear in the menu bar. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
