### PR TITLE
[Fix] Fix save_model_frequency None error in trainer

### DIFF
--- a/python/graphstorm/trainer/ep_trainer.py
+++ b/python/graphstorm/trainer/ep_trainer.py
@@ -79,7 +79,7 @@ class GSgnnEdgePredictionTrainer(GSgnnTrainer):
             test_loader=None,
             use_mini_batch_infer=True,
             save_model_path=None,
-            save_model_frequency=None,
+            save_model_frequency=-1,
             save_perf_results_path=None,
             freeze_input_layer_epochs=0,
             max_grad_norm=None,
@@ -107,7 +107,8 @@ class GSgnnEdgePredictionTrainer(GSgnnTrainer):
         save_model_path : str
             The path where the model is saved.
         save_model_frequency : int
-            The number of iteration to train the model before saving the model.
+            The number of iteration to train the model before saving the model. Default is -1,
+            meaning only save model after each epoch.
         save_perf_results_path : str
             The path of the file where the performance results are saved.
         freeze_input_layer_epochs: int

--- a/python/graphstorm/trainer/lp_trainer.py
+++ b/python/graphstorm/trainer/lp_trainer.py
@@ -84,7 +84,7 @@ class GSgnnLinkPredictionTrainer(GSgnnTrainer):
             test_loader=None,           # pylint: disable=unused-argument
             use_mini_batch_infer=True,      # pylint: disable=unused-argument
             save_model_path=None,
-            save_model_frequency=None,
+            save_model_frequency=-1,
             save_perf_results_path=None,
             edge_mask_for_gnn_embeddings='train_mask',
             freeze_input_layer_epochs=0,
@@ -108,7 +108,8 @@ class GSgnnLinkPredictionTrainer(GSgnnTrainer):
         save_model_path : str
             The path where the model is saved.
         save_model_frequency : int
-            The number of iteration to train the model before saving the model.
+            The number of iteration to train the model before saving the model. Default is -1,
+            meaning only save model after each epoch.
         save_perf_results_path : str
             The path of the file where the performance results are saved.
         edge_mask_for_gnn_embeddings : str

--- a/python/graphstorm/trainer/np_trainer.py
+++ b/python/graphstorm/trainer/np_trainer.py
@@ -107,7 +107,8 @@ class GSgnnNodePredictionTrainer(GSgnnTrainer):
         save_model_path : str
             The path where the model is saved.
         save_model_frequency : int
-            The number of iteration to train the model before saving the model.
+            The number of iteration to train the model before saving the model. Default is -1,
+            meaning only save model after each epoch.
         save_perf_results_path : str
             The path of the file where the performance results are saved.
         freeze_input_layer_epochs: int


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This PR fixed the error when calling `fit()` function in `ep_trainer` and `lp_trainer` without specifying the `save_model_frequency` value, which will cause an operation error when compare None to int in the code `save_model_frequency > 0`.

Also add default value and its explanation in the doc string for all three kinds of trainer.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
