### PR TITLE
[GSProcessing] Initial support for multi-task mask generation

### DIFF
--- a/docs/source/advanced/multi-task-learning.rst
+++ b/docs/source/advanced/multi-task-learning.rst
@@ -154,6 +154,8 @@ You can follow the instructions in :ref:`Run graph construction<run-graph-constr
 GraphStorm construction tool for creating partitioned graph data. Please ensure you
 customize the command line arguments such as `--conf-file`, `--output-dir`, `--graph-name` to your
 specific values.
+For large graphs you can use GSProcessing to prepare your data. For specific instructions when
+using GSProcessing for multi-task training see :ref:`gsprocessing-multitask-ref`.
 
 
 Run Multi-task Learning Training

--- a/docs/source/cli/graph-construction/distributed/gsprocessing/input-configuration.rst
+++ b/docs/source/cli/graph-construction/distributed/gsprocessing/input-configuration.rst
@@ -497,18 +497,16 @@ arguments.
 Creating a graph for multi-task training
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-To create a graph for multi-task training, you simply need to
-define a label in your config for each of the labels you want to
-use during training. GSProcessing will generate separate
-train/val/test masks for each of your labels, which
-will be named ``<mask_type>_<label_column>``, e.g.
-if your label columns were ``label_class``, and ``label_reg``
-GSProcessing will generate masks named as ``train_mask_label_class``,
-``train_mask_label_reg`` etc. For link prediction tasks, the masks
-will have ``_lp`` added as a suffix, e.g. ``train_mask_lp``.
+To create a graph for multi-task training, you need to
+define custom label names in your config for each of the labels you want to
+use during training in a ``mask_field_names`` entry for each label config.
+GSProcessing will generate separate
+train/val/test masks for each of your labels named
+accordingly.
 
-After partitioning the data, you can then provide these masks
-in your train YAML file to use during multi-task training.
+After partitioning the data, you need to then provide the same
+mask names in a ``mask_fields`` entry
+in your train YAML file during multi-task training.
 
 For details on running multi-task training see
 :doc:`/advanced/multi-task-learning`.
@@ -555,7 +553,12 @@ type.
                             "train": 0.8,
                             "val": 0.1,
                             "test": 0.1
-                        }
+                        },
+                        "mask_field_names": [
+                            "train_mask_class",
+                            "val_mask_class",
+                            "test_mask_class"
+                        ]
                     }
                 ]
             }
@@ -587,7 +590,12 @@ type.
                             "train": 0.8,
                             "val": 0.1,
                             "test": 0.1
-                        }
+                        },
+                        "mask_field_names": [
+                            "train_mask_lp",
+                            "val_mask_lp",
+                            "test_mask_lp"
+                        ]
                     }
                 ]
             }
@@ -636,9 +644,9 @@ train YAML file to run multi-task training:
                 target_ntype: "paper"
                 label_field: "label"
                 mask_fields:
-                    - "train_mask_label"
-                    - "val_mask_label"
-                    - "test_mask_label"
+                    - "train_mask_class"
+                    - "val_mask_class"
+                    - "test_mask_class"
                 num_classes: 14
                 task_weight: 1.0
             - link_prediction:
@@ -671,7 +679,7 @@ when you want to produce a graph just for inference.
 Examples
 ~~~~~~~~
 
-OAG-Paper dataset
+Node classification for node type `field` in OAG-Paper dataset
 -----------------
 
 .. code-block:: json

--- a/graphstorm-processing/graphstorm_processing/config/config_conversion/gconstruct_converter.py
+++ b/graphstorm-processing/graphstorm_processing/config/config_conversion/gconstruct_converter.py
@@ -83,10 +83,7 @@ class GConstructConfigConverter(ConfigConverter):
                 if "separator" in label:
                     label_sep = label["separator"]
                     label_dict["separator"] = label_sep
-                # Not supported for multi-task config for GSProcessing
-                assert "mask_field_names" not in label, (
-                    "GSProcessing currently cannot " "construct labels for multi-task learning"
-                )
+
                 labels_list.append(label_dict)
             except KeyError as exc:
                 raise KeyError(f"A required key was missing from label input {label}") from exc
@@ -189,7 +186,6 @@ class GConstructConfigConverter(ConfigConverter):
                         "hf_model": gconstruct_transform_dict["bert_model"],
                         "max_seq_length": gconstruct_transform_dict["max_seq_length"],
                     }
-                # TODO: Add support for other common transformations here
                 else:
                     raise ValueError(
                         "Unsupported GConstruct transformation name: "

--- a/graphstorm-processing/graphstorm_processing/config/config_conversion/gconstruct_converter.py
+++ b/graphstorm-processing/graphstorm_processing/config/config_conversion/gconstruct_converter.py
@@ -83,6 +83,8 @@ class GConstructConfigConverter(ConfigConverter):
                 if "separator" in label:
                     label_sep = label["separator"]
                     label_dict["separator"] = label_sep
+                if "mask_field_names" in label:
+                    label_dict["mask_field_names"] = label["mask_field_names"]
 
                 labels_list.append(label_dict)
             except KeyError as exc:

--- a/graphstorm-processing/graphstorm_processing/config/label_config_base.py
+++ b/graphstorm-processing/graphstorm_processing/config/label_config_base.py
@@ -28,7 +28,6 @@ class LabelConfig(abc.ABC):
             self._label_column = config_dict["column"]
         else:
             self._label_column = ""
-            assert config_dict["type"] == "link_prediction"
         self._task_type: str = config_dict["type"]
         self._separator: Optional[str] = (
             config_dict["separator"] if "separator" in config_dict else None
@@ -37,7 +36,11 @@ class LabelConfig(abc.ABC):
         self._custom_split_filenames: Dict[str, list[str]] = {}
         self._split: Dict[str, float] = {}
         if "custom_split_filenames" not in config_dict:
-            self._split = config_dict["split_rate"]
+            # Get the custom split rate, or use the default 80/10/10 split
+            self._split = config_dict.get(
+                "split_rate",
+                {"train": 0.8, "val": 0.1, "test": 0.1},
+            )
         else:
             self._custom_split_filenames = config_dict["custom_split_filenames"]
 

--- a/graphstorm-processing/graphstorm_processing/config/label_config_base.py
+++ b/graphstorm-processing/graphstorm_processing/config/label_config_base.py
@@ -43,6 +43,10 @@ class LabelConfig(abc.ABC):
             )
         else:
             self._custom_split_filenames = config_dict["custom_split_filenames"]
+        if "mask_field_names" in config_dict:
+            self._mask_field_names: list[str] = config_dict["mask_field_names"]
+        else:
+            self._mask_field_names = None
 
     def _sanity_check(self):
         if self._label_column == "":
@@ -61,6 +65,10 @@ class LabelConfig(abc.ABC):
             assert "test" in self._custom_split_filenames
             assert "column" in self._custom_split_filenames
             assert isinstance(self._separator, str) if self._multilabel else self._separator is None
+        if self._mask_field_names:
+            assert isinstance(self._mask_field_names, list)
+            assert all(isinstance(x, str) for x in self._mask_field_names)
+            assert len(self._mask_field_names) == 3
 
     @property
     def label_column(self) -> str:
@@ -93,6 +101,11 @@ class LabelConfig(abc.ABC):
     def custom_split_filenames(self) -> Dict[str, Any]:
         """The config for custom split labels."""
         return self._custom_split_filenames
+
+    @property
+    def mask_field_names(self) -> Optional[tuple[str, str, str]]:
+        """Custom names to assign to masks for multi-task learning."""
+        return tuple(self._mask_field_names) if self._mask_field_names else None
 
 
 class EdgeLabelConfig(LabelConfig):

--- a/graphstorm-processing/graphstorm_processing/config/label_config_base.py
+++ b/graphstorm-processing/graphstorm_processing/config/label_config_base.py
@@ -44,7 +44,7 @@ class LabelConfig(abc.ABC):
         else:
             self._custom_split_filenames = config_dict["custom_split_filenames"]
         if "mask_field_names" in config_dict:
-            self._mask_field_names: list[str] = config_dict["mask_field_names"]
+            self._mask_field_names: Optional[list[str]] = config_dict["mask_field_names"]
         else:
             self._mask_field_names = None
 

--- a/graphstorm-processing/graphstorm_processing/data_transformations/dist_label_loader.py
+++ b/graphstorm-processing/graphstorm_processing/data_transformations/dist_label_loader.py
@@ -104,7 +104,7 @@ class DistLabelLoader:
         self.label_config = label_config
         self.label_column = label_config.label_column
         self.spark = spark
-        self.label_map = {}  # type: Dict[str, int]
+        self.label_map: dict[str, int] = {}
 
     def process_label(self, input_df: DataFrame) -> DataFrame:
         """Transforms the label column in the input DataFrame to conform to GraphStorm expectations.

--- a/graphstorm-processing/graphstorm_processing/data_transformations/dist_label_loader.py
+++ b/graphstorm-processing/graphstorm_processing/data_transformations/dist_label_loader.py
@@ -15,6 +15,7 @@ limitations under the License.
 """
 
 from dataclasses import dataclass
+from math import fsum
 
 from pyspark.sql import DataFrame, SparkSession
 from pyspark.sql.types import FloatType
@@ -58,7 +59,7 @@ class SplitRates:
         Validate the split rates.
         """
         # TODO: add support for sums <= 1.0, useful for large-scale link prediction
-        if self.train_rate + self.val_rate + self.test_rate != 1.0:
+        if fsum([self.train_rate, self.val_rate, self.test_rate]) != 1.0:
             raise ValueError(
                 "Sum of split rates must be 1.0, got "
                 f"{self.train_rate=}, {self.val_rate=}, {self.test_rate=}"

--- a/graphstorm-processing/graphstorm_processing/data_transformations/dist_label_loader.py
+++ b/graphstorm-processing/graphstorm_processing/data_transformations/dist_label_loader.py
@@ -15,7 +15,6 @@ limitations under the License.
 """
 
 from dataclasses import dataclass
-from typing import Dict, List
 
 from pyspark.sql import DataFrame, SparkSession
 from pyspark.sql.types import FloatType
@@ -37,11 +36,22 @@ class SplitRates:
     val_rate: float
     test_rate: float
 
-    def tolist(self) -> List[float]:
+    def tolist(self) -> list[float]:
         """
         Return the split rates as a list of floats: [train_rate, val_rate, test_rate]
         """
         return [self.train_rate, self.val_rate, self.test_rate]
+
+    def todict(self) -> dict[str, float]:
+        """
+        Return the split rates as a dict of str to float:
+        {
+            "train": train_rate,
+            "val": val_rate,
+            "test": test_rate,
+        }
+        """
+        return {"train": self.train_rate, "val": self.val_rate, "test": self.test_rate}
 
     def __post_init__(self) -> None:
         """

--- a/graphstorm-processing/graphstorm_processing/graph_loaders/dist_heterogeneous_loader.py
+++ b/graphstorm-processing/graphstorm_processing/graph_loaders/dist_heterogeneous_loader.py
@@ -202,6 +202,34 @@ class DistHeterogeneousGraphLoader(object):
         # we collect an column name substitutions we had to make
         # here and later output as a JSON file.
         self.column_substitutions: dict[str, str] = {}
+        # graph_info structure:
+        # {
+        #     "nfeat_size": {
+        #         "ntype_name": { Mapping from ntype to length of feature vector
+        #             "feature_name": feature_vector_length (int),
+        #             [...]
+        #         },
+        #         [...]
+        #     },
+        #     "efeat_size": Same as nfeat_size,
+        #     [n/e]type_label assume only a single node/edge type has label, for NeptuneML
+        #     "ntype_label": ["ntype_that_has_labels"],
+        #     "ntype_label_property": ["column_of_ntype_with_label"],
+        #     "etype_label": [],
+        #     "etype_label_property": [],
+        #     "task_type": "node_class",
+        #     "label_map": {"male": 0, "female": 1}, # Value map for classification tasks
+        #     "label_properties": { # Name and value counts for classification labels
+        #         "user": {
+        #             "COLUMN_NAME": "gender",
+        #             "VALUE_COUNTS": {"male": 3, "female": 1, "null": 1},
+        #         }
+        #     },
+        #     "ntype_to_label_masks": { Mapping from node type to label mask names
+        #           "user": ["train_mask", "val_mask", "test_mask"]
+        #     },
+        #     "etype_to_label_masks": {},
+        # }
         self.graph_info: dict[str, Any] = {}
 
         # transformation_representations structure:

--- a/graphstorm-processing/graphstorm_processing/graph_loaders/dist_heterogeneous_loader.py
+++ b/graphstorm-processing/graphstorm_processing/graph_loaders/dist_heterogeneous_loader.py
@@ -49,7 +49,11 @@ from graphstorm_processing.constants import (
     HUGGINGFACE_TOKENIZE,
     TRANSFORMATIONS_FILENAME,
 )
-from graphstorm_processing.config.config_parser import EdgeConfig, NodeConfig, StructureConfig
+from graphstorm_processing.config.config_parser import (
+    EdgeConfig,
+    NodeConfig,
+    StructureConfig,
+)
 from graphstorm_processing.config.label_config_base import LabelConfig
 from graphstorm_processing.config.feature_config_base import FeatureConfig
 from graphstorm_processing.data_transformations.dist_feature_transformer import (
@@ -288,10 +292,10 @@ class DistHeterogeneousGraphLoader(object):
             metadata_dict["node_data"] = {}
 
         edges_start_time = perf_counter()
-        edge_data_dict, edges_dict = self.process_edge_data(edge_configs)
+        edge_data_dict, edge_structure_dict = self.process_edge_data(edge_configs)
         self.timers["process_edge_data"] = perf_counter() - edges_start_time
         metadata_dict["edge_data"] = edge_data_dict
-        metadata_dict["edges"] = edges_dict
+        metadata_dict["edges"] = edge_structure_dict
         # We use the data location as the graph name, can also take from user?
         # TODO: Fix this, take from config?
         metadata_dict["graph_name"] = (
@@ -320,7 +324,9 @@ class DistHeterogeneousGraphLoader(object):
 
         # Write the transformations file
         with open(
-            os.path.join(self.output_path, TRANSFORMATIONS_FILENAME), "w", encoding="utf-8"
+            os.path.join(self.output_path, TRANSFORMATIONS_FILENAME),
+            "w",
+            encoding="utf-8",
         ) as f:
             json.dump(self.transformation_representations, f, indent=4)
 
@@ -328,7 +334,9 @@ class DistHeterogeneousGraphLoader(object):
         # name did not fit Parquet requirements
         if len(self.column_substitutions) > 0:
             with open(
-                os.path.join(self.output_path, "column_substitutions.json"), "w", encoding="utf-8"
+                os.path.join(self.output_path, "column_substitutions.json"),
+                "w",
+                encoding="utf-8",
             ) as f:
                 json.dump(self.column_substitutions, f, indent=4)
 
@@ -647,7 +655,9 @@ class DistHeterogeneousGraphLoader(object):
         return missing_node_types
 
     def create_node_id_maps_from_edges(
-        self, edge_configs: Sequence[EdgeConfig], missing_node_types: Optional[Set[str]] = None
+        self,
+        edge_configs: Sequence[EdgeConfig],
+        missing_node_types: Optional[Set[str]] = None,
     ) -> None:
         """Creates node id mappings from edges.
 
@@ -785,7 +795,8 @@ class DistHeterogeneousGraphLoader(object):
         # TODO: The counts trigger computations, should we avoid this?
         if node_df_with_ids.count() > mapping_df.count():
             logging.info(
-                "Node mapping count mismatch, for node_col: %s, re-assigning int ids...", node_col
+                "Node mapping count mismatch, for node_col: %s, re-assigning int ids...",
+                node_col,
             )
             node_rdd_with_ids = (
                 node_df_with_ids.select(join_col)
@@ -899,6 +910,7 @@ class DistHeterogeneousGraphLoader(object):
         self.graph_info["nfeat_size"] = {}
         self.graph_info["ntype_label"] = []
         self.graph_info["ntype_label_property"] = []
+        self.graph_info["ntype_to_label_masks"] = defaultdict(list)
         for node_config in node_configs:
             files = node_config.files
             file_paths = [f"{self.input_prefix}/{f}" for f in files]
@@ -958,7 +970,9 @@ class DistHeterogeneousGraphLoader(object):
                     nodes_df_count = nodes_df.count()
                     mapping_df_count = mapping_df.count()
                     logging.warning(
-                        "Node mapping count for node type %s: %d", node_type, mapping_df_count
+                        "Node mapping count for node type %s: %d",
+                        node_type,
+                        mapping_df_count,
                     )
                     assert nodes_df_count == mapping_df_count, (
                         f"Nodes df count ({nodes_df_count}) does not match "
@@ -992,6 +1006,14 @@ class DistHeterogeneousGraphLoader(object):
                     node_config.label_configs, nodes_df, node_type
                 )
                 node_type_metadata_dicts.update(node_type_label_metadata)
+
+                for label_config in node_config.label_configs:
+                    if label_config.mask_field_names:
+                        mask_names = label_config.mask_field_names
+                    else:
+                        mask_names = ("train_mask", "val_mask", "test_mask")
+                    self.graph_info["ntype_to_label_masks"][node_type].extend(mask_names)
+
                 self.graph_info["ntype_label"].append(node_type)
                 self.graph_info["ntype_label_property"].append(
                     node_config.label_configs[0].label_column
@@ -1045,7 +1067,10 @@ class DistHeterogeneousGraphLoader(object):
         return node_feature_metadata_dict, nfeat_size
 
     def _process_node_features(
-        self, feature_configs: Sequence[FeatureConfig], nodes_df: DataFrame, node_type: str
+        self,
+        feature_configs: Sequence[FeatureConfig],
+        nodes_df: DataFrame,
+        node_type: str,
     ) -> Tuple[Dict, Dict]:
         """Transform node features and write to storage.
 
@@ -1088,7 +1113,8 @@ class DistHeterogeneousGraphLoader(object):
 
             if json_representation:
                 logging.info(
-                    "Will apply pre-computed transformation for feature: %s", feat_conf.feat_name
+                    "Will apply pre-computed transformation for feature: %s",
+                    feat_conf.feat_name,
                 )
 
             transformed_feature_df, json_representation = transformer.apply_transformation(nodes_df)
@@ -1107,7 +1133,11 @@ class DistHeterogeneousGraphLoader(object):
                     and feat_conf.transformation_kwargs["action"] == HUGGINGFACE_TOKENIZE
                 ):
 
-                    for bert_feat_name in ["input_ids", "attention_mask", "token_type_ids"]:
+                    for bert_feat_name in [
+                        "input_ids",
+                        "attention_mask",
+                        "token_type_ids",
+                    ]:
                         single_feature_df = transformed_feature_df.select(bert_feat_name)
                         feature_output_path = os.path.join(
                             self.output_prefix,
@@ -1168,7 +1198,7 @@ class DistHeterogeneousGraphLoader(object):
             self.graph_info["label_map"] = node_label_loader.label_map
 
             label_output_path = (
-                f"{self.output_prefix}/node_data/{node_type}-label-{label_conf.label_column}"
+                f"{self.output_prefix}/node_data/" f"{node_type}-label-{label_conf.label_column}"
             )
 
             path_list = self._write_df(transformed_label, label_output_path)
@@ -1251,10 +1281,14 @@ class DistHeterogeneousGraphLoader(object):
         dst_col = edge_config.dst_col
         dst_ntype = edge_config.dst_ntype
         edge_type = (
-            f"{edge_config.src_ntype}:{edge_config.get_relation_name()}:{edge_config.dst_ntype}"
+            f"{edge_config.src_ntype}:"
+            f"{edge_config.get_relation_name()}:"
+            f"{edge_config.dst_ntype}"
         )
         rev_edge_type = (
-            f"{edge_config.dst_ntype}:{edge_config.get_relation_name()}-rev:{edge_config.src_ntype}"
+            f"{edge_config.dst_ntype}:"
+            f"{edge_config.get_relation_name()}-rev:"
+            f"{edge_config.src_ntype}"
         )
 
         src_node_id_mapping = (
@@ -1417,104 +1451,149 @@ class DistHeterogeneousGraphLoader(object):
         """
         # iterates over entries of the edge section in the export config
         edge_data_dict = {}
-        edges_dict = {}
+        edge_structure_dict = {}
         logging.info("Processing edge data...")
         self.graph_info["efeat_size"] = {}
         self.graph_info["etype_label"] = []
         self.graph_info["etype_label_property"] = []
+        # A mapping from edge type to all label masks for the type
+        self.graph_info["etype_to_label_masks"] = defaultdict(list)
         for edge_config in edge_configs:
-            read_edges_start = perf_counter()
-            edges_df = self._read_edge_df(edge_config)
-            # TODO: Assert columns from config exist in the edge df
-
-            # This will throw an "already cached" warning if
-            # we created mappings from the edges alone
-            edges_df.cache()
-            edge_type = (
-                f"{edge_config.src_ntype}:{edge_config.get_relation_name()}:{edge_config.dst_ntype}"
-            )
-            reverse_edge_type = (
-                f"{edge_config.dst_ntype}"
-                f":{edge_config.get_relation_name()}-rev"
-                f":{edge_config.src_ntype}"
-            )
-            logging.info("Processing edge type '%s'...", edge_type)
-
-            # The following performs the str-to-node-id mapping conversion
-            # on the edge files and writes them to S3, along with their reverse.
-            edges_df, edge_structure_path_list, reverse_edge_path_list = self.write_edge_structure(
-                edges_df, edge_config
-            )
-            self.timers["read_edges_and_write_structure"] += perf_counter() - read_edges_start
-
-            edges_metadata_dict = {
-                "format": {"name": FORMAT_NAME, "delimiter": DELIMITER},
-                "data": edge_structure_path_list,
-            }
-            edges_dict[edge_type] = edges_metadata_dict
-
-            if self.add_reverse_edges:
-                reverse_edges_metadata_dict = {
-                    "format": {"name": FORMAT_NAME, "delimiter": DELIMITER},
-                    "data": reverse_edge_path_list,
-                }
-
-                edges_dict[reverse_edge_type] = reverse_edges_metadata_dict
-
-            # Without features or labels
-            if edge_config.feature_configs is None and edge_config.label_configs is None:
-                logging.info("No features or labels for edge type: %s", edge_type)
-            # With features or labels
-            else:
-                # TODO: Add unit tests for this branch
-                relation_col = edge_config.rel_col
-                edge_type_metadata_dicts = {}
-
-                if edge_config.feature_configs is not None:
-                    edge_feature_start = perf_counter()
-                    edge_feature_metadata_dicts, etype_feat_sizes = self._process_edge_features(
-                        edge_config.feature_configs, edges_df, edge_type
-                    )
-                    self.graph_info["efeat_size"].update({edge_type: etype_feat_sizes})
-                    edge_type_metadata_dicts.update(edge_feature_metadata_dicts)
-                    self.timers["_process_edge_features"] += perf_counter() - edge_feature_start
-                if edge_config.label_configs is not None:
-                    if relation_col is None or relation_col == "":
-                        edge_label_start = perf_counter()
-                        # All edges have the same relation type
-                        label_metadata_dicts = self._process_edge_labels(
-                            edge_config.label_configs, edges_df, edge_type, edge_config.rel_type
-                        )
-                        edge_type_metadata_dicts.update(label_metadata_dicts)
-                        self.graph_info["etype_label"].append(edge_type)
-                        self.graph_info["etype_label"].append(reverse_edge_type)
-                        if edge_config.label_configs[0].task_type != "link_prediction":
-                            self.graph_info["etype_label_property"].append(
-                                edge_config.label_configs[0].label_column
-                            )
-
-                        if self.add_reverse_edges:
-                            # For reverse edges only the label metadata
-                            # (labels + split masks) are relevant.
-                            edge_data_dict[reverse_edge_type] = label_metadata_dicts
-                        self.timers["_process_edge_labels"] += perf_counter() - edge_label_start
-                    else:
-                        # Different edges can have different relation types
-                        # TODO: For each rel_type we need get the label and output it separately.
-                        # We'll create one file output per rel_type, with the labels for each type
-                        raise NotImplementedError(
-                            "Currently we do not support loading edge "
-                            "labels with multiple edge relation types"
-                        )
-                if edge_type_metadata_dicts:
-                    edge_data_dict[edge_type] = edge_type_metadata_dicts
-                edges_df.unpersist()
+            self._process_single_edge(edge_config, edge_data_dict, edge_structure_dict)
 
         logging.info("Finished processing edge features")
-        return edge_data_dict, edges_dict
+        return edge_data_dict, edge_structure_dict
+
+    def _process_single_edge(
+        self, edge_config: EdgeConfig, edge_data_dict: dict, edge_structure_dict: dict
+    ):
+        """Processes a single edge type, including writing the edge structure and data.
+
+        Updates ``edge_data_dict`` and ``edge_structure_dict`` dicts in-place.
+
+        Parameters
+        ----------
+        edge_config : EdgeConfig
+            Configuration object for one edge type.
+        edge_data_dict : dict
+            Shared edge data dict that will be used as output for metadata.json.
+        edge_structure_dict : dict
+            Shared edge structure dict that will be used as output for metadata.json.
+
+        Raises
+        ------
+        NotImplementedError
+            If the config contains a "relation" column, indicating that the type
+            of edge is determined by a column in the data (Gremlin format).
+        """
+        read_edges_start = perf_counter()
+        edges_df = self._read_edge_df(edge_config)
+        # TODO: Assert columns from config exist in the edge df
+
+        # This will throw an "already cached" warning if
+        # we created mappings from the edges alone
+        edges_df.cache()
+        edge_type = (
+            f"{edge_config.src_ntype}:"
+            f"{edge_config.get_relation_name()}:"
+            f"{edge_config.dst_ntype}"
+        )
+        reverse_edge_type = (
+            f"{edge_config.dst_ntype}:"
+            f"{edge_config.get_relation_name()}-rev:"
+            f"{edge_config.src_ntype}"
+        )
+        logging.info("Processing edge type '%s'...", edge_type)
+
+        # The following performs the str-to-node-id mapping conversion
+        # on the edge files and writes them to S3, along with their reverse.
+        edges_df, edge_structure_path_list, reverse_edge_path_list = self.write_edge_structure(
+            edges_df, edge_config
+        )
+        self.timers["read_edges_and_write_structure"] += perf_counter() - read_edges_start
+
+        edges_metadata_dict = {
+            "format": {"name": FORMAT_NAME, "delimiter": DELIMITER},
+            "data": edge_structure_path_list,
+        }
+        edge_structure_dict[edge_type] = edges_metadata_dict
+
+        if self.add_reverse_edges:
+            reverse_edges_metadata_dict = {
+                "format": {"name": FORMAT_NAME, "delimiter": DELIMITER},
+                "data": reverse_edge_path_list,
+            }
+
+            edge_structure_dict[reverse_edge_type] = reverse_edges_metadata_dict
+
+        # Without features or labels
+        if edge_config.feature_configs is None and edge_config.label_configs is None:
+            logging.info("No features or labels for edge type: %s", edge_type)
+        # With features or labels
+        else:
+            # TODO: Add unit tests for this branch
+            relation_col = edge_config.rel_col
+            edge_type_metadata_dicts = {}
+
+            if edge_config.feature_configs is not None:
+                edge_feature_start = perf_counter()
+                edge_feature_metadata_dicts, etype_feat_sizes = self._process_edge_features(
+                    edge_config.feature_configs, edges_df, edge_type
+                )
+                self.graph_info["efeat_size"].update({edge_type: etype_feat_sizes})
+                edge_type_metadata_dicts.update(edge_feature_metadata_dicts)
+                self.timers["_process_edge_features"] += perf_counter() - edge_feature_start
+
+            if edge_config.label_configs is not None:
+                if relation_col is None or relation_col == "":
+                    edge_label_start = perf_counter()
+                    # All edges have the same relation type
+                    label_metadata_dicts = self._process_edge_labels(
+                        edge_config.label_configs,
+                        edges_df,
+                        edge_type,
+                        edge_config.rel_type,
+                    )
+                    edge_type_metadata_dicts.update(label_metadata_dicts)
+                    self.graph_info["etype_label"].append(edge_type)
+                    self.graph_info["etype_label"].append(reverse_edge_type)
+                    self.graph_info["etype_to_label_masks"][edge_type] = []
+
+                    # Collect all the mask names for the edge type
+                    for label_config in edge_config.label_configs:
+                        if label_config.mask_field_names:
+                            mask_names = label_config.mask_field_names
+                        else:
+                            mask_names = ("train_mask", "val_mask", "test_mask")
+                        self.graph_info["etype_to_label_masks"][edge_type].extend(mask_names)
+
+                    if edge_config.label_configs[0].task_type != "link_prediction":
+                        self.graph_info["etype_label_property"].append(
+                            edge_config.label_configs[0].label_column
+                        )
+
+                    if self.add_reverse_edges:
+                        # For reverse edges only the label metadata
+                        # (labels + split masks) are relevant.
+                        edge_data_dict[reverse_edge_type] = label_metadata_dicts
+                    self.timers["_process_edge_labels"] += perf_counter() - edge_label_start
+                else:
+                    # Different edges can have different relation types
+                    # TODO: For each rel_type we need get the label and output it separately.
+                    # We'll create one file output per rel_type, with the labels for each type
+                    raise NotImplementedError(
+                        "Currently we do not support loading edge "
+                        "labels with multiple edge relation types"
+                    )
+            if edge_type_metadata_dicts:
+                edge_data_dict[edge_type] = edge_type_metadata_dicts
+            edges_df.unpersist()
 
     def _process_edge_features(
-        self, feature_configs: Sequence[FeatureConfig], edges_df: DataFrame, edge_type: str
+        self,
+        feature_configs: Sequence[FeatureConfig],
+        edges_df: DataFrame,
+        edge_type: str,
     ) -> Tuple[Dict, Dict]:
         """Process edge features.
 
@@ -1553,7 +1632,8 @@ class DistHeterogeneousGraphLoader(object):
 
             if json_representation:
                 logging.info(
-                    "Will apply pre-computed transformation for feature: %s", feat_conf.feat_name
+                    "Will apply pre-computed transformation for feature: %s",
+                    feat_conf.feat_name,
                 )
             transformed_feature_df, json_representation = transformer.apply_transformation(edges_df)
             transformed_feature_df.cache()
@@ -1571,7 +1651,11 @@ class DistHeterogeneousGraphLoader(object):
                     feat_conf.feat_type == HUGGINGFACE_TRANFORM
                     and feat_conf.transformation_kwargs["action"] == HUGGINGFACE_TOKENIZE
                 ):
-                    for bert_feat_name in ["input_ids", "attention_mask", "token_type_ids"]:
+                    for bert_feat_name in [
+                        "input_ids",
+                        "attention_mask",
+                        "token_type_ids",
+                    ]:
                         single_feature_df = transformed_feature_df.select(bert_feat_name)
                         feature_output_path = os.path.join(
                             self.output_prefix,
@@ -1715,7 +1799,10 @@ class DistHeterogeneousGraphLoader(object):
         return label_metadata_dicts
 
     def _update_label_properties(
-        self, node_or_edge_type: str, original_labels: DataFrame, label_config: LabelConfig
+        self,
+        node_or_edge_type: str,
+        original_labels: DataFrame,
+        label_config: LabelConfig,
     ) -> None:
         """Extracts and stores statistics about labels.
 
@@ -1842,7 +1929,10 @@ class DistHeterogeneousGraphLoader(object):
             mask_dfs = self._create_split_files_custom_split(input_df, custom_split_file)
 
         def create_metadata_entry(path_list):
-            return {"format": {"name": FORMAT_NAME, "delimiter": DELIMITER}, "data": path_list}
+            return {
+                "format": {"name": FORMAT_NAME, "delimiter": DELIMITER},
+                "data": path_list,
+            }
 
         if mask_field_names is not None:
             mask_names = mask_field_names

--- a/graphstorm-processing/graphstorm_processing/repartition_files.py
+++ b/graphstorm-processing/graphstorm_processing/repartition_files.py
@@ -55,7 +55,7 @@ from graphstorm_processing.data_transformations import s3_utils
 from graphstorm_processing.graph_loaders.row_count_utils import ParquetRowCounter
 from graphstorm_processing.constants import FilesystemType
 
-NUM_WRITE_THREADS = 1
+NUM_WRITE_THREADS = 16
 
 
 class ParquetRepartitioner:

--- a/graphstorm-processing/tests/resources/repartitioning/partitioned_metadata.json
+++ b/graphstorm-processing/tests/resources/repartitioning/partitioned_metadata.json
@@ -76,6 +76,48 @@
                     "name": "parquet",
                     "delimiter": ""
                 }
+            },
+            "class_train_mask": {
+                "data":[
+                    "edge_data/dummy_type-class_train_mask/parquet/part-00000.parquet",
+                    "edge_data/dummy_type-class_train_mask/parquet/part-00001.parquet",
+                    "edge_data/dummy_type-class_train_mask/parquet/part-00002.parquet",
+                    "edge_data/dummy_type-class_train_mask/parquet/part-00003.parquet",
+                    "edge_data/dummy_type-class_train_mask/parquet/part-00004.parquet"
+                ],
+                "row_counts": [10, 10, 10, 10, 10],
+                "format": {
+                    "name": "parquet",
+                    "delimiter": ""
+                }
+            },
+            "class_val_mask": {
+                "data":[
+                    "edge_data/dummy_type-class_val_mask/parquet/part-00000.parquet",
+                    "edge_data/dummy_type-class_val_mask/parquet/part-00001.parquet",
+                    "edge_data/dummy_type-class_val_mask/parquet/part-00002.parquet",
+                    "edge_data/dummy_type-class_val_mask/parquet/part-00003.parquet",
+                    "edge_data/dummy_type-class_val_mask/parquet/part-00004.parquet"
+                ],
+                "row_counts": [10, 10, 10, 10, 10],
+                "format": {
+                    "name": "parquet",
+                    "delimiter": ""
+                }
+            },
+            "class_test_mask": {
+                "data":[
+                    "edge_data/dummy_type-class_test_mask/parquet/part-00000.parquet",
+                    "edge_data/dummy_type-class_test_mask/parquet/part-00001.parquet",
+                    "edge_data/dummy_type-class_test_mask/parquet/part-00002.parquet",
+                    "edge_data/dummy_type-class_test_mask/parquet/part-00003.parquet",
+                    "edge_data/dummy_type-class_test_mask/parquet/part-00004.parquet"
+                ],
+                "row_counts": [10, 10, 10, 10, 10],
+                "format": {
+                    "name": "parquet",
+                    "delimiter": ""
+                }
             }
         },
         "dst:dummy_type-rev:src": {
@@ -120,7 +162,49 @@
                         "name": "parquet",
                         "delimiter": ""
                     }
+                },
+                "class_train_mask": {
+                "data":[
+                    "edge_data/dummy_type-class_train_mask/parquet/part-00000.parquet",
+                    "edge_data/dummy_type-class_train_mask/parquet/part-00001.parquet",
+                    "edge_data/dummy_type-class_train_mask/parquet/part-00002.parquet",
+                    "edge_data/dummy_type-class_train_mask/parquet/part-00003.parquet",
+                    "edge_data/dummy_type-class_train_mask/parquet/part-00004.parquet"
+                ],
+                "row_counts": [10, 10, 10, 10, 10],
+                "format": {
+                    "name": "parquet",
+                    "delimiter": ""
                 }
+            },
+            "class_val_mask": {
+                "data":[
+                    "edge_data/dummy_type-class_val_mask/parquet/part-00000.parquet",
+                    "edge_data/dummy_type-class_val_mask/parquet/part-00001.parquet",
+                    "edge_data/dummy_type-class_val_mask/parquet/part-00002.parquet",
+                    "edge_data/dummy_type-class_val_mask/parquet/part-00003.parquet",
+                    "edge_data/dummy_type-class_val_mask/parquet/part-00004.parquet"
+                ],
+                "row_counts": [10, 10, 10, 10, 10],
+                "format": {
+                    "name": "parquet",
+                    "delimiter": ""
+                }
+            },
+            "class_test_mask": {
+                "data":[
+                    "edge_data/dummy_type-class_test_mask/parquet/part-00000.parquet",
+                    "edge_data/dummy_type-class_test_mask/parquet/part-00001.parquet",
+                    "edge_data/dummy_type-class_test_mask/parquet/part-00002.parquet",
+                    "edge_data/dummy_type-class_test_mask/parquet/part-00003.parquet",
+                    "edge_data/dummy_type-class_test_mask/parquet/part-00004.parquet"
+                ],
+                "row_counts": [10, 10, 10, 10, 10],
+                "format": {
+                    "name": "parquet",
+                    "delimiter": ""
+                }
+            }
         }
     },
     "node_type": [
@@ -170,6 +254,48 @@
                     "name": "parquet",
                     "delimiter": ""
                 }
+            },
+            "class_train_mask": {
+                "data":[
+                    "node_data/src-class_train_mask/parquet/part-00000.parquet",
+                    "node_data/src-class_train_mask/parquet/part-00001.parquet",
+                    "node_data/src-class_train_mask/parquet/part-00002.parquet",
+                    "node_data/src-class_train_mask/parquet/part-00003.parquet",
+                    "node_data/src-class_train_mask/parquet/part-00004.parquet"
+                ],
+                "row_counts": [10, 10, 10, 10, 10],
+                "format": {
+                    "name": "parquet",
+                    "delimiter": ""
+                }
+            },
+            "class_val_mask": {
+                "data":[
+                    "node_data/src-class_val_mask/parquet/part-00000.parquet",
+                    "node_data/src-class_val_mask/parquet/part-00001.parquet",
+                    "node_data/src-class_val_mask/parquet/part-00002.parquet",
+                    "node_data/src-class_val_mask/parquet/part-00003.parquet",
+                    "node_data/src-class_val_mask/parquet/part-00004.parquet"
+                ],
+                "row_counts": [10, 10, 10, 10, 10],
+                "format": {
+                    "name": "parquet",
+                    "delimiter": ""
+                }
+            },
+            "class_test_mask": {
+                "data":[
+                    "node_data/src-class_test_mask/parquet/part-00000.parquet",
+                    "node_data/src-class_test_mask/parquet/part-00001.parquet",
+                    "node_data/src-class_test_mask/parquet/part-00002.parquet",
+                    "node_data/src-class_test_mask/parquet/part-00003.parquet",
+                    "node_data/src-class_test_mask/parquet/part-00004.parquet"
+                ],
+                "row_counts": [10, 10, 10, 10, 10],
+                "format": {
+                    "name": "parquet",
+                    "delimiter": ""
+                }
             }
         }
     },
@@ -186,6 +312,16 @@
         "etype_label_property": [
             "label"
         ],
-        "task_type": "edge_class"
+        "task_type": "edge_class",
+        "ntype_to_label_masks": {
+            "src": [
+                "class_train_mask", "class_val_mask", "class_test_mask"
+            ]
+        },
+        "etype_to_label_masks": {
+            "src:dummy_type:dst": [
+                "class_train_mask", "class_val_mask", "class_test_mask"
+            ]
+        }
     }
 }

--- a/graphstorm-processing/tests/test_converter.py
+++ b/graphstorm-processing/tests/test_converter.py
@@ -81,32 +81,20 @@ def test_try_read_invalid_gconstruct_config(converter: GConstructConfigConverter
     with pytest.raises(AssertionError):
         _ = converter.convert_nodes(node_dict["nodes"])
 
-    """Feature Name must exist for multiple feature columns"""
+    # Feature Name must exist for multiple feature columns
     node_dict["nodes"][0]["features"] = [{"feature_col": ["feature_1", "feature_2"]}]
 
     with pytest.raises(AssertionError):
         _ = converter.convert_nodes(node_dict["nodes"])
 
-    """Unsupported output dtype"""
+    # Unsupported output dtype
     node_dict["nodes"][0]["features"] = [{"feature_col": ["feature_1"], "out_dtype": "float16"}]
 
     with pytest.raises(AssertionError):
         _ = converter.convert_nodes(node_dict["nodes"])
 
-    """Unsupported format type"""
+    # Unsupported format type
     node_dict["nodes"][0]["format"] = {"name": "txt", "separator": ","}
-
-    with pytest.raises(AssertionError):
-        _ = converter.convert_nodes(node_dict["nodes"])
-
-
-def test_try_read_multi_task_gconstruct_config(
-    converter: GConstructConfigConverter, node_dict: dict
-):
-    """Check unsupported mask column"""
-    node_dict["nodes"][0]["labels"] = [
-        {"label_col": "label", "task_type": "classification", "mask_field_names": "train_mask"}
-    ]
 
     with pytest.raises(AssertionError):
         _ = converter.convert_nodes(node_dict["nodes"])
@@ -117,6 +105,7 @@ def test_try_read_multi_task_gconstruct_config(
 def test_try_convert_out_dtype(
     converter: GConstructConfigConverter, node_dict: dict, transform: str, out_dtype: str
 ):
+    """Test conversion of outdtype kwarg"""
     node_dict["nodes"][0]["features"] = [
         {
             "feature_col": ["paper_title"],

--- a/graphstorm-processing/tests/test_dist_label_loader.py
+++ b/graphstorm-processing/tests/test_dist_label_loader.py
@@ -14,8 +14,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-from typing import List
-
 import numpy as np
 
 from pyspark.sql import DataFrame, SparkSession
@@ -123,7 +121,7 @@ def test_dist_multilabel_classification(spark: SparkSession, check_df_schema):
 
     transformed_rows = transformed_labels.collect()
 
-    row_val_list = []  # type: List[List[float]]
+    row_val_list: list[list[float]] = []
     for row in transformed_rows:
         row_val_list.append(row[label_col])
 


### PR DESCRIPTION
Currently support only random mask generation.

*Issue #, if available:*

Fixes #992

*Description of changes:*

We add support for multi-task mask generation to GSProcessing.

~~To achieve this we add a boolean `is_multitask` class variable to `DistHeterogeneousGraphLoader`. We set this to true when there's more than one label defined in the input configuration.~~

~~When `is_multitask` is True, we append the label column name to the mask name of every label. For link prediction tasks, we append `_lp` to the mask name. We also modify `repartition_files.py` accordingly.~~

We use the same UX as with GConstruct: users are expected to provide a `mask_field_names` entry for each label they want to use in MT training.

We add an example to documentation and link to it from the main multi-task training guide. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
