### PR TITLE
Fix ParMETIS call so it uses all workers in cluster.

### DIFF
--- a/python/graphstorm/gpartition/metis_partition.py
+++ b/python/graphstorm/gpartition/metis_partition.py
@@ -71,11 +71,11 @@ class ParMetisPartitionAlgorithm(LocalPartitionAlgorithm):
                     --schema_file {metadata_filename} \
                     --output_dir {input_path} --num_parts {num_parts}"
 
-
         if self.run_command(command, "preprocess"):
             # parmetis_preprocess.py creates this file, but doesn't put it in the cwd,
             # where the parmetis program (pm_dglpart) expects it to be.
-            # So we copy it here.
+            # So we copy it from the location parmetis_preprocess saves it to the cwd.
+            # https://github.com/dmlc/dgl/blob/cbad2f0af317dce2af1771c131b7eea92ae7c8a7/tools/distpartitioning/parmetis_preprocess.py#L318
             with open(os.path.join(input_path, metadata_filename), encoding="utf-8") as f:
                 graph_meta = json.load(f)
             graph_name = graph_meta["graph_name"]


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

* Previously we were calling the `pm_dglpart` executable through `mpirun` using only a single/process worker. This PR pulls in a necessary file that `parmetis_preprocess.py` creates in the wrong path, and fixes the number of workers used to match the number of partitions.

### Detailed motivation for the change

The parmetis program implicitly expects a file named `<graph-name>_stats.txt` to be in the current working directory, the way the call is implemented at least. Actually the reference DGL implementation is wrong, it passes the graph_name whereas pm_dglpart actually expects a prefix path to which it appends _stats.txt. It just so happens that if we prefix the graph_name to a file in the cwd, and name it graph-name_stats.txt pm_dglpart will pick it up and use it.

A more correct solution would be to pass the absolute path to graph-name_stats.txt as the first argument to pm_dglpart (which pm_dglpart refers to as `fstem`)


You can check out the actual call [here](https://github.com/KarypisLab/PM4GNN/blob/e9c5a98d58681312ed012cc73b86d285a07b51d7/programs/dglpart.c#L57-L65)

The fstem var is used downstream [here](https://github.com/KarypisLab/PM4GNN/blob/e9c5a98d58681312ed012cc73b86d285a07b51d7/programs/dglpart.c#L184-L190)

### Testing

Tested using Docker compose on ml-25M with 2 partitions. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
