### PR TITLE
Update multi-task evaluation logic to avoid information leakage issue in lp and nfeat reconstruct task evaluation.

### DIFF
--- a/python/graphstorm/model/__init__.py
+++ b/python/graphstorm/model/__init__.py
@@ -37,8 +37,7 @@ from .lp_gnn import (GSgnnLinkPredictionModel,
                      run_lp_mini_batch_predict)
 from .multitask_gnn import (GSgnnMultiTaskModelInterface,
                             GSgnnMultiTaskSharedEncoderModel)
-from .multitask_gnn import (multi_prediction_task_mini_batch_predict,
-                            multi_nfeat_recon_task_mini_batch_predict,
+from .multitask_gnn import (multi_task_mini_batch_predict,
                             gen_emb_for_nfeat_reconstruct)
 from .rgcn_encoder import RelationalGCNEncoder, RelGraphConvLayer
 from .rgat_encoder import RelationalGATEncoder, RelationalAttLayer

--- a/python/graphstorm/model/__init__.py
+++ b/python/graphstorm/model/__init__.py
@@ -37,7 +37,9 @@ from .lp_gnn import (GSgnnLinkPredictionModel,
                      run_lp_mini_batch_predict)
 from .multitask_gnn import (GSgnnMultiTaskModelInterface,
                             GSgnnMultiTaskSharedEncoderModel)
-from .multitask_gnn import multi_task_mini_batch_predict
+from .multitask_gnn import (multi_prediction_task_mini_batch_predict,
+                            multi_nfeat_recon_task_mini_batch_predict,
+                            gen_emb_for_nfeat_reconstruct)
 from .rgcn_encoder import RelationalGCNEncoder, RelGraphConvLayer
 from .rgat_encoder import RelationalGATEncoder, RelationalAttLayer
 from .sage_encoder import SAGEEncoder, SAGEConv

--- a/python/graphstorm/model/multitask_gnn.py
+++ b/python/graphstorm/model/multitask_gnn.py
@@ -490,7 +490,7 @@ def gen_emb_for_nfeat_reconstruct(model, gen_embs):
 
     Return
     ------
-    embs: node embedings
+    embs: node embeddings
     """
     if isinstance(model.gnn_encoder, GSgnnGNNEncoderInterface):
         if model.has_sparse_params():
@@ -507,11 +507,11 @@ def gen_emb_for_nfeat_reconstruct(model, gen_embs):
                             "skip the last layer self-loop"
                             "Please set use_self_loop to False",
                             BUILTIN_TASK_RECONSTRUCT_NODE_FEAT)
-            embs = gen_embs(last_self_loop=True)
+            embs = gen_embs(skip_last_self_loop=False)
         else:
             # skip the selfloop of the last layer to
             # avoid information leakage.
-            embs = gen_embs(last_self_loop=False)
+            embs = gen_embs(skip_last_self_loop=True)
     else:
         # we will use the computed embs directly
         logging.warning("The gnn encoder %s does not support skip "
@@ -520,5 +520,5 @@ def gen_emb_for_nfeat_reconstruct(model, gen_embs):
                         "node feature leakage risk when doing %s training.",
                         type(model.gnn_encoder),
                         BUILTIN_TASK_RECONSTRUCT_NODE_FEAT)
-        embs = gen_embs(last_self_loop=True)
+        embs = gen_embs(skip_last_self_loop=False)
     return embs

--- a/python/graphstorm/run/gsgnn_mt/gsgnn_mt.py
+++ b/python/graphstorm/run/gsgnn_mt/gsgnn_mt.py
@@ -444,8 +444,12 @@ def main(config_args):
                 logging.warning("The training data do not have validation set.")
             if test_loader is None:
                 logging.warning("The training data do not have test set.")
-            task_evaluators[task.task_id] = \
-                create_evaluator(task)
+
+            if val_loader is None and test_loader is None:
+                logging.warning("Task %s does not have validation and test sets.", task.task_id)
+            else:
+                task_evaluators[task.task_id] = \
+                    create_evaluator(task)
 
     train_dataloader = GSgnnMultiTaskDataLoader(train_data, tasks, train_dataloaders)
     val_dataloader = GSgnnMultiTaskDataLoader(train_data, tasks, val_dataloaders)

--- a/python/graphstorm/trainer/mt_trainer.py
+++ b/python/graphstorm/trainer/mt_trainer.py
@@ -657,7 +657,7 @@ class GSgnnMultiTaskLearningTrainer(GSgnnTrainer):
                     test_results = {task_info.task_id: test_scores}
 
         if len(nfeat_recon_tasks) > 0:
-            def nfrecon_gen_embs(skip_last_self_loop=False):
+            def nfrecon_gen_embs(skip_last_self_loop=False, node_embs=embs):
                 """ Generate node embeddings for node feature reconstruction
                 """
                 if skip_last_self_loop is True:
@@ -671,10 +671,9 @@ class GSgnnMultiTaskLearningTrainer(GSgnnTrainer):
                     # If skip_last_self_loop is False
                     # we will not change the way we compute
                     # node embeddings.
-                    if embs is not None:
+                    if node_embs is not None:
                         # The embeddings have been computed
-                        # when handling predict_tasks in L608
-                        return embs
+                        return node_embs
                     else:
                         return gen_embs()
 

--- a/python/graphstorm/trainer/mt_trainer.py
+++ b/python/graphstorm/trainer/mt_trainer.py
@@ -479,7 +479,7 @@ class GSgnnMultiTaskLearningTrainer(GSgnnTrainer):
                            self.get_best_model_path() if save_model_path is not None else None}
             self.log_params(output)
 
-def eval(self, model, data, mt_val_loader, mt_test_loader, total_steps,
+    def eval(self, model, data, mt_val_loader, mt_test_loader, total_steps,
         use_mini_batch_infer=False, return_proba=True):
         """ do the model evaluation using validation and test sets
 

--- a/tests/unit-tests/test_gnn.py
+++ b/tests/unit-tests/test_gnn.py
@@ -2301,21 +2301,20 @@ def test_multi_task_mini_batch_predict():
 
 def test_gen_emb_for_nfeat_recon():
     encoder_model = DummyGSgnnEncoderModel()
-    model = DummyGSgnnModel(encoder_model, has_sparse=True)
-    call_self_loop = True
-    def check_call_gen_embs(last_self_loop):
-        assert last_self_loop == call_self_loop
+    def check_call_gen_embs(skip_last_self_loop):
+        assert skip_last_self_loop == skip_self_loop
 
+    model = DummyGSgnnModel(encoder_model, has_sparse=True)
+    skip_self_loop = False
     gen_emb_for_nfeat_reconstruct(model, check_call_gen_embs)
 
-    call_self_loop = False
+    skip_self_loop = True
     model = DummyGSgnnModel(encoder_model, has_sparse=False)
     gen_emb_for_nfeat_reconstruct(model, check_call_gen_embs)
 
     model = DummyGSgnnModel(None)
-    call_self_loop = True
-    def check_call_gen_embs(last_self_loop):
-        assert last_self_loop == call_self_loop
+    skip_self_loop = False
+    gen_emb_for_nfeat_reconstruct(model, check_call_gen_embs)
 
 
 if __name__ == '__main__':

--- a/tests/unit-tests/test_gnn.py
+++ b/tests/unit-tests/test_gnn.py
@@ -38,7 +38,8 @@ from graphstorm.config import (BUILTIN_TASK_NODE_CLASSIFICATION,
                                 BUILTIN_TASK_NODE_REGRESSION,
                                 BUILTIN_TASK_EDGE_CLASSIFICATION,
                                 BUILTIN_TASK_EDGE_REGRESSION,
-                                BUILTIN_TASK_LINK_PREDICTION)
+                                BUILTIN_TASK_LINK_PREDICTION,
+                                BUILTIN_TASK_RECONSTRUCT_NODE_FEAT)
 from graphstorm.model import GSNodeEncoderInputLayer, RelationalGCNEncoder
 from graphstorm.model import GSgnnNodeModel, GSgnnEdgeModel
 from graphstorm.model import GSLMNodeEncoderInputLayer, GSPureLMNodeInputLayer
