### PR TITLE
[Bugfix] Fix eval_fanout of validation dataloader for lp task in multi-task learning

### DIFF
--- a/.github/workflow_scripts/e2e_mgpu_check.sh
+++ b/.github/workflow_scripts/e2e_mgpu_check.sh
@@ -1,7 +1,7 @@
 # Move to parent directory
 cd ../../
 
-pip install --no-cache-dir --extra-index-url https://pypi.nvidia.com pylibwholegraph-cu11
+pip install --no-cache-dir --extra-index-url https://pypi.nvidia.com pylibwholegraph-cu11==24.4.0
 
 set -ex
 

--- a/python/graphstorm/dataloading/dataloading.py
+++ b/python/graphstorm/dataloading/dataloading.py
@@ -1280,10 +1280,10 @@ class GSgnnLinkPredictionTestDataLoader(GSgnnLinkPredictionDataLoaderBase):
         return cur_iter, self._neg_sample_type
 
     def __len__(self):
-        num_samples = 0
+        num_iters = 0
         for _, test_size in self._fixed_test_size.items():
-            num_samples += math.ceil(test_size / self._batch_size)
-        return num_samples
+            num_iters += math.ceil(test_size / self._batch_size)
+        return num_iters
 
     @property
     def fanout(self):

--- a/python/graphstorm/dataloading/dataloading.py
+++ b/python/graphstorm/dataloading/dataloading.py
@@ -1279,6 +1279,12 @@ class GSgnnLinkPredictionTestDataLoader(GSgnnLinkPredictionDataLoaderBase):
         # return pos, neg pairs
         return cur_iter, self._neg_sample_type
 
