### PR TITLE
[GSProcessing] Add pre-computed categorical transformation loading

### DIFF
--- a/docs/source/gs-processing/gs-processing-getting-started.rst
+++ b/docs/source/gs-processing/gs-processing-getting-started.rst
@@ -161,6 +161,22 @@ GSProcessing supports both the GConstruct JSON configuration format,
 as well as its own GSProcessing config. You can learn about the
 GSProcessing JSON configuration in :doc:`developer/input-configuration`.
 
+Re-applying feature transformations to new data
+-----------------------------------------------
+
+Often you will process your data at training time and run inference at later
+dates. If your data changes in the meantime. e.g. new values appear in a
+categorical feature, you'll need to ensure no new values appear in the transformed
+data, as the trained model relies on pre-existing values only.
+
+To achieve that, GSProcessing creates an additional file in the output,
+named ``precomputed_transformations.json``. To ensure the same transformations
+are applied to new data, you can copy this file to the top-level path of your
+new input data, and GSProcessing will pick up any transformations there to ensure
+the produced data match the ones that were used to train your model.
+
+Currently, we only support re-applying transformations for categorical features.
+
 
 Developer guide
 ---------------

--- a/docs/source/gs-processing/usage/example.rst
+++ b/docs/source/gs-processing/usage/example.rst
@@ -173,7 +173,7 @@ we can use the following command to run the processing job locally:
 
 .. code-block:: bash
 
-    gs-processing --config-filename gconstruct-config.json \
+    gs-processing --config-filename gsprocessing-config.json \
         --input-prefix ./tests/resources/small_heterogeneous_graph \
         --output-prefix /tmp/gsprocessing-example/ \
         --do-repartition True
@@ -211,26 +211,41 @@ and can be used downstream to create a partitioned graph.
 .. code-block:: bash
 
     $ cd /tmp/gsprocessing-example
-    $ ls
+    $ ls -l
 
-    edges/  launch_arguments.json  metadata.json  node_data/
-    raw_id_mappings/  perf_counters.json  updated_row_counts_metadata.json
+    edges/
+    gconstruct-config_with_transformations.json
+    launch_arguments.json
+    metadata.json
+    node_data/
+    perf_counters.json
+    precomputed_transformations.json
+    raw_id_mappings/
+    updated_row_counts_metadata.json
 
 We have a few JSON files and the data directories containing
 the graph structure, features, and labels. In more detail:
 
+* ``gsprocessing-config_with_transformations.json``: This is the input configuration
+  we used, modified to include representations of any supported transformations
+  we applied. This file can be used to re-apply the transformations on new data.
 * ``launch_arguments.json``: Contains the arguments that were used
   to launch the processing job, allowing you to check the parameters after the
   job finishes.
-* ``updated_row_counts_metadata.json``:
-  This file is meant to be used as the input configuration for the
-  distributed partitioning pipeline. ``gs-repartition`` produces
-  this file using the original ``metadata.json`` file as input.
 * ``metadata.json``: Created by ``gs-processing`` and used as input
   for ``gs-repartition``, can be removed the ``gs-repartition`` step.
 * ``perf_counters.json``: A JSON file that contains runtime measurements
   for the various components of GSProcessing. Can be used to profile the
   application and discover bottlenecks.
+* ``precomputed_transformations.json``: A JSON file that contains representations
+  of supported transformations. This file can be copied to the input path of another
+  set of raw files, and GSProcessing will use the transformation values listed here
+  instead of creating new ones. Use this to re-apply the same transformations to new
+  data.
+* ``updated_row_counts_metadata.json``:
+  This file is meant to be used as the input configuration for the
+  distributed partitioning pipeline. ``gs-repartition`` produces
+  this file using the original ``metadata.json`` file as input.
 
 The directories created contain:
 

--- a/docs/source/gs-processing/usage/example.rst
+++ b/docs/source/gs-processing/usage/example.rst
@@ -214,7 +214,7 @@ and can be used downstream to create a partitioned graph.
     $ ls -l
 
     edges/
-    gconstruct-config_with_transformations.json
+    gsprocessing-config_with_transformations.json
     launch_arguments.json
     metadata.json
     node_data/

--- a/docs/source/gs-processing/usage/example.rst
+++ b/docs/source/gs-processing/usage/example.rst
@@ -238,10 +238,13 @@ the graph structure, features, and labels. In more detail:
   for the various components of GSProcessing. Can be used to profile the
   application and discover bottlenecks.
 * ``precomputed_transformations.json``: A JSON file that contains representations