@@ -59,7 +60,7 @@ from graphstorm.model.edge_decoder import (DenseBiDecoder,
 from graphstorm.model.node_decoder import EntityRegression, EntityClassifier
 from graphstorm.model.loss_func import RegressionLossFunc
 from graphstorm.dataloading import GSgnnData
-from graphstorm.dataloading import GSgnnNodeDataLoader, GSgnnEdgeDataLoader, GSgnnMultiTaskDataLoader
+from graphstorm.dataloading import GSgnnNodeDataLoader, GSgnnEdgeDataLoader
 from graphstorm.dataloading.dataset import prepare_batch_input
 from graphstorm import (create_builtin_edge_gnn_model,
                         create_builtin_node_gnn_model,
@@ -75,13 +76,17 @@ from graphstorm.model.node_gnn import GSgnnNodeModelInterface
 from graphstorm.model.edge_gnn import (edge_mini_batch_predict,
                                        run_edge_mini_batch_predict,
                                        edge_mini_batch_gnn_predict)
-from graphstorm.model.multitask_gnn import multi_task_mini_batch_predict
+from graphstorm.model.multitask_gnn import (multi_task_mini_batch_predict,
+                                            gen_emb_for_nfeat_reconstruct)
 from graphstorm.model.gnn_with_reconstruct import construct_node_feat, get_input_embeds_combined
 from graphstorm.model.utils import load_model, save_model
 from graphstorm.model import GSgnnMultiTaskSharedEncoderModel
-from graphstorm.dataloading import (GSgnnEdgeDataLoaderBase,
-                                    GSgnnLinkPredictionDataLoaderBase,
-                                    GSgnnNodeDataLoaderBase)
+
+from util import (DummyGSgnnNodeDataLoader,
+                  DummyGSgnnEdgeDataLoader,
+                  DummyGSgnnLinkPredictionDataLoader,
+                  DummyGSgnnModel,
+                  DummyGSgnnEncoderModel)
 
 from data_utils import generate_dummy_dist_graph, generate_dummy_dist_graph_multi_target_ntypes
 from data_utils import generate_dummy_dist_graph_reconstruct
@@ -2082,36 +2087,6 @@ def test_multi_task_predict():
 
     check_forward()
 
-class DummyGSgnnNodeDataLoader(GSgnnNodeDataLoaderBase):
-    def __init__(self):
-        pass # do nothing
-
-    def __len__(self):
-        return 10
-
-    def __iter__(self):
-        return self
-
-class DummyGSgnnEdgeDataLoader(GSgnnEdgeDataLoaderBase):
-    def __init__(self):
-        pass # do nothing
-
-    def __len__(self):
-        return 10
-
-    def __iter__(self):
-        return self
-
-class DummyGSgnnLinkPredictionDataLoader(GSgnnLinkPredictionDataLoaderBase):
-    def __init__(self):
-        pass # do nothing
-
-    def __len__(self):
-        return 10
-
-    def __iter__(self):
-        return self
-
 def test_multi_task_mini_batch_predict():
     mt_model = GSgnnMultiTaskSharedEncoderModel(0.1)
 
@@ -2144,6 +2119,11 @@ def test_multi_task_mini_batch_predict():
                       DummyLPDecoder(),
                       pred_lp_loss_func)
 
+    mt_model.add_task("nfr_task",
+                      BUILTIN_TASK_RECONSTRUCT_NODE_FEAT,
+                      DummyLPDecoder(),
+                      pred_lp_loss_func)
+
     tast_info_nc = TaskInfo(task_type=BUILTIN_TASK_NODE_CLASSIFICATION,
                             task_id='nc_task',
                             task_config=None)
@@ -2164,8 +2144,14 @@ def test_multi_task_mini_batch_predict():
                             task_id='lp_task',
                             task_config=None)
     lp_dataloader = DummyGSgnnLinkPredictionDataLoader()
