### PR TITLE
[BugFix] Fix distmult evaluation score calculation

### DIFF
--- a/python/graphstorm/model/edge_decoder.py
+++ b/python/graphstorm/model/edge_decoder.py
@@ -831,14 +831,14 @@ class LinkPredictDotDecoder(LinkPredictNoParamDecoder):
             Positive and negative edges stored in a dict of tuple in the format of
             {("src_ntype1", "etype1", "dst_ntype1" ): (pos_src_idx, neg_src_idx,
             pos_dst_idx, neg_dst_idx)}.
-            
+
             The `pos_src_idx` represents the postive source node indexes in the format
             of Torch.Tensor. The `neg_src_idx` represents the negative source node indexes
             in the format of Torch.Tensor. The `pos_dst_idx` represents the postive destination
             node indexes in the format of Torch.Tensor. The `neg_dst_idx` represents the
             negative destination node indexes in the format of Torch.Tensor.
 
-            We define positive and negative edges as: 
+            We define positive and negative edges as:
 
             * The positive edges: (pos_src_idx, pos_dst_idx)
             * The negative edges: (pos_src_idx, neg_dst_idx) and
@@ -1126,14 +1126,14 @@ class LinkPredictDistMultDecoder(LinkPredictLearnableDecoder):
             Positive and negative edges stored in a dict of tuple in the format of
             {("src_ntype1", "etype1", "dst_ntype1" ): (pos_src_idx, neg_src_idx,
             pos_dst_idx, neg_dst_idx)}.
-            
+
             The `pos_src_idx` represents the postive source node indexes in the format
             of Torch.Tensor. The `neg_src_idx` represents the negative source node indexes
             in the format of Torch.Tensor. The `pos_dst_idx` represents the postive destination
             node indexes in the format of Torch.Tensor. The `neg_dst_idx` represents the
             negative destination node indexes in the format of Torch.Tensor.
 
-            We define positive and negative edges as: 
+            We define positive and negative edges as:
 
             * The positive edges: (pos_src_idx, pos_dst_idx)
             * The negative edges: (pos_src_idx, neg_dst_idx) and
@@ -1182,7 +1182,7 @@ class LinkPredictDistMultDecoder(LinkPredictLearnableDecoder):
                     rel_embedding = rel_embedding.reshape(
                         1, 1, rel_embedding.shape[-1])
                     neg_score = calc_distmult_pos_score(
-                        neg_src_emb, rel_embedding, pos_dst_emb, device)
+                        neg_src_emb, pos_dst_emb, rel_embedding, device)
                 elif neg_sample_type == BUILTIN_LP_JOINT_NEG_SAMPLER:
                     # joint sampled negative samples
                     assert len(pos_dst_emb.shape) == 2, \
@@ -1216,7 +1216,7 @@ class LinkPredictDistMultDecoder(LinkPredictLearnableDecoder):
                     rel_embedding = rel_embedding.reshape(
                         1, 1, rel_embedding.shape[-1])
                     neg_score = calc_distmult_pos_score(
-                        pos_src_emb, rel_embedding, neg_dst_emb, device)
+                        pos_src_emb, neg_dst_emb, rel_embedding, device)
                 elif neg_sample_type == BUILTIN_LP_JOINT_NEG_SAMPLER:
                     neg_dst_emb = emb[vtype][neg_dst]
                     # joint sampled negative samples
@@ -1399,7 +1399,7 @@ class LinkPredictWeightedDotDecoder(LinkPredictDotDecoder):
         The input dimension size. It is the dimension for both source and destination
         node embeddings.
     edge_weight_fields: dict of str
