### PR TITLE
Relax the train/val/test mask check for multi-task learning

### DIFF
--- a/python/graphstorm/gconstruct/construct_graph.py
+++ b/python/graphstorm/gconstruct/construct_graph.py
@@ -710,6 +710,8 @@ def print_graph_info(g, node_data, edge_data, node_label_stats, edge_label_stats
                 logging.info("Train/val/test on %s with mask %s, %s, %s: %d, %d, %d",
                             ntype, train_mask, val_mask, test_mask,
                             num_train, num_val, num_test)
+                logging.info("Note: Custom train, validate, test mask "
+                             "information for nodes are not collected.")
     for etype in edge_data:
         feat_names = list(edge_data[etype].keys())
         logging.info("Edge type %s has features: %s.", str(etype), str(feat_names))
@@ -726,6 +728,8 @@ def print_graph_info(g, node_data, edge_data, node_label_stats, edge_label_stats
                 logging.info("Train/val/test on %s with mask %s, %s, %s: %d, %d, %d",
                             str(etype), train_mask, val_mask, test_mask,
                             num_train, num_val, num_test)
+                logging.info("Note: Custom train, validate, test mask "
+                             "information for edges are not collected.")
 
     for ntype in node_label_stats:
         for label_name, stats in node_label_stats[ntype].items():

--- a/python/graphstorm/gconstruct/transform.py
+++ b/python/graphstorm/gconstruct/transform.py
@@ -1823,12 +1823,13 @@ def parse_label_ops(confs, is_node):
             # But there can be exceptions as users want to
             # provide masks through node features or
             # some tasks are sharing the same mask.
-            logging.warning(f"Some train/val/test mask field "
-                            "names are duplicated, please check: {mask_names}."
+            logging.warning("Some train/val/test mask field "
+                            "names are duplicated, please check: %s."
                             "If you provide masks as node/edge features,"
                             "please ignore this warning."
                             "If you share train/val/test mask fields "
-                            "across different tasks, please ignore this warning.")
+                            "across different tasks, please ignore this warning.",
+                            mask_names)
 
     return label_ops
 

--- a/python/graphstorm/gconstruct/transform.py
+++ b/python/graphstorm/gconstruct/transform.py
@@ -1817,8 +1817,18 @@ def parse_label_ops(confs, is_node):
             mask_names.append(ops.train_mask_name)
             mask_names.append(ops.val_mask_name)
             mask_names.append(ops.test_mask_name)
-        assert len(mask_names) == len(set(mask_names)), \
-            f"Some train/val/test mask field names are duplicated, please check: {mask_names}."
+        if len(mask_names) == len(set(mask_names)):
+            # In multi-task learning, we expect each task has
+            # its own train, validation and test mask fields.
+            # But there can be exceptions as users want to
+            # provide masks through node features or
+            # some tasks are sharing the same mask.
+            logging.warning(f"Some train/val/test mask field "
+                            "names are duplicated, please check: {mask_names}."
+                            "If you provide masks as node/edge features,"
+                            "please ignore this warning."
+                            "If you share train/val/test mask fields "
+                            "across different tasks, please ignore this warning.")
 
     return label_ops
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
The original train/val/test mask fields check is too strict. As there can be some exception when users want to provide masks through node features or some tasks are sharing the same mask.

Relax the check and turn the assertion into warning.




By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