-    task_infos = [tast_info_nc, tast_info_nr, tast_info_ec, tast_info_er, tast_info_lp]
-    dataloaders = [nc_dataloader, nr_dataloader, ec_dataloader, er_dataloader, lp_dataloader]
+    tast_info_nfr = TaskInfo(task_type=BUILTIN_TASK_RECONSTRUCT_NODE_FEAT,
+                            task_id='nfr_task',
+                            task_config=None)
+    nfr_dataloader = DummyGSgnnNodeDataLoader()
+    task_infos = [tast_info_nc, tast_info_nr, tast_info_ec,
+                  tast_info_er, tast_info_lp, tast_info_nfr]
+    dataloaders = [nc_dataloader, nr_dataloader, ec_dataloader,
+                   er_dataloader, lp_dataloader, nfr_dataloader]
 
     node_pred = {"n0": th.arange(10)}
     node_prob = {"n0": th.arange(10)/10}
@@ -2206,10 +2192,10 @@ def test_multi_task_mini_batch_predict():
                       mock_run_edge_mini_batch_predict,
                       mock_run_node_mini_batch_predict):
 
-        mt_dataloader = GSgnnMultiTaskDataLoader(None, task_infos, dataloaders)
         res = multi_task_mini_batch_predict(mt_model,
                                             None,
-                                            mt_dataloader,
+                                            dataloaders,
+                                            task_infos,
                                             device=th.device('cpu'),
                                             return_proba=False,
                                             return_label=False)
