### PR TITLE
Make IP config argument for distpart consistent with the rest of GSF

### DIFF
--- a/python/graphstorm/gpartition/dist_partition_graph.py
+++ b/python/graphstorm/gpartition/dist_partition_graph.py
@@ -163,12 +163,13 @@ def parse_args() -> argparse.Namespace:
     argparser.add_argument("--num-parts", type=int, required=True,
                            help="Number of partitions to generate")
     argparser.add_argument("--ssh-port", type=int, default=22, help="SSH Port")
-    argparser.add_argument("--dgl-tool-path", type=str,
+    argparser.add_argument("--dgl-tool-path", type=str, default="/root/dgl/tools",
                            help="The path to dgl/tools")
     argparser.add_argument("--partition-algorithm", type=str, default="random",
                            choices=["random", "parmetis"], help="Partition algorithm to use.")
     argparser.add_argument("--ip-config", type=str,
-                           help="A file storing a list of IPs, one line for each instance of the partition cluster.")
+                           help=("A file storing a list of IPs, one line for "
+                                "each instance of the partition cluster."))
     argparser.add_argument("--do-dispatch", action='store_true')
     argparser.add_argument("--logging-level", type=str, default="info",
                            help="The logging level. The possible values: debug, info, warning, \

--- a/python/graphstorm/gpartition/dist_partition_graph.py
+++ b/python/graphstorm/gpartition/dist_partition_graph.py
@@ -119,7 +119,7 @@ def main():
     if args.partition_algorithm == "random":
         partitioner = RandomPartitionAlgorithm(metadata_dict)
     elif args.partition_algorithm == "parmetis":
-        partition_config = ParMETISConfig(args.ip_list, args.input_path,
+        partition_config = ParMETISConfig(args.ip_config, args.input_path,
                                           args.dgl_tool_path, args.metadata_filename)
         partitioner = ParMetisPartitionAlgorithm(metadata_dict, partition_config)
     else:
@@ -139,7 +139,7 @@ def main():
         run_build_dglgraph(
             args.input_path,
             part_assignment_dir,
-            args.ip_list,
+            args.ip_config,
             os.path.join(output_path, "dist_graph"),
             args.metadata_filename,
             args.dgl_tool_path,
@@ -167,8 +167,8 @@ def parse_args() -> argparse.Namespace:
                            help="The path to dgl/tools")
     argparser.add_argument("--partition-algorithm", type=str, default="random",
                            choices=["random", "parmetis"], help="Partition algorithm to use.")
-    argparser.add_argument("--ip-list", type=str,
-                           help="A file storing the ip list of instances of the partition cluster.")
+    argparser.add_argument("--ip-config", type=str,
+                           help="A file storing a list of IPs, one line for each instance of the partition cluster.")
     argparser.add_argument("--do-dispatch", action='store_true')
     argparser.add_argument("--logging-level", type=str, default="info",
                            help="The logging level. The possible values: debug, info, warning, \


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

All other launchers use `--ip-config` to refer to the IP list file, this PR makes the dist part launcher be consistent with th rest.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
