### PR TITLE
[Bugfix] Fix EntityRegression.out_dims() dimension mismatch

### DIFF
--- a/python/graphstorm/model/node_decoder.py
+++ b/python/graphstorm/model/node_decoder.py
@@ -122,7 +122,8 @@ class EntityRegression(GSLayer):
                  dropout=0,
                  out_dim=1):
         super(EntityRegression, self).__init__()
-        self.h_dim = h_dim
+        self._h_dim = h_dim
+        self._out_dim = out_dim
         self.decoder = nn.Parameter(th.Tensor(h_dim, out_dim))
         nn.init.xavier_uniform_(self.decoder)
         # TODO(zhengda): The dropout is not used.
@@ -166,10 +167,10 @@ class EntityRegression(GSLayer):
     def in_dims(self):
         """ The number of input dimensions.
         """
-        return self.h_dim
+        return self._h_dim
 
     @property
     def out_dims(self):
         """ The number of output dimensions.
         """
-        return 1
+        return self._out_dim

--- a/tests/unit-tests/test_decoder.py
+++ b/tests/unit-tests/test_decoder.py
@@ -481,7 +481,7 @@ def test_MLPEFeatEdgeDecoder(h_dim, feat_dim, out_dim, num_ffn_layers):
         pred = out.argmax(dim=1)
         assert_almost_equal(prediction.cpu().numpy(), pred.cpu().numpy())
 
-@pytest.mark.parametrize("h_dim", [16, 64])
+@pytest.mark.parametrize("in_dim", [16, 64])
 @pytest.mark.parametrize("out_dim", [1, 8])
 def test_EntityRegression(in_dim, out_dim):
     decoder = EntityRegression(h_dim=in_dim)

--- a/tests/unit-tests/test_decoder.py
+++ b/tests/unit-tests/test_decoder.py
@@ -24,6 +24,7 @@ from graphstorm.model import (LinkPredictDotDecoder,
                               LinkPredictDistMultDecoder,
                               LinkPredictWeightedDotDecoder,
                               LinkPredictWeightedDistMultDecoder,
+                              EntityRegression,
                               MLPEFeatEdgeDecoder,
                               LinkPredictContrastiveDotDecoder,
                               LinkPredictContrastiveDistMultDecoder)
@@ -480,7 +481,21 @@ def test_MLPEFeatEdgeDecoder(h_dim, feat_dim, out_dim, num_ffn_layers):
         pred = out.argmax(dim=1)
         assert_almost_equal(prediction.cpu().numpy(), pred.cpu().numpy())
 
+@pytest.mark.parametrize("h_dim", [16, 64])
+@pytest.mark.parametrize("out_dim", [1, 8])
+def test_EntityRegression(in_dim, out_dim):
+    decoder = EntityRegression(h_dim=in_dim)
+    assert decoder.in_dims == in_dim
+    assert decoder.out_dims == 1
+
+    decoder = EntityRegression(h_dim=in_dim, out_dim=out_dim)
+    assert decoder.in_dims == in_dim
+    assert decoder.out_dims == out_dim
+
 if __name__ == '__main__':
+    test_EntityRegression(8, 1)
+    test_EntityRegression(8, 8)
+
     test_LinkPredictContrastiveDistMultDecoder(32, 8, 16, "cpu")
     test_LinkPredictContrastiveDistMultDecoder(16, 32, 32, "cuda:0")
     test_LinkPredictContrastiveDotDecoder(32, 8, 16, "cpu")


### PR DESCRIPTION
*Issue #, if available:*
Code to reproduce the error:
```
>>> from graphstorm.model import EntityRegression
>>> decoder = EntityRegression(h_dim=in_dim, out_dim=10)
>>> print(decoder.out_dims)
1
```
The decoder.out_dims should be 10.

*Description of changes:*
Fix the bug

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
