### PR TITLE
[Bug Fix] Trim leading/tailing space for `node_feat_name`

### DIFF
--- a/docs/source/cli/model-training-inference/configuration-run.rst
+++ b/docs/source/cli/model-training-inference/configuration-run.rst
@@ -54,9 +54,9 @@ GraphStorm provides a set of parameters to config the GNN model structure (input
 - **node_feat_name**: User defined feature name. It accepts two formats: a) `fname`, if a node has node features, the corresponding feature name will be fname; b) `ntype0:feat0 ntype1:featA ...`, different node types have different node feature name(s). In the example, "ntype0" has a node feature named "feat0" and "ntype1" has a node feature named "featA".
 
     - Yaml: ``node_feat_name:``
-                | ``- "ntype1:featA"``
+                | ``- "ntype1:featA,featB"``
                 | ``- "ntype0:feat0"``
-    - Argument: ``--node-feat-name "ntype0:feat0 ntype1:featA"``
+    - Argument: ``--node-feat-name "ntype0:feat0 ntype1:featA,featB"``
     - Default value: If not provided, there will be no node features used by GraphStorm even graphs have node features attached.
 
     .. Note:: Characters ``:`` and white space are not allowed to be used in node feature names.  And in Yaml format, need to put each node's feature in a separated line that starts with a hyphon.

--- a/python/graphstorm/config/argument.py
+++ b/python/graphstorm/config/argument.py
@@ -1198,7 +1198,7 @@ class GSConfig:
                 assert isinstance(feat_info[1], str), \
                     f"Feature name of {ntype} should be a string not {feat_info[1]}"
                 # multiple features separated by ','
-                fname_dict[ntype] = feat_info[1].split(",")
+                fname_dict[ntype] = [item.strip() for item in feat_info[1].split(",")]
             return fname_dict
 
         # By default, return None which means there is no node feature

--- a/tests/unit-tests/test_config.py
+++ b/tests/unit-tests/test_config.py
@@ -1187,7 +1187,7 @@ def create_gnn_config(tmp_path, file_name):
     with open(os.path.join(tmp_path, file_name+"5.yaml"), "w") as f:
         yaml.dump(yaml_object, f)
 
-    # The config here should be the last,
+    # The config here should be the last one,
     # otherwise the following default test will have wrong config
     yaml_object["gsf"]["basic"] = {
         "model_encoder_type": "lm"

--- a/tests/unit-tests/test_config.py
+++ b/tests/unit-tests/test_config.py
@@ -1295,7 +1295,7 @@ def test_gnn_info():
         assert 'ntype1' in config.node_feat_name
         assert len(config.node_feat_name['ntype0']) == 2
         assert "feat_name" in config.node_feat_name['ntype0']
-        assert "fname" in config.node_feat_name['ntype0']
+        assert "feat_name2" in config.node_feat_name['ntype0']
         assert config.node_feat_name['ntype1'] == ["fname"]
         assert config.use_mini_batch_infer == True
 

--- a/tests/unit-tests/test_config.py
+++ b/tests/unit-tests/test_config.py
@@ -1187,6 +1187,16 @@ def create_gnn_config(tmp_path, file_name):
     with open(os.path.join(tmp_path, file_name+"5.yaml"), "w") as f:
         yaml.dump(yaml_object, f)
 
+    yaml_object["gsf"]["node_classification"] = {}
+    yaml_object["gsf"]["basic"] = {
+        "model_encoder_type": "rgat"
+    }
+    yaml_object["gsf"]["gnn"] = {
+        "node_feat_name": ["ntype0:feat_name, feat_name2 ", "ntype1: fname"],
+    }
+    with open(os.path.join(tmp_path, file_name+"6.yaml"), "w") as f:
+        yaml.dump(yaml_object, f)
+
     # config for check default value
     yaml_object["gsf"]["gnn"] = {
     }
@@ -1276,6 +1286,18 @@ def test_gnn_info():
                          local_rank=0)
         config = GSConfig(args)
         assert config.num_layers == 0 # lm model does not need n layers