+    def __len__(self):
+        num_samples = 0
+        for _, test_size in self._fixed_test_size.items():
+            num_samples += math.ceil(test_size / self._batch_size)
+        return num_samples
+
     @property
     def fanout(self):
         """ Get eval fanout

--- a/python/graphstorm/run/gsgnn_mt/gsgnn_mt.py
+++ b/python/graphstorm/run/gsgnn_mt/gsgnn_mt.py
@@ -187,13 +187,15 @@ def create_task_val_dataloader(task, config, train_data):
     elif task.task_type in [BUILTIN_TASK_LINK_PREDICTION]:
         val_idxs = train_data.get_edge_val_set(task_config.eval_etype, mask=task_config.val_mask)
         dataloader_cls = gs.get_builtin_lp_eval_dataloader_class(task_config)
+        # All tasks share the same GNN model, so the fanout should be the global fanout
+        fanout = config.eval_fanout if task_config.use_mini_batch_infer else []
         if len(val_idxs) > 0:
             # TODO(xiangsx): Support construct feat
             if task_config.eval_etypes_negative_dstnode is not None:
                 return dataloader_cls(train_data, val_idxs,
                     task_config.eval_batch_size,
                     fixed_edge_dst_negative_field=task_config.eval_etypes_negative_dstnode,
-                    fanout=task_config.eval_fanout,
+                    fanout=fanout,
                     fixed_test_size=task_config.fixed_test_size,
                     node_feats=node_feats,
                     pos_graph_edge_feats=task_config.lp_edge_weight_for_loss)
@@ -201,7 +203,7 @@ def create_task_val_dataloader(task, config, train_data):
                 return dataloader_cls(train_data, val_idxs,
                     task_config.eval_batch_size,
                     task_config.num_negative_edges_eval,
-                    fanout=task_config.eval_fanout,
+                    fanout=fanout,
                     fixed_test_size=task_config.fixed_test_size,
                     node_feats=node_feats,
                     pos_graph_edge_feats=task_config.lp_edge_weight_for_loss)

--- a/tests/end2end-tests/data_gen/movielens_multi_task.json
+++ b/tests/end2end-tests/data_gen/movielens_multi_task.json
@@ -74,9 +74,9 @@
             {
                 "task_type":	"link_prediction",
                 "split_pct":	[0.1, 0.1, 0.1],
-                "mask_field_names": ["train_mask_field_l",
-                            "val_mask_field_l",
-                            "test_mask_field_l"]
+                "mask_field_names": ["train_mask_field_lp",
+                            "val_mask_field_lp",
+                            "test_mask_field_lp"]
             }
         ]
     }

--- a/tests/unit-tests/test_dataloading.py
+++ b/tests/unit-tests/test_dataloading.py
@@ -765,7 +765,9 @@ def test_GSgnnLinkPredictionTestDataLoader(batch_size, num_negative_edges):
 
         total_edges = {etype: len(train_idxs[etype]) for etype in test_etypes}
         num_pos_edges = {etype: 0 for etype in test_etypes}
+        num_samples = 0
         for pos_neg_tuple, sample_type in dataloader:
+            num_samples += 1
             assert sample_type == BUILTIN_LP_UNIFORM_NEG_SAMPLER
             assert isinstance(pos_neg_tuple, dict)
             assert len(pos_neg_tuple) == 1
@@ -793,6 +795,7 @@ def test_GSgnnLinkPredictionTestDataLoader(batch_size, num_negative_edges):
                 assert neg_src.shape[0] == pos_src.shape[0]
                 assert neg_src.shape[1] == num_negative_edges
                 assert th.all(neg_src < g.number_of_nodes(canonical_etype[0]))
+        assert len(dataloader) == num_samples
 
         # The target idx size for ("n0", "r1", "n1") is 2
         # The target idx size for ("n0", "r0", "n1") is 50
@@ -822,6 +825,7 @@ def test_GSgnnLinkPredictionTestDataLoader(batch_size, num_negative_edges):
             expected_pos_pairs += expected_idx_len
 
         assert num_samples == expected_samples
+        assert len(dataloader) == num_samples
         assert num_pos_pairs == expected_pos_pairs
 
     # after test pass, destroy all process group
@@ -2396,6 +2400,8 @@ def test_GSgnnMultiTaskDataLoader():
         assert np.any(edge0_seeds_cnt.numpy() >= 0)
 
 if __name__ == '__main__':
+    test_GSgnnLinkPredictionTestDataLoader(1, 1)
+    test_GSgnnLinkPredictionTestDataLoader(10, 20)
     test_GSgnnMultiTaskDataLoader()
     test_GSgnnLinkPredictionPredefinedTestDataLoader(1)
     test_GSgnnLinkPredictionPredefinedTestDataLoader(10)
@@ -2419,8 +2425,6 @@ if __name__ == '__main__':
     test_node_dataloader_reconstruct()
     test_GSgnnAllEtypeLinkPredictionDataLoader(10)
     test_GSgnnAllEtypeLinkPredictionDataLoader(1)
-    test_GSgnnLinkPredictionTestDataLoader(1, 1)
-    test_GSgnnLinkPredictionTestDataLoader(10, 20)
     test_GSgnnLinkPredictionJointTestDataLoader(1, 1)
     test_GSgnnLinkPredictionJointTestDataLoader(10, 20)
 

--- a/training_scripts/gsgnn_mt/ml_nc_ec_er_lp.yaml
+++ b/training_scripts/gsgnn_mt/ml_nc_ec_er_lp.yaml
@@ -98,7 +98,7 @@ gsf:
         batch_size: 128 # will overwrite the global batch_size
         mask_fields:
           - "train_mask_field_lp"
-          - "val_mask_field_l" # empty means there is no validation mask
+          - "val_mask_field_lp" # empty means there is no validation mask
           - null # empty means there is no test mask
         task_weight: 1.0
     - reconstruct_node_feat:

--- a/training_scripts/gsgnn_mt/ml_nc_ec_er_lp.yaml
+++ b/training_scripts/gsgnn_mt/ml_nc_ec_er_lp.yaml
@@ -98,7 +98,7 @@ gsf:
         batch_size: 128 # will overwrite the global batch_size
         mask_fields:
           - "train_mask_field_lp"
-          - null # empty means there is no validation mask
+          - "val_mask_field_l" # empty means there is no validation mask
           - null # empty means there is no test mask
         task_weight: 1.0
     - reconstruct_node_feat:


### PR DESCRIPTION
*Issue #, if available:*
The way to set the eval_fanout when creating the validation datalaoder for a link prediction task in multi-task learning setting is incorrect. It will crash the training script.

*Description of changes:*
Update the code to use the global eval_fanout for the validation dataloader.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