-  of supported transformations. This file can be copied to the input path of another
-  set of raw files, and GSProcessing will use the transformation values listed here
-  instead of creating new ones. Use this to re-apply the same transformations to new
-  data.
+  of supported transformations. To re-use these transformations on another dataset,
+  place this file in the top level of another set of raw data, at the same level
+  as the input GSProcessing/GConstruct configuration JSON file.
+  GSProcessing will use the transformation values listed here
+  instead of creating new ones, ensuring that models trained with the original
+  data can still be used in the newly transformed data. Currently only
+  categorical transformations can be re-applied.
 * ``updated_row_counts_metadata.json``:
   This file is meant to be used as the input configuration for the
   distributed partitioning pipeline. ``gs-repartition`` produces

--- a/graphstorm-processing/graphstorm_processing/data_transformations/dist_transformations/base_dist_transformation.py
+++ b/graphstorm-processing/graphstorm_processing/data_transformations/dist_transformations/base_dist_transformation.py
@@ -16,6 +16,7 @@ limitations under the License.
 
 from abc import ABC, abstractmethod
 from typing import Optional, Sequence
+import logging
 
 from pyspark.sql import DataFrame, SparkSession
 
@@ -23,6 +24,15 @@ from pyspark.sql import DataFrame, SparkSession
 class DistributedTransformation(ABC):
     """
     Base class for all distributed transformations.
+
+    Parameters
+    ----------
+    cols : Sequence[str]
+        Column names to which we will apply the transformation
+    spark : Optional[SparkSession], optional
+        Optional SparkSession if needed by the underlying implementation, by default None
+    json_representation : Optional[dict], optional
+        Pre-computed transformation representation to use, by default None
     """
 
     def __init__(
@@ -51,6 +61,28 @@ class DistributedTransformation(ABC):
             return self.json_representation
         else:
             return {}
+
+    def apply_precomputed_transformation(self, input_df: DataFrame) -> DataFrame:
+        """Applies a transformation using pre-computed representation.
+
+        Parameters
+        ----------
+        input_df : DataFrame
+            Input DataFrame to apply the transformation to.
+
+        Returns
+        -------
+        DataFrame
+            The input DataFrame, modified according to the pre-computed transformation values.
+        """
+        logging.warning(
+            (
+                "Transformation %s does not support pre-existing transform"
+                ", applying new transformation"
+            ),
+            self.get_transformation_name(),
+        )
+        return self.apply(input_df)
 
     @staticmethod
     @abstractmethod

--- a/graphstorm-processing/graphstorm_processing/data_transformations/dist_transformations/base_dist_transformation.py
+++ b/graphstorm-processing/graphstorm_processing/data_transformations/dist_transformations/base_dist_transformation.py
@@ -16,7 +16,6 @@ limitations under the License.
 
 from abc import ABC, abstractmethod
 from typing import Optional, Sequence
-import logging
 
 from pyspark.sql import DataFrame, SparkSession
 
@@ -74,15 +73,14 @@ class DistributedTransformation(ABC):
         -------
         DataFrame
             The input DataFrame, modified according to the pre-computed transformation values.
+        Raises
+        ------
+        NotImplementedError
+            If the underlying transformation does not support re-applying using JSON input.
         """
-        logging.warning(
-            (
-                "Transformation %s does not support pre-existing transform"
-                ", applying new transformation"
-            ),
-            self.get_transformation_name(),
+        raise NotImplementedError(
+            f"Pre-computed transformation not available for {self.get_transformation_name()}"
         )
-        return self.apply(input_df)
 
     @staticmethod
     @abstractmethod

--- a/graphstorm-processing/graphstorm_processing/data_transformations/dist_transformations/dist_category_transformation.py
+++ b/graphstorm-processing/graphstorm_processing/data_transformations/dist_transformations/dist_category_transformation.py
@@ -186,7 +186,8 @@ class DistCategoryTransformation(DistributedTransformation):
         assert set(precomputed_cols) == set(self.cols), (
             f"Mismatched columns in precomputed transformation: "
             f"pre-computed cols: {sorted(precomputed_cols)}, "
-            f"columns in current config: {sorted(self.cols)}"
+            f"columns in current config: {sorted(self.cols)}, "
+            f"different items: {set(precomputed_cols).symmetric_difference(set(self.cols))}"
         )
         for col_labels, col in zip(labels_arrays, precomputed_cols):
             for idx, label in enumerate(col_labels):

--- a/graphstorm-processing/graphstorm_processing/data_transformations/dist_transformations/dist_category_transformation.py
+++ b/graphstorm-processing/graphstorm_processing/data_transformations/dist_transformations/dist_category_transformation.py
@@ -175,11 +175,15 @@ class DistCategoryTransformation(DistributedTransformation):
 
     def apply_precomputed_transformation(self, input_df: DataFrame) -> DataFrame:
 
-        # Get JSON representation of categorical transformation
+        # List of StringIndexerModel labelsArray lists, each one containing the strings
+        # for one column. See docs for pyspark.ml.feature.StringIndexerModel.labelsArray
         labels_arrays: list[list[str]] = self.json_representation["string_indexer_labels_arrays"]
+        # More verbose representation of the mapping from string to one hot index location,
+        # for each column in the input.
         per_col_label_to_one_hot_idx: dict[str, dict[str, int]] = self.json_representation[
             "per_col_label_to_one_hot_idx"
         ]
+        # The list of cols the transformation was originally applied to.
         precomputed_cols: list[str] = self.json_representation["cols"]
 
         # Assertions to ensure correctness of representation

--- a/graphstorm-processing/graphstorm_processing/graph_loaders/dist_heterogeneous_loader.py
+++ b/graphstorm-processing/graphstorm_processing/graph_loaders/dist_heterogeneous_loader.py
@@ -1038,6 +1038,9 @@ class DistHeterogeneousGraphLoader(object):
         ntype_feat_sizes = {}  # type: Dict[str, int]
 
         for feat_conf in feature_configs:
+            # This will get a value iff there exists a pre-computed representation
+            # for this feature name and node type, an empty dict (which evaluates to False)
+            # otherwise. We do the same for the edges.
             json_representation = (
                 self.pre_computed_transformations.get("node_features", {})
                 .get(node_type, {})

--- a/graphstorm-processing/pyproject.toml
+++ b/graphstorm-processing/pyproject.toml
@@ -40,6 +40,7 @@ black = "~24.2.0"
 pre-commit = "^3.3.3"
 types-mock = "^5.1.0.1"
 pylint = "~2.17.5"
+diff-cover = "^9.0.0"
 
 [project]
 requires-python = ">=3.9" # TODO: Do we need a tilde here?

--- a/graphstorm-processing/tests/resources/precomputed_transformations/user_state_categorical_transformation.json
+++ b/graphstorm-processing/tests/resources/precomputed_transformations/user_state_categorical_transformation.json
@@ -1,0 +1,19 @@
+{
+    "node_features": {
+        "user": {
+            "state": {
+                "transformation_name": "DistCategoryTransformation",
+                "string_indexer_labels_arrays": [["wa", "ca", "ny"]],
+                "cols": ["state"],
+                "per_col_label_to_one_hot_idx": {
+                    "state": {
+                        "wa": 0,
+                        "ca": 1,
+                        "ny": 2
+                    }
+                }
+            }
+        }
+    },
+    "edge_features": {}
+}

--- a/graphstorm-processing/tests/test_dist_executor.py
+++ b/graphstorm-processing/tests/test_dist_executor.py
@@ -14,15 +14,19 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
+import json
 import os
 import shutil
 import tempfile
+from unittest import mock
 
 import pytest
 
 from graphstorm_processing.distributed_executor import DistributedExecutor, ExecutorConfig
-from graphstorm_processing.constants import ExecutionEnv, FilesystemType
+from graphstorm_processing.constants import TRANSFORMATIONS_FILENAME, FilesystemType, ExecutionEnv
+from test_dist_heterogenous_loader import verify_integ_test_output, NODE_CLASS_GRAPHINFO_UPDATES
 
+pytestmark = pytest.mark.usefixtures("spark")
 _ROOT = os.path.abspath(os.path.dirname(__file__))
 
 
@@ -36,8 +40,74 @@ def tempdir_fixture():
     shutil.rmtree(tempdirectory)
 
 
-def test_merge_input_and_transform_dicts(tempdir: str):
+def precomp_json_file(local_input, precomp_filename):
+    """Copy precomputed json to local input dir"""
+    precomp_file = shutil.copy(
+        os.path.join(_ROOT, "resources", "precomputed_transformations", precomp_filename),
+        os.path.join(local_input, TRANSFORMATIONS_FILENAME),
+    )
+    return precomp_file
+
+
+@pytest.fixture(name="user_state_categorical_precomp_file")
+def user_state_categorical_precomp_file_fixture():
+    """Copy precomputed user->state feature transformation to local input dir"""
+    precomp_file = precomp_json_file(
+        os.path.join(_ROOT, "resources/small_heterogeneous_graph"),
+        "user_state_categorical_transformation.json",
+    )
+
+    yield precomp_file
+
+    os.remove(precomp_file)
+
+
+def test_dist_executor_run_with_precomputed(tempdir: str, user_state_categorical_precomp_file):
     """Test run function with local data"""
+    input_path = os.path.join(_ROOT, "resources/small_heterogeneous_graph")
+    executor_configuration = ExecutorConfig(
+        local_config_path=input_path,
+        local_metadata_output_path=tempdir,
+        input_prefix=input_path,
+        output_prefix=tempdir,
+        num_output_files=-1,
+        config_filename="gsprocessing-config.json",
+        execution_env=ExecutionEnv.LOCAL,
+        filesystem_type=FilesystemType.LOCAL,
+        add_reverse_edges=True,
+        graph_name="small_heterogeneous_graph",
+        do_repartition=True,
+    )
+
+    original_precomp_file = user_state_categorical_precomp_file
+
+    with open(original_precomp_file, "r", encoding="utf-8") as f:
+        original_transformations = json.load(f)
+
+    dist_executor = DistributedExecutor(executor_configuration)
+
+    # Mock the SparkContext stop() function to leave the Spark context running
+    # for the other tests, otherwise dist_executor stops it
+    dist_executor.spark.stop = mock.MagicMock(name="stop")
+
+    dist_executor.run()
+
+    with open(os.path.join(tempdir, "metadata.json"), "r", encoding="utf-8") as mfile:
+        metadata = json.load(mfile)
+
+    verify_integ_test_output(metadata, dist_executor.loader, NODE_CLASS_GRAPHINFO_UPDATES)
+
+    with open(os.path.join(tempdir, TRANSFORMATIONS_FILENAME), "r", encoding="utf-8") as f:
+        reapplied_transformations = json.load(f)
+
+    # There should be no difference between original and re-applied transformation dicts
+    assert reapplied_transformations == original_transformations
+
+    # TODO: Verify other metadata files that verify_integ_test_output doesn't check for
+
+
+def test_merge_input_and_transform_dicts(tempdir: str):
+    """Test the _merge_config_with_transformations function with hardcoded json data"""
     input_path = os.path.join(_ROOT, "resources/small_heterogeneous_graph")
     executor_configuration = ExecutorConfig(
         local_config_path=input_path,
@@ -71,7 +141,7 @@ def test_merge_input_and_transform_dicts(tempdir: str):
         pre_comp_transormations,
     )
 
-    # Ensure the "user" node type's "age" feature includes a transformation entry
+    # Ensure the "user" node type's "state" feature includes a transformation entry
     for node_input_dict in input_config_with_transforms["graph"]["nodes"]:
         if "user" == node_input_dict["type"]:
             for feature in node_input_dict["features"]:


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

* Follow-up to #857 
* Allow us to re-apply a previously saved categorical transformation to new data. See below for design details.

To be able to re-apply the categorical transformations that we create using the code in #857 , we first create a mapping from original string to one-hot representation, that we read from the saved JSON file, then use a UDF to use the mapping(s) on the column(s).

The `DistributedTransformation` class from which all transformation implementations inherit, gains a new function, `apply_precomputed_transformation`. When a pre-computed transformation JSON file exists in the input, and the feature is one of those listed in that file, we use this function to re-apply the existing transformation instead of creating a new one.

The default implementation for `apply_precomputed_transformation` is to log a warning and apply a new transformation. 

When we implement a pre-computed transform for a new transformation (e.g. numerical) we need to:
* Ensure the the transformation's `self.json_representation` is populated during the call to `apply()`. This ensures the transformation info will be saved in the output JSON.
* Override the `apply_precomputed_transformation` function (as we did for `DistCategoryTransformation` here), so that it uses the dict loaded from the JSON file to re-apply the transformation to the new data.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
