### PR TITLE
[Bugfix] Loss funcs for multitask learning should also be added as torch nn.module

### DIFF
--- a/python/graphstorm/model/multitask_gnn.py
+++ b/python/graphstorm/model/multitask_gnn.py
@@ -92,6 +92,7 @@ class GSgnnMultiTaskSharedEncoderModel(GSgnnModel, GSgnnMultiTaskModelInterface)
         self._alpha_l2norm = alpha_l2norm
         self._task_pool = {}
         self._decoder = nn.ModuleDict()
+        self._loss_fn = nn.ModuleDict()
         self._warn_printed = False
 
     def add_task(self, task_id, task_type,
@@ -117,6 +118,8 @@ class GSgnnMultiTaskSharedEncoderModel(GSgnnModel, GSgnnMultiTaskModelInterface)
         logging.info("Setup task %s", task_id)
         self._task_pool[task_id] = (task_type, loss_func)
         self._decoder[task_id] = decoder
+        # add loss func in nn module
+        self._loss_fn[task_id] = loss_func
 
     @property
     def alpha_l2norm(self):

--- a/tests/unit-tests/test_gnn.py
+++ b/tests/unit-tests/test_gnn.py
@@ -1807,38 +1807,41 @@ class DummyLPDecoder(nn.Module):
     def forward(self, g, h, e_h=None):
         return h
 
+class DummyPredLoss(nn.Module):
+    def forward(self, logits, labels):
+        return logits - labels
+
+class DummyLPPredLoss(nn.Module):
+    def forward(self, pos_score, neg_score):
+        return pos_score["n0"] + neg_score["n0"]
 
 def test_multi_task_forward():
     mt_model = GSgnnMultiTaskSharedEncoderModel(0.1)
 
-    def pred_los_func(logits, labels):
-        return logits - labels
-    def pred_lp_loss_func(pos_score, neg_score):
-        return pos_score["n0"] + neg_score["n0"]
     mt_model.add_task("nc_task",
                       BUILTIN_TASK_NODE_CLASSIFICATION,
                       DummyNCDecoder(),
-                      pred_los_func)
+                      DummyPredLoss())
 
     mt_model.add_task("nr_task",
                       BUILTIN_TASK_NODE_REGRESSION,
                       DummyNRDecoder(),
-                      pred_los_func)
+                      DummyPredLoss())
 
     mt_model.add_task("ec_task",
                       BUILTIN_TASK_EDGE_CLASSIFICATION,
                       DummyECDecoder(),
-                      pred_los_func)
+                      DummyPredLoss())
 
     mt_model.add_task("er_task",
                       BUILTIN_TASK_EDGE_REGRESSION,
                       DummyERDecoder(),
-                      pred_los_func)
+                      DummyPredLoss())
 
     mt_model.add_task("lp_task",
                       BUILTIN_TASK_LINK_PREDICTION,
                       DummyLPDecoder(),
-                      pred_lp_loss_func)
+                      DummyLPPredLoss())
 
     @patch.object(GSgnnMultiTaskSharedEncoderModel, 'comput_input_embed')
     @patch.object(GSgnnMultiTaskSharedEncoderModel, 'compute_embed_step')
@@ -1946,34 +1949,30 @@ def test_multi_task_forward():
 def test_multi_task_predict():
     mt_model = GSgnnMultiTaskSharedEncoderModel(0.1)
 
-    def pred_los_func(logits, labels):
-        return logits - labels
-    def pred_lp_loss_func(pos_score, neg_score):
-        return pos_score["n0"] + neg_score["n0"]
     mt_model.add_task("nc_task",
                       BUILTIN_TASK_NODE_CLASSIFICATION,
                       DummyNCDecoder(),
-                      pred_los_func)
+                      DummyPredLoss())
 
     mt_model.add_task("nr_task",
                       BUILTIN_TASK_NODE_REGRESSION,
                       DummyNRDecoder(),
-                      pred_los_func)
+                      DummyPredLoss())
 
     mt_model.add_task("ec_task",
                       BUILTIN_TASK_EDGE_CLASSIFICATION,
                       DummyECDecoder(),
-                      pred_los_func)
+                      DummyPredLoss())
 
     mt_model.add_task("er_task",
                       BUILTIN_TASK_EDGE_REGRESSION,
                       DummyERDecoder(),
-                      pred_los_func)
+                      DummyPredLoss())
 
     mt_model.add_task("lp_task",
                       BUILTIN_TASK_LINK_PREDICTION,
                       DummyLPDecoder(),
-                      pred_lp_loss_func)
+                      DummyLPPredLoss())
 
     @patch.object(GSgnnMultiTaskSharedEncoderModel, 'comput_input_embed')
     @patch.object(GSgnnMultiTaskSharedEncoderModel, 'compute_embed_step')
@@ -2090,39 +2089,35 @@ def test_multi_task_predict():
 def test_multi_task_mini_batch_predict():
     mt_model = GSgnnMultiTaskSharedEncoderModel(0.1)
 
-    def pred_los_func(logits, labels):
-        return logits - labels
-    def pred_lp_loss_func(pos_score, neg_score):
-        return pos_score["n0"] + neg_score["n0"]
     mt_model.add_task("nc_task",
                       BUILTIN_TASK_NODE_CLASSIFICATION,
                       DummyNCDecoder(),
-                      pred_los_func)
+                      DummyPredLoss())
 
     mt_model.add_task("nr_task",
                       BUILTIN_TASK_NODE_REGRESSION,
                       DummyNRDecoder(),
-                      pred_los_func)
+                      DummyPredLoss())
 
     mt_model.add_task("ec_task",
                       BUILTIN_TASK_EDGE_CLASSIFICATION,
                       DummyECDecoder(),
-                      pred_los_func)
+                      DummyPredLoss())
 
     mt_model.add_task("er_task",
                       BUILTIN_TASK_EDGE_REGRESSION,
                       DummyERDecoder(),
-                      pred_los_func)
+                      DummyPredLoss())
 
     mt_model.add_task("lp_task",
                       BUILTIN_TASK_LINK_PREDICTION,
                       DummyLPDecoder(),
-                      pred_lp_loss_func)
+                      DummyLPPredLoss())
 
     mt_model.add_task("nfr_task",
                       BUILTIN_TASK_RECONSTRUCT_NODE_FEAT,
                       DummyLPDecoder(),
-                      pred_lp_loss_func)
+                      DummyLPPredLoss())
 
     tast_info_nc = TaskInfo(task_type=BUILTIN_TASK_NODE_CLASSIFICATION,
                             task_id='nc_task',


### PR DESCRIPTION
*Issue #, if available:*
The loss funcs of GSgnnMultiTaskSharedEncoderModel are not added as nn.modules of GSgnnMultiTaskSharedEncoderModel. This will cause device error in some cases.

*Description of changes:*
Adding loss funcs as a nn.ModuleDict() of GSgnnMultiTaskSharedEncoderModel.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