-        
+
     """
     def __init__(self, in_dim, edge_weight_fields):
         self._edge_weight_fields = edge_weight_fields

--- a/tests/unit-tests/test_decoder.py
+++ b/tests/unit-tests/test_decoder.py
@@ -77,13 +77,13 @@ def check_calc_test_scores_uniform_neg(decoder, etypes, h_dim, num_pos, num_neg,
         pos_src_emb = emb[etypes[0][0]][pos_src]
         pos_dst_emb = emb[etypes[0][2]][pos_dst]
         rel_emb = decoder.get_relemb(etypes[0])
-        pos_score = calc_distmult_pos_score(pos_src_emb, rel_emb, pos_dst_emb)
+        pos_score = calc_distmult_pos_score(pos_src_emb, pos_dst_emb, rel_emb)
         neg_scores = []
         for i in range(pos_src.shape[0]):
             pse = pos_src_emb[i]
             neg_dst_emb = emb[etypes[0][2]][neg_dst[i]]
             # (dim) * (dim) * (num_neg, dim)
-            ns = calc_distmult_pos_score(pse, rel_emb, neg_dst_emb)
+            ns = calc_distmult_pos_score(pse, neg_dst_emb, rel_emb)
             neg_scores.append(ns)
         neg_scores = th.stack(neg_scores)
         _check_scores(score, pos_score, neg_scores, etypes[0], num_neg, pos_src.shape[0])
@@ -92,13 +92,13 @@ def check_calc_test_scores_uniform_neg(decoder, etypes, h_dim, num_pos, num_neg,
         pos_src_emb = emb[etypes[1][0]][pos_src]
         pos_dst_emb = emb[etypes[1][2]][pos_dst]
         rel_emb = decoder.get_relemb(etypes[1])
-        pos_score = calc_distmult_pos_score(pos_src_emb, rel_emb, pos_dst_emb)
+        pos_score = calc_distmult_pos_score(pos_src_emb, pos_dst_emb, rel_emb)
         neg_scores = []
         for i in range(pos_dst.shape[0]):
             neg_src_emb = emb[etypes[1][0]][neg_src[i]]
             pde = pos_dst_emb[i]
             # (num_neg, dim) * (dim) * (dim)
-            ns = calc_distmult_pos_score(neg_src_emb, rel_emb, pde)
+            ns = calc_distmult_pos_score(neg_src_emb, pde, rel_emb)
             neg_scores.append(ns)
         neg_scores = th.stack(neg_scores)
         _check_scores(score, pos_score, neg_scores, etypes[1], num_neg, pos_src.shape[0])
@@ -111,7 +111,7 @@ def check_calc_test_scores_uniform_neg(decoder, etypes, h_dim, num_pos, num_neg,
         pos_src_emb = emb[etypes[0][0]][pos_src]
         pos_dst_emb = emb[etypes[0][2]][pos_dst]
         rel_emb = decoder.get_relemb(etypes[0])
-        pos_score = calc_distmult_pos_score(pos_src_emb, rel_emb, pos_dst_emb)
+        pos_score = calc_distmult_pos_score(pos_src_emb, pos_dst_emb, rel_emb)
         neg_scores = []
         for i in range(pos_src.shape[0]):
             pse = pos_src_emb[i]
@@ -119,9 +119,9 @@ def check_calc_test_scores_uniform_neg(decoder, etypes, h_dim, num_pos, num_neg,
             neg_src_emb = emb[etypes[0][0]][neg_src[i]]
             neg_dst_emb = emb[etypes[0][2]][neg_dst[i]]
             # (num_neg, dim) * (dim) * (dim)
-            ns_0 = calc_distmult_pos_score(neg_src_emb, rel_emb, pde)
+            ns_0 = calc_distmult_pos_score(neg_src_emb, pde, rel_emb)
             # (dim) * (dim) * (num_neg, dim)
-            ns_1 = calc_distmult_pos_score(pse, rel_emb, neg_dst_emb)
+            ns_1 = calc_distmult_pos_score(pse, neg_dst_emb, rel_emb)
             neg_scores.append(th.cat((ns_0, ns_1), dim=-1))
         neg_scores = th.stack(neg_scores)
         _check_scores(score, pos_score, neg_scores, etypes[0], num_neg*2, pos_src.shape[0])
@@ -154,13 +154,13 @@ def check_calc_test_scores_joint_neg(decoder, etypes, h_dim, num_pos, num_neg, d
         pos_src_emb = emb[etypes[0][0]][pos_src]
         pos_dst_emb = emb[etypes[0][2]][pos_dst]
         rel_emb = decoder.get_relemb(etypes[0])
-        pos_score = calc_distmult_pos_score(pos_src_emb, rel_emb, pos_dst_emb)
+        pos_score = calc_distmult_pos_score(pos_src_emb, pos_dst_emb, rel_emb)
         neg_scores = []
         for i in range(pos_src.shape[0]):
             pse = pos_src_emb[i]
             neg_dst_emb = emb[etypes[0][2]][neg_dst]
             # (dim) * (dim) * (num_neg, dim)
-            ns = calc_distmult_pos_score(pse, rel_emb, neg_dst_emb)
+            ns = calc_distmult_pos_score(pse, neg_dst_emb, rel_emb)
             neg_scores.append(ns)
         neg_scores = th.stack(neg_scores)
         _check_scores(score, pos_score, neg_scores, etypes[0], num_neg, pos_src.shape[0])
@@ -169,13 +169,13 @@ def check_calc_test_scores_joint_neg(decoder, etypes, h_dim, num_pos, num_neg, d
         pos_src_emb = emb[etypes[1][0]][pos_src]
         pos_dst_emb = emb[etypes[1][2]][pos_dst]
         rel_emb = decoder.get_relemb(etypes[1])
-        pos_score = calc_distmult_pos_score(pos_src_emb, rel_emb, pos_dst_emb)
+        pos_score = calc_distmult_pos_score(pos_src_emb, pos_dst_emb, rel_emb)
         neg_scores = []
         for i in range(pos_dst.shape[0]):
             neg_src_emb = emb[etypes[1][0]][neg_src]
             pde = pos_dst_emb[i]
             # (num_neg, dim) * (dim) * (dim)
-            ns = calc_distmult_pos_score(neg_src_emb, rel_emb, pde)
+            ns = calc_distmult_pos_score(neg_src_emb, pde, rel_emb)
             neg_scores.append(ns)
         neg_scores = th.stack(neg_scores)
         _check_scores(score, pos_score, neg_scores, etypes[1], num_neg, pos_src.shape[0])
@@ -188,7 +188,7 @@ def check_calc_test_scores_joint_neg(decoder, etypes, h_dim, num_pos, num_neg, d
         pos_src_emb = emb[etypes[0][0]][pos_src]
         pos_dst_emb = emb[etypes[0][2]][pos_dst]
         rel_emb = decoder.get_relemb(etypes[0])
-        pos_score = calc_distmult_pos_score(pos_src_emb, rel_emb, pos_dst_emb)
+        pos_score = calc_distmult_pos_score(pos_src_emb, pos_dst_emb, rel_emb)
         neg_scores = []
         for i in range(pos_src.shape[0]):
             pse = pos_src_emb[i]
@@ -196,9 +196,9 @@ def check_calc_test_scores_joint_neg(decoder, etypes, h_dim, num_pos, num_neg, d
             neg_src_emb = emb[etypes[0][0]][neg_src]
             neg_dst_emb = emb[etypes[0][2]][neg_dst]
             # (num_neg, dim) * (dim) * (dim)
-            ns_0 = calc_distmult_pos_score(neg_src_emb, rel_emb, pde)
+            ns_0 = calc_distmult_pos_score(neg_src_emb, pde, rel_emb)
             # (dim) * (dim) * (num_neg, dim)
-            ns_1 = calc_distmult_pos_score(pse, rel_emb, neg_dst_emb)
+            ns_1 = calc_distmult_pos_score(pse, neg_dst_emb, rel_emb)
             neg_scores.append(th.cat((ns_0, ns_1), dim=-1))
         neg_scores = th.stack(neg_scores)
         _check_scores(score, pos_score, neg_scores, etypes[0], num_neg*2, pos_src.shape[0])


### PR DESCRIPTION
*Issue #, if available:*
There is a bug when calling `calc_distmult_pos_score` to compute scores of positive edges during testing. Though the bug will not cause any performance issue as mathematically, reordering tensor position in DistMult will not cause any problem.

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