+
+        args = Namespace(yaml_config_file=os.path.join(Path(tmpdirname), 'gnn_test6.yaml'),
+                         local_rank=0)
+        config = GSConfig(args)
+        assert len(config.node_feat_name) == 2
+        assert 'ntype0' in config.node_feat_name
+        assert 'ntype1' in config.node_feat_name
+        assert len(config.node_feat_name['ntype0']) == 2
+        assert "feat_name" in config.node_feat_name['ntype0']
+        assert "fname" in config.node_feat_name['ntype0']
+        assert config.node_feat_name['ntype1'] == ["fname"]
+        assert config.use_mini_batch_infer == True
 
         args = Namespace(yaml_config_file=os.path.join(Path(tmpdirname), 'gnn_test_default.yaml'),
                          local_rank=0)

--- a/tests/unit-tests/test_config.py
+++ b/tests/unit-tests/test_config.py
@@ -1177,22 +1177,22 @@ def create_gnn_config(tmp_path, file_name):
     with open(os.path.join(tmp_path, file_name+"4.yaml"), "w") as f:
         yaml.dump(yaml_object, f)
 
-    yaml_object["gsf"]["basic"] = {
-        "model_encoder_type": "lm"
-    }
-    yaml_object["gsf"]["gnn"] = {
-        "num_layers": 2, # for encoder of lm, num_layers will always be 0
-        "hidden_size": 128,
-    }
-    with open(os.path.join(tmp_path, file_name+"5.yaml"), "w") as f:
-        yaml.dump(yaml_object, f)
-
     yaml_object["gsf"]["node_classification"] = {}
     yaml_object["gsf"]["basic"] = {
         "model_encoder_type": "rgat"
     }
     yaml_object["gsf"]["gnn"] = {
         "node_feat_name": ["ntype0:feat_name, feat_name2 ", "ntype1: fname"],
+    }
+    with open(os.path.join(tmp_path, file_name+"5.yaml"), "w") as f:
+        yaml.dump(yaml_object, f)
+
+    yaml_object["gsf"]["basic"] = {
+        "model_encoder_type": "lm"
+    }
+    yaml_object["gsf"]["gnn"] = {
+        "num_layers": 2, # for encoder of lm, num_layers will always be 0
+        "hidden_size": 128,
     }
     with open(os.path.join(tmp_path, file_name+"6.yaml"), "w") as f:
         yaml.dump(yaml_object, f)
@@ -1285,11 +1285,6 @@ def test_gnn_info():
         args = Namespace(yaml_config_file=os.path.join(Path(tmpdirname), 'gnn_test5.yaml'),
                          local_rank=0)
         config = GSConfig(args)
-        assert config.num_layers == 0 # lm model does not need n layers
-
-        args = Namespace(yaml_config_file=os.path.join(Path(tmpdirname), 'gnn_test6.yaml'),
-                         local_rank=0)
-        config = GSConfig(args)
         assert len(config.node_feat_name) == 2
         assert 'ntype0' in config.node_feat_name
         assert 'ntype1' in config.node_feat_name
@@ -1298,6 +1293,11 @@ def test_gnn_info():
         assert "feat_name2" in config.node_feat_name['ntype0']
         assert config.node_feat_name['ntype1'] == ["fname"]
         assert config.use_mini_batch_infer == True
+
+        args = Namespace(yaml_config_file=os.path.join(Path(tmpdirname), 'gnn_test6.yaml'),
+                         local_rank=0)
+        config = GSConfig(args)
+        assert config.num_layers == 0 # lm model does not need n layers
 
         args = Namespace(yaml_config_file=os.path.join(Path(tmpdirname), 'gnn_test_default.yaml'),
                          local_rank=0)

--- a/tests/unit-tests/test_config.py
+++ b/tests/unit-tests/test_config.py
@@ -1187,6 +1187,8 @@ def create_gnn_config(tmp_path, file_name):
     with open(os.path.join(tmp_path, file_name+"5.yaml"), "w") as f:
         yaml.dump(yaml_object, f)
 
+    # The config here should be the last,
+    # otherwise the following default test will have wrong config
     yaml_object["gsf"]["basic"] = {
         "model_encoder_type": "lm"
     }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Support `node_feat_name` input to add space like: `node_type_a:feat_name_1, feat_name_2`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