@@ -2227,10 +2213,15 @@ def test_multi_task_mini_batch_predict():
         assert res["er_task"][1] is None
         assert_equal(res["lp_task"][("n0", "r0", "n1")].numpy(), lp_pred[("n0", "r0", "n1")].numpy())
         assert_equal(res["lp_task"][("n0", "r0", "n2")].numpy(), lp_pred[("n0", "r0", "n2")].numpy())
+        # node feature reconstruction also calls
+        # run_node_mini_batch_predict
+        assert len(res["nfr_task"]) == 2
+        assert_equal(res["nfr_task"][0].numpy(), node_pred["n0"].numpy())
 
         res = multi_task_mini_batch_predict(mt_model,
                                             None,
-                                            mt_dataloader,
+                                            dataloaders,
+                                            task_infos,
                                             device=th.device('cpu'),
                                             return_proba=True,
                                             return_label=False)
@@ -2248,10 +2239,15 @@ def test_multi_task_mini_batch_predict():
         assert res["er_task"][1] is None
         assert_equal(res["lp_task"][("n0", "r0", "n1")].numpy(), lp_pred[("n0", "r0", "n1")].numpy())
         assert_equal(res["lp_task"][("n0", "r0", "n2")].numpy(), lp_pred[("n0", "r0", "n2")].numpy())
+        # node feature reconstruction also calls
+        # run_node_mini_batch_predict
+        assert len(res["nfr_task"]) == 2
+        assert_equal(res["nfr_task"][0].numpy(), node_prob["n0"].numpy())
 
         res = multi_task_mini_batch_predict(mt_model,
                                             None,
-                                            mt_dataloader,
+                                            dataloaders,
+                                            task_infos,
                                             device=th.device('cpu'),
                                             return_proba=False,
                                             return_label=True)
@@ -2269,14 +2265,18 @@ def test_multi_task_mini_batch_predict():
         assert_equal(res["ec_task"][0].numpy(), edge_label[("n0", "r0", "n1")].numpy())
         assert_equal(res["lp_task"][("n0", "r0", "n1")].numpy(), lp_pred[("n0", "r0", "n1")].numpy())
         assert_equal(res["lp_task"][("n0", "r0", "n2")].numpy(), lp_pred[("n0", "r0", "n2")].numpy())
+        # node feature reconstruction also calls
+        # run_node_mini_batch_predict
+        assert len(res["nfr_task"]) == 2
+        assert_equal(res["nfr_task"][0].numpy(), node_pred["n0"].numpy())
+        assert_equal(res["nfr_task"][1].numpy(), node_label["n0"].numpy())
 
 
-        new_dataloaders = [nc_dataloader, None, ec_dataloader, None, None]
-        mt_dataloader = GSgnnMultiTaskDataLoader(None, task_infos, new_dataloaders)
-
+        new_dataloaders = [nc_dataloader, None, ec_dataloader, None, None, None]
         res = multi_task_mini_batch_predict(mt_model,
                                             None,
-                                            mt_dataloader,
+                                            new_dataloaders,
+                                            task_infos,
                                             device=th.device('cpu'),
                                             return_proba=False,
                                             return_label=False)
@@ -2293,10 +2293,29 @@ def test_multi_task_mini_batch_predict():
         assert res["er_task"][0] is None
         assert res["er_task"][1] is None
         assert res["lp_task"] is None
-
-
+        assert len(res["nfr_task"]) == 2
+        assert res["nfr_task"][0] is None
+        assert res["nfr_task"][1] is None
 
     check_forward()
+
+def test_gen_emb_for_nfeat_recon():
+    encoder_model = DummyGSgnnEncoderModel()
+    model = DummyGSgnnModel(encoder_model, has_sparse=True)
+    call_self_loop = True
+    def check_call_gen_embs(last_self_loop):
+        assert last_self_loop == call_self_loop
+
+    gen_emb_for_nfeat_reconstruct(model, check_call_gen_embs)
+
+    call_self_loop = False
+    model = DummyGSgnnModel(encoder_model, has_sparse=False)
+    gen_emb_for_nfeat_reconstruct(model, check_call_gen_embs)
+
+    model = DummyGSgnnModel(None)
+    call_self_loop = True
+    def check_call_gen_embs(last_self_loop):
+        assert last_self_loop == call_self_loop
 
 
 if __name__ == '__main__':
