### PR TITLE
[GSProcessing] Add default argument values for optional numerical transformation kwargs

### DIFF
--- a/graphstorm-processing/graphstorm_processing/data_transformations/dist_transformations/dist_numerical_transformation.py
+++ b/graphstorm-processing/graphstorm_processing/data_transformations/dist_transformations/dist_numerical_transformation.py
@@ -236,8 +236,8 @@ class DistNumericalTransformation(DistributedTransformation):
     def __init__(
         self,
         cols: Sequence[str],
-        normalizer: str,
-        imputer: str,
+        normalizer: str = "none",
+        imputer: str = "none",
         out_dtype: str = TYPE_FLOAT32,
         epsilon: float = 1e-6,
     ) -> None:
@@ -290,9 +290,9 @@ class DistMultiNumericalTransformation(DistNumericalTransformation):
     def __init__(
         self,
         cols: Sequence[str],
-        separator: Optional[str],
-        normalizer: str,
-        imputer: str,
+        separator: Optional[str] = None,
+        normalizer: str = "none",
+        imputer: str = "none",
         out_dtype: str = TYPE_FLOAT32,
     ) -> None:
         assert (


### PR DESCRIPTION
Also adds tests and fixes some pylint errors in test file.

*Issue #, if available:*

*Description of changes:*

* Previously if a user provided a numerical transformation config where imputer, norm, or separator (for multi-num) was missing, the job would fail since the object could not be instantiated without all required arguments, although we list those args as optional.
* This PR adds default values for all optional args in the classes' __init__
* Also adds a couple of tests and fixes a few pylint errors in the test file.
* Also add a test for the case where the multi-numerical input is a vector value (which is the case for Parquet vector inputs)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