@@ -2305,6 +2324,7 @@ if __name__ == '__main__':
     test_multi_task_forward()
     test_multi_task_predict()
     test_multi_task_mini_batch_predict()
+    test_gen_emb_for_nfeat_recon()
 
     test_lm_rgcn_node_prediction_with_reconstruct()
     test_rgcn_node_prediction_with_reconstruct(True)

--- a/tests/unit-tests/test_trainer.py
+++ b/tests/unit-tests/test_trainer.py
@@ -460,41 +460,41 @@ class MTaskCheckerEvaluator():
         return "dummy tracker"
 
 def test_mtask_eval():
-    tast_info_nc = TaskInfo(task_type=BUILTIN_TASK_NODE_CLASSIFICATION,
+    task_info_nc = TaskInfo(task_type=BUILTIN_TASK_NODE_CLASSIFICATION,
                             task_id='nc_task',
                             task_config=None)
     nc_dataloader = DummyGSgnnNodeDataLoader()
-    tast_info_nr = TaskInfo(task_type=BUILTIN_TASK_NODE_REGRESSION,
+    task_info_nr = TaskInfo(task_type=BUILTIN_TASK_NODE_REGRESSION,
                             task_id='nr_task',
                             task_config=None)
     nr_dataloader = DummyGSgnnNodeDataLoader()
-    tast_info_ec = TaskInfo(task_type=BUILTIN_TASK_EDGE_CLASSIFICATION,
+    task_info_ec = TaskInfo(task_type=BUILTIN_TASK_EDGE_CLASSIFICATION,
                             task_id='ec_task',
                             task_config=None)
     ec_dataloader = DummyGSgnnEdgeDataLoader()
-    tast_info_er = TaskInfo(task_type=BUILTIN_TASK_EDGE_REGRESSION,
+    task_info_er = TaskInfo(task_type=BUILTIN_TASK_EDGE_REGRESSION,
                             task_id='er_task',
                             task_config=None)
     er_dataloader = DummyGSgnnEdgeDataLoader()
     task_config = GSConfig.__new__(GSConfig)
     setattr(task_config, "train_mask", "train_mask")
-    tast_info_lp = TaskInfo(task_type=BUILTIN_TASK_LINK_PREDICTION,
+    task_info_lp = TaskInfo(task_type=BUILTIN_TASK_LINK_PREDICTION,
                             task_id='lp_task',
                             task_config=task_config)
 
     encoder_model = DummyGSgnnEncoderModel()
-    model = DummyGSgnnMTModel(encoder_model, decoders={tast_info_lp.task_id: "dummy"}, has_sparse=True)
+    model = DummyGSgnnMTModel(encoder_model, decoders={task_info_lp.task_id: "dummy"}, has_sparse=True)
 
     mt_trainer = GSgnnMultiTaskLearningTrainer(model)
     mt_trainer._device = 'cpu'
 
     lp_dataloader = DummyGSgnnLinkPredictionDataLoader()
-    tast_info_nfr = TaskInfo(task_type=BUILTIN_TASK_RECONSTRUCT_NODE_FEAT,
+    task_info_nfr = TaskInfo(task_type=BUILTIN_TASK_RECONSTRUCT_NODE_FEAT,
                             task_id='nfr_task',
                             task_config=None)
     nfr_dataloader = DummyGSgnnNodeDataLoader()
-    task_infos = [tast_info_nc, tast_info_nr, tast_info_ec,
-                  tast_info_er, tast_info_lp, tast_info_nfr]
+    task_infos = [task_info_nc, task_info_nr, task_info_ec,
+                  task_info_er, task_info_lp, task_info_nfr]
 
     data = None
     res = mt_trainer.eval(model, data, None, None, 100)
@@ -595,7 +595,6 @@ def test_mtask_eval():
         }
         evaluator = MTaskCheckerEvaluator(target_res, target_res, 100)
         mt_trainer.setup_evaluator(evaluator)
-        # test when val_loader is None
         mt_trainer.eval(model, data, val_loader, test_loader, 100)
 
         # lp tasks are empty
@@ -614,7 +613,6 @@ def test_mtask_eval():
         }
         evaluator = MTaskCheckerEvaluator(target_res, target_res, 200)
         mt_trainer.setup_evaluator(evaluator)
-        # test when val_loader is None
         mt_trainer.eval(model, data, val_loader, test_loader, 200)
 
         # node feature reconstruct tasks are empty
@@ -633,7 +631,6 @@ def test_mtask_eval():
         }
         evaluator = MTaskCheckerEvaluator(target_res, target_res, 200)
         mt_trainer.setup_evaluator(evaluator)
-        # test when val_loader is None
         mt_trainer.eval(model, data, val_loader, test_loader, 200)
 
     check_eval()

--- a/tests/unit-tests/util.py
+++ b/tests/unit-tests/util.py
@@ -16,7 +16,13 @@
 import torch as th
 
 from graphstorm.model.lm_model import TOKEN_IDX, ATT_MASK_IDX, TOKEN_TID_IDX
-# pylint: disable=missing-function-docstring
+from graphstorm.dataloading import (GSgnnEdgeDataLoaderBase,
+                                    GSgnnLinkPredictionDataLoaderBase,
+                                    GSgnnNodeDataLoaderBase)
+from graphstorm.model import GSOptimizer
+from graphstorm.model import GSgnnModelBase
+from graphstorm.model.multitask_gnn import GSgnnMultiTaskModelInterface
+from graphstorm.model.gnn_encoder_base import GSgnnGNNEncoderInterface
 
 class Dummy:
     """dummy object used to create config objects
@@ -35,3 +41,82 @@ def create_tokens(tokenizer, input_text, max_seq_length, num_node, return_token_
     token_type_ids = tokens.get(TOKEN_TID_IDX, th.zeros_like(input_ids))\
         if return_token_type_ids else None
     return input_ids, valid_len, attention_mask, token_type_ids
+
+class DummyGSgnnNodeDataLoader(GSgnnNodeDataLoaderBase):
+    def __init__(self):
+        pass # do nothing
+
+    def __len__(self):
+        return 10
+
+    def __iter__(self):
+        return self
+
+    @property
+    def fanout(self):
+        return [10]
+
+class DummyGSgnnEdgeDataLoader(GSgnnEdgeDataLoaderBase):
+    def __init__(self):
+        pass # do nothing
+
+    def __len__(self):
+        return 10
+
+    def __iter__(self):
+        return self
+
+    @property
+    def fanout(self):
+        return [10]
+
+class DummyGSgnnLinkPredictionDataLoader(GSgnnLinkPredictionDataLoaderBase):
+    def __init__(self):
+        pass # do nothing
+
+    def __len__(self):
+        return 10
+
+    def __iter__(self):
+        return self
+
+    @property
+    def fanout(self):
+        return [10]
+
+class DummyGSgnnModel(GSgnnModelBase):
+    def __init__(self, encoder_model, has_sparse=False):
+        self.gnn_encoder = encoder_model
+        self._has_sparse = has_sparse
+
+    def has_sparse_params(self):
+        return self._has_sparse
+
+    def create_optimizer(self):
+        return GSOptimizer(dense_opts=["dummy"])
+
+class DummyGSgnnMTModel(DummyGSgnnModel, GSgnnMultiTaskModelInterface):
+    def __init__(self, encoder_model, decoders, has_sparse=False):
+        super(DummyGSgnnMTModel, self).__init__(encoder_model, has_sparse)
+        self._decoders = decoders
+
+
+    def forward(self, task_mini_batches):
+        pass
+
+    def predict(self, task_id, mini_batch):
+        pass
+
+    def train(self, train=True):
+        pass
+
+    @property
+    def task_decoders(self):
+        return self._decoders
+
+class DummyGSgnnEncoderModel(GSgnnGNNEncoderInterface):
+    def skip_last_selfloop(self):
+        pass
+
+    def reset_last_selfloop(self):
+        pass

--- a/training_scripts/gsgnn_mt/ml_nc_ec_er_lp.yaml
+++ b/training_scripts/gsgnn_mt/ml_nc_ec_er_lp.yaml
@@ -98,7 +98,7 @@ gsf:
         batch_size: 128 # will overwrite the global batch_size
         mask_fields:
           - "train_mask_field_lp"
-          - "val_mask_field_lp" # empty means there is no validation mask
+          - "val_mask_field_lp"
           - null # empty means there is no test mask
         task_weight: 1.0
     - reconstruct_node_feat:


### PR DESCRIPTION
*Issue #, if available:*
#789 

*Description of changes:*
Previously, in the eval() function of GSgnnMultiTaskLearningTrainer, both link prediction and node feature reconstruction tasks use the node embeddings computed with the entire graph. This will cause test edge leakage for link prediction tasks and target node node feature leakage for node feature reconstruction tasks. This PR fixes this issue.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
