### PR TITLE
Add adversarial negative option to cross-entropy loss for link prediction tasks

### DIFF
--- a/docs/source/advanced/link-prediction.rst
+++ b/docs/source/advanced/link-prediction.rst
@@ -49,9 +49,11 @@ GraphStorm provides two ways to compute link prediction scores: Dot Product and 
     the ``tail_emb`` is the node embedding of the tail node and
     the ``relation_emb`` is the relation embedding of the specific edge type.
 
+.. _link_prediction_loss:
+
 Link Prediction Loss Functions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-GraphStorm provides three options to compute training losses:
+GraphStorm provides four options to compute training losses:
 
 * **Cross Entropy Loss**: The cross entropy loss turns a link prediction task into a binary classification task. We treat positive edges as 1 and negative edges as 0. The loss of an edge ``e`` is as:
 
@@ -82,6 +84,28 @@ GraphStorm provides three options to compute training losses:
         \end{eqnarray}
 
     where ``G`` is the training graph.
+
+
+* **Adversarial Cross Entropy Loss**: The adversarial cross entropy loss turns a link prediction task into a binary classification task. We treat positive edges as 1 and negative edges as 0. In addition, adversarial cross-entropy loss adjusts the loss value of each negative sample based on its degree of difficulty. This is enabled by setting the ``--adversarial_temperature`` config.
+
+    The loss of positive edges is as:
+
+    .. math::
+        \begin{eqnarray}
+            loss = - y \cdot \log score + (1 - y) \cdot \log (1 - score)
+        \end{eqnarray}
+
+    where ``y`` is 1, ``score`` is the score value of the positive edges computed by the score function.
+
+    The loss of negative edges is as:
+
+    .. math::
+        \begin{eqnarray}
+            loss = - y \cdot \log score + (1 - y) \cdot \log (1 - score)
+            loss = softmax(score * adversarial_temperature) * loss
+        \end{eqnarray}
+
+    where ``y`` is 0, ``score`` is the score value of the negative edges computed by the score function and ``adversarial_temperature`` is a hyper-parameter.
 
 * **Contrastive Loss**: The contrastive loss compels the representations of connected nodes to be similar while forcing the representations of disconnected nodes remains dissimilar. In the implementation, we use the score computed by the score function to represent the distance between nodes. When computing the loss, we group one positive edge with the ``N`` negative edges corresponding to it.The loss function is as follows:
 

--- a/docs/source/advanced/link-prediction.rst
+++ b/docs/source/advanced/link-prediction.rst
@@ -97,9 +97,10 @@ GraphStorm provides four options to compute training losses:
 
     .. math::
 
-        loss_{neg} &= \log (1 - score)
-
-        loss_{neg} &= \mathrm{softmax}(score * adversarial\_temperature) * loss_{neg}
+        \begin{gather*}
+        loss_{neg} = \log (1 - score) \\
+        loss_{neg} = \mathrm{softmax}(score * adversarial\_temperature) * loss_{neg}
+        \end{gather*}
 
     where ``score`` is the score value of the negative edges computed by the score function and ``adversarial_temperature`` is a hyper-parameter.
 

--- a/docs/source/advanced/link-prediction.rst
+++ b/docs/source/advanced/link-prediction.rst
@@ -58,6 +58,7 @@ GraphStorm provides four options to compute training losses:
 * **Cross Entropy Loss**: The cross entropy loss turns a link prediction task into a binary classification task. We treat positive edges as 1 and negative edges as 0. The loss of an edge ``e`` is as:
 
     .. math::
+
         \begin{eqnarray}
             loss = - y \cdot \log score + (1 - y) \cdot \log (1 - score)
         \end{eqnarray}
@@ -67,6 +68,7 @@ GraphStorm provides four options to compute training losses:
 * **Weighted Cross Entropy Loss**: The weighted cross entropy loss is similar to **Cross Entropy Loss** except that it allows users to set a weight for each positive edge. The loss function of an edge ``e`` is as:
 
     .. math::
+
         \begin{eqnarray}
             loss = - w\_e \left[ y \cdot \log score + (1 - y) \cdot \log (1 - score) \right]
         \end{eqnarray}
@@ -74,6 +76,7 @@ GraphStorm provides four options to compute training losses:
     where ``y`` is 1 when ``e`` is a positive edge and 0 when it is a negative edge. ``score`` is the score value of ``e`` computed by the score function, ``w_e`` is the weight of ``e`` and is defined as
 
     .. math::
+
         \begin{eqnarray}
         w\_e = \left \{
         \begin{array}{lc}
@@ -91,6 +94,7 @@ GraphStorm provides four options to compute training losses:
     The loss of positive edges is as:
 
     .. math::
+
         \begin{eqnarray}
             loss_{pos} = - \log score
         \end{eqnarray}
@@ -100,8 +104,10 @@ GraphStorm provides four options to compute training losses:
     The loss of negative edges is as:
 
     .. math::
+
         \begin{eqnarray}
-            loss_{neg} = \log (1 - score) \\
+            loss_{neg} = \log (1 - score)
+
             loss_{neg} = softmax(score * adversarial\_temperature) * loss_{neg}
         \end{eqnarray}
 
@@ -110,6 +116,7 @@ GraphStorm provides four options to compute training losses:
     The final loss is as:
 
     .. math::
+
         \begin{eqnarray}
             loss = (avg(loss_{pos}) + avg(loss_{neg})) / 2
         \end{eqnarray}
@@ -117,6 +124,7 @@ GraphStorm provides four options to compute training losses:
 * **Weighted Adversarial Cross Entropy Loss**  The weighted cross entropy loss is similar to **Adversarial Cross Entropy Loss** except that it allows users to set a weight for each positive edge. The loss function of a positive edge ``e`` is as:
 
     .. math::
+
         \begin{eqnarray}
             loss_{pos} = - w * \log score
         \end{eqnarray}
@@ -126,6 +134,7 @@ GraphStorm provides four options to compute training losses:
     The final loss is as:
 
     .. math::
+
         \begin{eqnarray}
             loss = (avg(loss_{pos}) + avg(loss_{neg})) / 2
         \end{eqnarray}
@@ -133,6 +142,7 @@ GraphStorm provides four options to compute training losses:
 * **Contrastive Loss**: The contrastive loss compels the representations of connected nodes to be similar while forcing the representations of disconnected nodes remains dissimilar. In the implementation, we use the score computed by the score function to represent the distance between nodes. When computing the loss, we group one positive edge with the ``N`` negative edges corresponding to it.The loss function is as follows:
 
     .. math::
+
         loss = -log(\dfrac{exp(pos\_score)}{\sum_{i=0}^N exp(score\_i)})
 
     where ``pos_score`` is the score of the positive edge. ``score_i`` is the score of the i-th edge. In total, there are ``N+1`` edges, within which there is 1 positive edge and ``N`` negative edges.

--- a/docs/source/advanced/link-prediction.rst
+++ b/docs/source/advanced/link-prediction.rst
@@ -49,7 +49,7 @@ GraphStorm provides two ways to compute link prediction scores: Dot Product and 
     the ``tail_emb`` is the node embedding of the tail node and
     the ``relation_emb`` is the relation embedding of the specific edge type.
 
-.. _link-prediction-loss:
+.. _link_prediction_loss:
 
 Link Prediction Loss Functions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -101,8 +101,8 @@ GraphStorm provides four options to compute training losses:
 
     .. math::
         \begin{eqnarray}
-            loss_{neg} = \log (1 - score)
-            loss_{neg} = softmax(score * adversarial_temperature) * loss_{neg}
+            loss_{neg} = \log (1 - score) \\
+            loss_{neg} = softmax(score * adversarial\_temperature) * loss_{neg}
         \end{eqnarray}
 
     where ``score`` is the score value of the negative edges computed by the score function and ``adversarial_temperature`` is a hyper-parameter.
@@ -118,10 +118,10 @@ GraphStorm provides four options to compute training losses:
 
     .. math::
         \begin{eqnarray}
-            loss_{pos} = - w\_e * \log score
+            loss_{pos} = - w * \log score
         \end{eqnarray}
 
-    where ``y`` is 1, ``score`` is the score value of the positive edges computed by the score function. The loss of the negative edges is the same as **Adversarial Cross Entropy Loss**.
+    where ``score`` is the score value of the positive edges computed by the score function, ``w`` is the weight of each positive edge. The loss of the negative edges is the same as **Adversarial Cross Entropy Loss**.
 
     The final loss is as:
 

--- a/docs/source/advanced/link-prediction.rst
+++ b/docs/source/advanced/link-prediction.rst
@@ -97,9 +97,9 @@ GraphStorm provides four options to compute training losses:
 
     .. math::
 
-        loss_{neg} = \log (1 - score)
+        loss_{neg} &= \log (1 - score)
 
-        loss_{neg} = softmax(score * adversarial\_temperature) * loss_{neg}
+        loss_{neg} &= \mathrm{softmax}(score * adversarial\_temperature) * loss_{neg}
 
     where ``score`` is the score value of the negative edges computed by the score function and ``adversarial_temperature`` is a hyper-parameter.
 
@@ -107,7 +107,7 @@ GraphStorm provides four options to compute training losses:
 
     .. math::
 
-        loss = (avg(loss_{pos}) + avg(loss_{neg})) / 2
+        loss = \left(\mathrm{avg}(loss_{pos}) + \mathrm{avg}(loss_{neg})\right) / 2
 
 * **Weighted Adversarial Cross Entropy Loss**  The weighted cross entropy loss is similar to **Adversarial Cross Entropy Loss** except that it allows users to set a weight for each positive edge. The loss function of a positive edge ``e`` is as:
 
@@ -121,13 +121,13 @@ GraphStorm provides four options to compute training losses:
 
     .. math::
 
-        loss = (avg(loss_{pos}) + avg(loss_{neg})) / 2
+        loss = \left(\mathrm{avg}(loss_{pos}) + \mathrm{avg}(loss_{neg})\right) / 2
 
 * **Contrastive Loss**: The contrastive loss compels the representations of connected nodes to be similar while forcing the representations of disconnected nodes remains dissimilar. In the implementation, we use the score computed by the score function to represent the distance between nodes. When computing the loss, we group one positive edge with the ``N`` negative edges corresponding to it.The loss function is as follows:
 
     .. math::
 
-        loss = -log(\dfrac{exp(pos\_score)}{\sum_{i=0}^N exp(score\_i)})
+        loss = -log(\dfrac{exp(pos\_score)}{\sum_{i=0}^N \exp(score\_i)})
 
     where ``pos_score`` is the score of the positive edge. ``score_i`` is the score of the i-th edge. In total, there are ``N+1`` edges, within which there is 1 positive edge and ``N`` negative edges.
 

--- a/docs/source/advanced/link-prediction.rst
+++ b/docs/source/advanced/link-prediction.rst
@@ -107,7 +107,7 @@ GraphStorm provides four options to compute training losses:
 
     .. math::
 
-        loss = \left(\mathrm{avg}(loss_{pos}) + \mathrm{avg}(loss_{neg})\right) / 2
+        loss = \dfrac{\mathrm{avg}(loss_{pos}) + \mathrm{avg}(loss_{neg})}{2}
 
 * **Weighted Adversarial Cross Entropy Loss**  The weighted cross entropy loss is similar to **Adversarial Cross Entropy Loss** except that it allows users to set a weight for each positive edge. The loss function of a positive edge ``e`` is as:
 
@@ -121,13 +121,13 @@ GraphStorm provides four options to compute training losses:
 
     .. math::
 
-        loss = \left(\mathrm{avg}(loss_{pos}) + \mathrm{avg}(loss_{neg})\right) / 2
+        loss = \dfrac{\mathrm{avg}(loss_{pos}) + \mathrm{avg}(loss_{neg})}{2}
 
 * **Contrastive Loss**: The contrastive loss compels the representations of connected nodes to be similar while forcing the representations of disconnected nodes remains dissimilar. In the implementation, we use the score computed by the score function to represent the distance between nodes. When computing the loss, we group one positive edge with the ``N`` negative edges corresponding to it.The loss function is as follows:
 
     .. math::
 
-        loss = -log(\dfrac{exp(pos\_score)}{\sum_{i=0}^N \exp(score\_i)})
+        loss = -\log \left( \dfrac{\exp(pos\_score)}{\sum_{i=0}^N \exp(score\_i)} \right)
 
     where ``pos_score`` is the score of the positive edge. ``score_i`` is the score of the i-th edge. In total, there are ``N+1`` edges, within which there is 1 positive edge and ``N`` negative edges.
 

--- a/docs/source/advanced/link-prediction.rst
+++ b/docs/source/advanced/link-prediction.rst
@@ -59,9 +59,7 @@ GraphStorm provides four options to compute training losses:
 
     .. math::
 
-        \begin{eqnarray}
-            loss = - y \cdot \log score + (1 - y) \cdot \log (1 - score)
-        \end{eqnarray}
+        loss = - y \cdot \log score + (1 - y) \cdot \log (1 - score)
 
     where ``y`` is 1 when ``e`` is a positive edge and 0 when it is a negative edge. ``score`` is the score value of ``e`` computed by the score function.
 
@@ -69,22 +67,18 @@ GraphStorm provides four options to compute training losses:
 
     .. math::
 
-        \begin{eqnarray}
-            loss = - w\_e \left[ y \cdot \log score + (1 - y) \cdot \log (1 - score) \right]
-        \end{eqnarray}
+        loss = - w\_e \left[ y \cdot \log score + (1 - y) \cdot \log (1 - score) \right]
 
     where ``y`` is 1 when ``e`` is a positive edge and 0 when it is a negative edge. ``score`` is the score value of ``e`` computed by the score function, ``w_e`` is the weight of ``e`` and is defined as
 
     .. math::
 
-        \begin{eqnarray}
         w\_e = \left \{
         \begin{array}{lc}
             1,  & \text{ if } e \in G, \\
             0,  & \text{ if } e \notin G
         \end{array}
         \right.
-        \end{eqnarray}
 
     where ``G`` is the training graph.
 
@@ -95,9 +89,7 @@ GraphStorm provides four options to compute training losses:
 
     .. math::
 
-        \begin{eqnarray}
-            loss_{pos} = - \log score
-        \end{eqnarray}
+        loss_{pos} = - \log score
 
     where ``score`` is the score value of the positive edges computed by the score function.
 
@@ -105,11 +97,9 @@ GraphStorm provides four options to compute training losses:
 
     .. math::
 
-        \begin{eqnarray}
-            loss_{neg} = \log (1 - score)
+        loss_{neg} = \log (1 - score)
 
-            loss_{neg} = softmax(score * adversarial\_temperature) * loss_{neg}
-        \end{eqnarray}
+        loss_{neg} = softmax(score * adversarial\_temperature) * loss_{neg}
 
     where ``score`` is the score value of the negative edges computed by the score function and ``adversarial_temperature`` is a hyper-parameter.
 
@@ -117,17 +107,13 @@ GraphStorm provides four options to compute training losses:
 
     .. math::
 
-        \begin{eqnarray}
-            loss = (avg(loss_{pos}) + avg(loss_{neg})) / 2
-        \end{eqnarray}
+        loss = (avg(loss_{pos}) + avg(loss_{neg})) / 2
 
 * **Weighted Adversarial Cross Entropy Loss**  The weighted cross entropy loss is similar to **Adversarial Cross Entropy Loss** except that it allows users to set a weight for each positive edge. The loss function of a positive edge ``e`` is as:
 
     .. math::
 
-        \begin{eqnarray}
-            loss_{pos} = - w * \log score
-        \end{eqnarray}
+        loss_{pos} = - w * \log score
 
     where ``score`` is the score value of the positive edges computed by the score function, ``w`` is the weight of each positive edge. The loss of the negative edges is the same as **Adversarial Cross Entropy Loss**.
 
@@ -135,9 +121,7 @@ GraphStorm provides four options to compute training losses:
 
     .. math::
 
-        \begin{eqnarray}
-            loss = (avg(loss_{pos}) + avg(loss_{neg})) / 2
-        \end{eqnarray}
+        loss = (avg(loss_{pos}) + avg(loss_{neg})) / 2
 
 * **Contrastive Loss**: The contrastive loss compels the representations of connected nodes to be similar while forcing the representations of disconnected nodes remains dissimilar. In the implementation, we use the score computed by the score function to represent the distance between nodes. When computing the loss, we group one positive edge with the ``N`` negative edges corresponding to it.The loss function is as follows:
 

--- a/docs/source/advanced/link-prediction.rst
+++ b/docs/source/advanced/link-prediction.rst
@@ -49,7 +49,7 @@ GraphStorm provides two ways to compute link prediction scores: Dot Product and 
     the ``tail_emb`` is the node embedding of the tail node and
     the ``relation_emb`` is the relation embedding of the specific edge type.
 
-.. _link_prediction_loss:
+.. _link-prediction-loss:
 
 Link Prediction Loss Functions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -86,26 +86,49 @@ GraphStorm provides four options to compute training losses:
     where ``G`` is the training graph.
 
 
-* **Adversarial Cross Entropy Loss**: The adversarial cross entropy loss turns a link prediction task into a binary classification task. We treat positive edges as 1 and negative edges as 0. In addition, adversarial cross-entropy loss adjusts the loss value of each negative sample based on its degree of difficulty. This is enabled by setting the ``--adversarial_temperature`` config.
+* **Adversarial Cross Entropy Loss**: The adversarial cross entropy loss turns a link prediction task into a binary classification task. We treat positive edges as 1 and negative edges as 0. In addition, adversarial cross-entropy loss adjusts the loss value of each negative sample based on its degree of difficulty. This is enabled by setting the ``adversarial_temperature`` config.
 
     The loss of positive edges is as:
 
     .. math::
         \begin{eqnarray}
-            loss = - y \cdot \log score + (1 - y) \cdot \log (1 - score)
+            loss_{pos} = - \log score
         \end{eqnarray}
 
-    where ``y`` is 1, ``score`` is the score value of the positive edges computed by the score function.
+    where ``score`` is the score value of the positive edges computed by the score function.
 
     The loss of negative edges is as:
 
     .. math::
         \begin{eqnarray}
-            loss = - y \cdot \log score + (1 - y) \cdot \log (1 - score)
-            loss = softmax(score * adversarial_temperature) * loss
+            loss_{neg} = \log (1 - score)
+            loss_{neg} = softmax(score * adversarial_temperature) * loss_{neg}
         \end{eqnarray}
 
-    where ``y`` is 0, ``score`` is the score value of the negative edges computed by the score function and ``adversarial_temperature`` is a hyper-parameter.
+    where ``score`` is the score value of the negative edges computed by the score function and ``adversarial_temperature`` is a hyper-parameter.
+
+    The final loss is as:
+
+    .. math::
+        \begin{eqnarray}
+            loss = (avg(loss_{pos}) + avg(loss_{neg})) / 2
+        \end{eqnarray}
+
+* **Weighted Adversarial Cross Entropy Loss**  The weighted cross entropy loss is similar to **Adversarial Cross Entropy Loss** except that it allows users to set a weight for each positive edge. The loss function of a positive edge ``e`` is as:
+
+    .. math::
+        \begin{eqnarray}
+            loss_{pos} = - w\_e * \log score
+        \end{eqnarray}
+
+    where ``y`` is 1, ``score`` is the score value of the positive edges computed by the score function. The loss of the negative edges is the same as **Adversarial Cross Entropy Loss**.
+
+    The final loss is as:
+
+    .. math::
+        \begin{eqnarray}
+            loss = (avg(loss_{pos}) + avg(loss_{neg})) / 2
+        \end{eqnarray}
 
 * **Contrastive Loss**: The contrastive loss compels the representations of connected nodes to be similar while forcing the representations of disconnected nodes remains dissimilar. In the implementation, we use the score computed by the score function to represent the distance between nodes. When computing the loss, we group one positive edge with the ``N`` negative edges corresponding to it.The loss function is as follows:
 

--- a/docs/source/cli/model-training-inference/configuration-run.rst
+++ b/docs/source/cli/model-training-inference/configuration-run.rst
@@ -485,6 +485,12 @@ Link Prediction Task
     - Argument: ``--lp-loss-func contrastive``
     - Default value: ``cross_entropy``
 
+- **adversarial_temperature**: Enable adversarial cross entropy loss and set the ``adversarial_temperature`` hyper-parameter. Only work when ``lp_loss_func`` is set to ``cross_entropy``. More detials can be found on the :ref:`Link Prediction Loss Functions<_link-prediction-loss>`.
+
+    - Yaml: ``adversarial_temperature: 1.0``
+    - Argument: ``adversarial-temperature 1.0``
+    - Default value: None
+
 - **lp_edge_weight_for_loss**: Edge feature field name for edge weight. The edge weight is used to rescale the positive edge loss for link prediction tasks.
 
     - Yaml: ``lp_edge_weight_for_loss:``

--- a/docs/source/cli/model-training-inference/configuration-run.rst
+++ b/docs/source/cli/model-training-inference/configuration-run.rst
@@ -485,7 +485,7 @@ Link Prediction Task
     - Argument: ``--lp-loss-func contrastive``
     - Default value: ``cross_entropy``
 
-- **adversarial_temperature**: Enable adversarial cross entropy loss and set the ``adversarial_temperature`` hyper-parameter. Only work when ``lp_loss_func`` is set to ``cross_entropy``. More detials can be found on the :ref:`Link Prediction Loss Functions<_link-prediction-loss>`.
+- **adversarial_temperature**: Enable adversarial cross entropy loss and set the ``adversarial_temperature`` hyper-parameter. Only work when ``lp_loss_func`` is set to ``cross_entropy``. More detials can be found on the :ref:`Link Prediction Loss Functions<link_prediction_loss>`.
 
     - Yaml: ``adversarial_temperature: 1.0``
     - Argument: ``adversarial-temperature 1.0``

--- a/examples/paper_experiments/README.md
+++ b/examples/paper_experiments/README.md
@@ -134,4 +134,4 @@ In the following table, we show the performance of link prediction on the Amazon
 | link_prediction/lp_also_buy_1_layer_rgcn_dot_entropy_loss_joint_32_negative.yaml | Joint negative sampling with batch size of 32 with cross entropy loss | 0.380 | 1290.72 |
 | link_prediction/lp_also_buy_1_layer_rgcn_dot_entropy_loss_joint_4_negative.yaml | Joint negative sampling with batch size of 4 with cross entropy loss | 0.645 | 1288.53 |
 | link_prediction/lp_also_buy_1_layer_rgcn_dot_entropy_uniform_32_negative.yaml | Uniform negative sampling with batch size of 32 with cross entropy loss | 0.377 | 1746.68 |
-| link_prediction/lp_also_buy_1_layer_rgcn_dot_ adversarial_entropy_loss_joint_32_negative.yaml | Joint negative sampling with batch size of 32 with adversarial cross entropy loss | 0.8796 | N/A |
+| link_prediction/lp_also_buy_1_layer_rgcn_dot_adversarial_entropy_loss_joint_32_negative.yaml | Joint negative sampling with batch size of 32 with adversarial cross entropy loss | 0.8796 | N/A |

--- a/examples/paper_experiments/README.md
+++ b/examples/paper_experiments/README.md
@@ -4,7 +4,7 @@ This folder contains the data processing and code to profile GraphStorm framewor
 ## MAG
 ### Process raw dataset into parquet files
 We first download the oag-2.1 MAG dataset from https://www.aminer.cn/oag-2-1 into raw_data/.
-The original data have affiliation data (`mag_affiliations.zip`), venue data (`mag_venues.zip`), 
+The original data have affiliation data (`mag_affiliations.zip`), venue data (`mag_venues.zip`),
 author data (`mag_authors_*.zip`), paper data (`mag_papers_*.zip`).
 
 After you unzip the above files, run the following notebook to generate the input for graph construction.
@@ -14,7 +14,7 @@ jupyter notebook MAG_parser_v0.2.ipynb
 
 ### Run gconstruct on process_data
 Once all the data are processed, run the following command to construct a graph
-for distributed GNN training in GraphStorm. 
+for distributed GNN training in GraphStorm.
 The command takes `MAG_construction_full.json` that specifies the
 input data for graph construction, constructs the graph,
 splits it into 4 partitions and saves the partitions to `MAG_full`.
@@ -134,3 +134,4 @@ In the following table, we show the performance of link prediction on the Amazon
 | link_prediction/lp_also_buy_1_layer_rgcn_dot_entropy_loss_joint_32_negative.yaml | Joint negative sampling with batch size of 32 with cross entropy loss | 0.380 | 1290.72 |
 | link_prediction/lp_also_buy_1_layer_rgcn_dot_entropy_loss_joint_4_negative.yaml | Joint negative sampling with batch size of 4 with cross entropy loss | 0.645 | 1288.53 |
 | link_prediction/lp_also_buy_1_layer_rgcn_dot_entropy_uniform_32_negative.yaml | Uniform negative sampling with batch size of 32 with cross entropy loss | 0.377 | 1746.68 |
+| link_prediction/lp_also_buy_1_layer_rgcn_dot_ adversarial_entropy_loss_joint_32_negative.yaml | Joint negative sampling with batch size of 32 with adversarial cross entropy loss | 0.8796 | N/A |

--- a/examples/paper_experiments/training_configs/link_prediction/lp_also_buy_1_layer_rgcn_dot_adversarial_entropy_loss_joint_32_negative.yaml
+++ b/examples/paper_experiments/training_configs/link_prediction/lp_also_buy_1_layer_rgcn_dot_adversarial_entropy_loss_joint_32_negative.yaml
@@ -1,0 +1,63 @@
+---
+version: 1.0
+lm_model:
+  node_lm_models:
+    -
+      lm_type: bert
+      model_name: "bert-base-uncased"
+      gradient_checkpoint: true
+      node_types:
+        - item
+    -
+      lm_type: bert
+      model_name: "bert-base-uncased"
+      gradient_checkpoint: true
+      node_types:
+        - review
+gsf:
+  basic:
+    backend: gloo
+    verbose: false
+    save_perf_results_path: null
+  lm:
+    cache_lm_embed: true
+  gnn:
+    model_encoder_type: rgcn
+    fanout: "5"
+    num_layers: 1
+    hidden_size: 128
+    use_mini_batch_infer: true
+  input:
+    restore_model_path: null
+  output:
+    save_model_path: null
+    save_embed_path: null
+  hyperparam:
+    dropout: 0.
+    lr: 0.001
+    lm_tune_lr: 0.0001
+    num_epochs: 20
+    batch_size: 1024
+    eval_batch_size: 1024
+    wd_l2norm: 0.00001
+    no_validation: false
+    eval_frequency: 100000
+  rgcn:
+    num_bases: -1
+    use_self_loop: true
+    lp_decoder_type: dot_product
+    sparse_optimizer_lr: 1e-2
+    use_node_embeddings: false
+  link_prediction:
+    num_negative_edges: 32
+    num_negative_edges_eval: 100
+    lp_loss_func: cross_entropy
+    lp_embed_normalizer: l2_norm
+    train_negative_sampler: joint
+    adversarial_temperature: 1.0
+    eval_etype:
+      - "item,also_buy,item"
+    train_etype:
+      - "item,also_buy,item"
+    exclude_training_targets: true
+    reverse_edge_types_map: ["item,also_buy,also_buy-rev,item"]

--- a/python/graphstorm/config/argument.py
+++ b/python/graphstorm/config/argument.py
@@ -2525,7 +2525,7 @@ class GSConfig:
 
     @property
     def adversarial_temperature(self):
-        """ Temperature of link prediction adversarial cross entropy loss.
+        """ Temperature of adversarial cross entropy loss for link prediction tasks.
         """
         # pylint: disable=no-member
         if hasattr(self, "_adversarial_temperature"):
@@ -3109,7 +3109,7 @@ def _add_link_prediction_args(parser):
     group.add_argument("--contrastive-loss-temperature", type=float, default=argparse.SUPPRESS,
             help="Temperature of link prediction contrastive loss.")
     group.add_argument("--adversarial-temperature", type=float, default=argparse.SUPPRESS,
-            help="Temperature of link prediction adversarial cross entropy loss.")
+            help="Temperature of adversarial cross entropy loss for link prediction tasks.")
     group.add_argument("--lp-embed-normalizer", type=str, default=argparse.SUPPRESS,
             help="Normalization method used to normalize node embeddings in"
                  "link prediction. Supported methods "

--- a/python/graphstorm/config/argument.py
+++ b/python/graphstorm/config/argument.py
@@ -2529,7 +2529,7 @@ class GSConfig:
         """
         # pylint: disable=no-member
         if hasattr(self, "_adversarial_temperature"):
-            assert self._lp_loss_func in [BUILTIN_LP_LOSS_CROSS_ENTROPY], \
+            assert self.lp_loss_func in [BUILTIN_LP_LOSS_CROSS_ENTROPY], \
                 f"adversarial_temperature only works with {BUILTIN_LP_LOSS_CROSS_ENTROPY}"
             return self._adversarial_temperature
         return None

--- a/python/graphstorm/config/argument.py
+++ b/python/graphstorm/config/argument.py
@@ -2524,6 +2524,17 @@ class GSConfig:
         return BUILTIN_LP_LOSS_CROSS_ENTROPY
 
     @property
+    def adversarial_temperature(self):
+        """ Temperature of link prediction adversarial cross entropy loss.
+        """
+        # pylint: disable=no-member
+        if hasattr(self, "_adversarial_temperature"):
+            assert self._lp_loss_func in [BUILTIN_LP_LOSS_CROSS_ENTROPY], \
+                f"adversarial_temperature only works with {BUILTIN_LP_LOSS_CROSS_ENTROPY}"
+            return self._adversarial_temperature
+        return None
+
+    @property
     def task_type(self):
         """ Task type
         """
@@ -3097,6 +3108,8 @@ def _add_link_prediction_args(parser):
             help="Link prediction loss function.")
     group.add_argument("--contrastive-loss-temperature", type=float, default=argparse.SUPPRESS,
             help="Temperature of link prediction contrastive loss.")
+    group.add_argument("--adversarial-temperature", type=float, default=argparse.SUPPRESS,
+            help="Temperature of link prediction adversarial cross entropy loss.")
     group.add_argument("--lp-embed-normalizer", type=str, default=argparse.SUPPRESS,
             help="Normalization method used to normalize node embeddings in"
                  "link prediction. Supported methods "

--- a/python/graphstorm/gsf.py
+++ b/python/graphstorm/gsf.py
@@ -56,6 +56,8 @@ from .model.loss_func import (ClassifyLossFunc,
                               RegressionLossFunc,
                               LinkPredictBCELossFunc,
                               WeightedLinkPredictBCELossFunc,
+                              LinkPredictAdvBCELossFunc,
+                              WeightedLinkPredictAdvBCELossFunc,
                               LinkPredictContrastiveLossFunc)
 from .model.node_decoder import EntityClassifier, EntityRegression
 from .model.edge_decoder import (DenseBiDecoder,
@@ -654,9 +656,15 @@ def create_builtin_lp_decoder(g, decoder_input_dim, config, train_task):
         loss_func = LinkPredictContrastiveLossFunc(config.contrastive_loss_temperature)
     elif config.lp_loss_func == BUILTIN_LP_LOSS_CROSS_ENTROPY:
         if config.lp_edge_weight_for_loss is None:
-            loss_func = LinkPredictBCELossFunc()
+            if config.adversarial_temperature is None:
+                loss_func = LinkPredictBCELossFunc()
+            else:
+                loss_func = LinkPredictAdvBCELossFunc(config.adversarial_temperature)
         else:
-            loss_func = WeightedLinkPredictBCELossFunc()
+            if config.adversarial_temperature is None:
+                loss_func = WeightedLinkPredictBCELossFunc()
+            else:
+                loss_func = WeightedLinkPredictAdvBCELossFunc(config.adversarial_temperature)
     else:
         raise TypeError(f"Unknown link prediction loss function {config.lp_loss_func}")
 

--- a/tests/end2end-tests/graphstorm-lp/test.sh
+++ b/tests/end2end-tests/graphstorm-lp/test.sh
@@ -163,14 +163,12 @@ python3 -m graphstorm.run.gs_link_prediction --workspace $GS_HOME/training_scrip
 error_and_exit $?
 
 echo "**************dataset: Movielens, RGCN layer 2, node feat: fixed HF BERT & sparse embed, BERT nodes: movie, inference: full-graph, negative_sampler: joint, decoder: DistMult, exclude_training_targets: false, adversarial cross entropy loss"
-python3 -m graphstorm.run.gs_link_prediction --workspace $GS_HOME/training_scripts/gsgnn_lp --num-trainers $NUM_TRAINERS --num-servers 1 --num-samplers 0 --part-config /data/movielen_100k_lp_train_val_1p_4t/movie-lens-100k.json --ip-config ip_list.txt --ssh-port 2222 --cf ml_lp.yaml --fanout '10,15' --num-layers 2 --use-mini-batch-infer false --lp-decoder-type distmult --train-etype user,rating,movie movie,rating-rev,user --num-epochs 1 --eval-frequency 300
---lp-loss-func cross_entropy --adversarial-temperature 0.1
+python3 -m graphstorm.run.gs_link_prediction --workspace $GS_HOME/training_scripts/gsgnn_lp --num-trainers $NUM_TRAINERS --num-servers 1 --num-samplers 0 --part-config /data/movielen_100k_lp_train_val_1p_4t/movie-lens-100k.json --ip-config ip_list.txt --ssh-port 2222 --cf ml_lp.yaml --fanout '10,15' --num-layers 2 --use-mini-batch-infer false --lp-decoder-type distmult --train-etype user,rating,movie movie,rating-rev,user --num-epochs 1 --eval-frequency 300 --lp-loss-func cross_entropy --adversarial-temperature 0.1
 
 error_and_exit $?
 
 echo "**************dataset: Movielens, RGCN layer 2, node feat: fixed HF BERT & sparse embed, BERT nodes: movie, inference: full-graph, negative_sampler: joint, decoder: RotatE, exclude_training_targets: false, adversarial cross entropy loss"
-python3 -m graphstorm.run.gs_link_prediction --workspace $GS_HOME/training_scripts/gsgnn_lp --num-trainers $NUM_TRAINERS --num-servers 1 --num-samplers 0 --part-config /data/movielen_100k_lp_train_val_1p_4t/movie-lens-100k.json --ip-config ip_list.txt --ssh-port 2222 --cf ml_lp.yaml --fanout '10,15' --num-layers 2 --use-mini-batch-infer false --lp-decoder-type rotate --train-etype user,rating,movie movie,rating-rev,user --num-epochs 1 --eval-frequency 300
---lp-loss-func cross_entropy --adversarial-temperature 0.1
+python3 -m graphstorm.run.gs_link_prediction --workspace $GS_HOME/training_scripts/gsgnn_lp --num-trainers $NUM_TRAINERS --num-servers 1 --num-samplers 0 --part-config /data/movielen_100k_lp_train_val_1p_4t/movie-lens-100k.json --ip-config ip_list.txt --ssh-port 2222 --cf ml_lp.yaml --fanout '10,15' --num-layers 2 --use-mini-batch-infer false --lp-decoder-type rotate --train-etype user,rating,movie movie,rating-rev,user --num-epochs 1 --eval-frequency 300 --lp-loss-func cross_entropy --adversarial-temperature 0.1
 
 error_and_exit $?
 

--- a/tests/end2end-tests/graphstorm-lp/test.sh
+++ b/tests/end2end-tests/graphstorm-lp/test.sh
@@ -162,6 +162,18 @@ python3 -m graphstorm.run.gs_link_prediction --workspace $GS_HOME/training_scrip
 
 error_and_exit $?
 
+echo "**************dataset: Movielens, RGCN layer 2, node feat: fixed HF BERT & sparse embed, BERT nodes: movie, inference: full-graph, negative_sampler: joint, decoder: DistMult, exclude_training_targets: false, adversarial cross entropy loss"
+python3 -m graphstorm.run.gs_link_prediction --workspace $GS_HOME/training_scripts/gsgnn_lp --num-trainers $NUM_TRAINERS --num-servers 1 --num-samplers 0 --part-config /data/movielen_100k_lp_train_val_1p_4t/movie-lens-100k.json --ip-config ip_list.txt --ssh-port 2222 --cf ml_lp.yaml --fanout '10,15' --num-layers 2 --use-mini-batch-infer false --lp-decoder-type distmult --train-etype user,rating,movie movie,rating-rev,user --num-epochs 1 --eval-frequency 300
+--lp-loss-func cross_entropy --adversarial-temperature 0.1
+
+error_and_exit $?
+
+echo "**************dataset: Movielens, RGCN layer 2, node feat: fixed HF BERT & sparse embed, BERT nodes: movie, inference: full-graph, negative_sampler: joint, decoder: RotatE, exclude_training_targets: false, adversarial cross entropy loss"
+python3 -m graphstorm.run.gs_link_prediction --workspace $GS_HOME/training_scripts/gsgnn_lp --num-trainers $NUM_TRAINERS --num-servers 1 --num-samplers 0 --part-config /data/movielen_100k_lp_train_val_1p_4t/movie-lens-100k.json --ip-config ip_list.txt --ssh-port 2222 --cf ml_lp.yaml --fanout '10,15' --num-layers 2 --use-mini-batch-infer false --lp-decoder-type rotate --train-etype user,rating,movie movie,rating-rev,user --num-epochs 1 --eval-frequency 300
+--lp-loss-func cross_entropy --adversarial-temperature 0.1
+
+error_and_exit $?
+
 date
 
 echo 'Done'

--- a/tests/unit-tests/test_config.py
+++ b/tests/unit-tests/test_config.py
@@ -1035,14 +1035,14 @@ def create_lp_config(tmp_path, file_name):
         yaml.dump(yaml_object, f)
 
     yaml_object["gsf"]["link_prediction"] = {
-        "adversarial_temperature": 0.1, # eval metric must be string or list
+        "adversarial_temperature": 0.1,
     }
     with open(os.path.join(tmp_path, file_name+"_adv_temp.yaml"), "w") as f:
         yaml.dump(yaml_object, f)
 
     yaml_object["gsf"]["link_prediction"] = {
         "lp_loss_func": BUILTIN_LP_LOSS_CONTRASTIVELOSS,
-        "adversarial_temperature": 0.1, # eval metric must be string or list
+        "adversarial_temperature": 0.1,
     }
     with open(os.path.join(tmp_path, file_name+"_adv_temp_fail.yaml"), "w") as f:
         yaml.dump(yaml_object, f)

--- a/tests/unit-tests/test_loss.py
+++ b/tests/unit-tests/test_loss.py
@@ -1,0 +1,89 @@
+"""
+    Copyright 2024 Contributors
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+"""
+import pytest
+
+import torch as th
+import torch.nn.functional as F
+
+from numpy.testing import assert_almost_equal
+
+from graphstorm.model.loss_func import (LinkPredictAdvBCELossFunc,
+                                        WeightedLinkPredictAdvBCELossFunc)
+
+@pytest.mark.parametrize("num_pos", [1, 8, 32])
+@pytest.mark.parametrize("num_neg", [1, 8, 32])
+def test_LinkPredictAdvBCELossFunc(num_pos, num_neg):
+    pos_score = {
+        ("n0", "r0" ,"n1"): th.rand((num_pos,)) + 0.5,
+        ("n0", "r1", "n2"): th.rand((num_pos,)) + 0.3
+    }
+
+    neg_score = {
+        ("n0", "r0" ,"n1"): th.rand((num_neg,)) - 0.4,
+        ("n0", "r1", "n2"): th.rand((num_neg,)) - 0.3
+    }
+
+    adversarial_temperature = 0.1
+    loss_func = LinkPredictAdvBCELossFunc(adversarial_temperature)
+    loss = loss_func(pos_score, neg_score)
+
+    p_score = th.cat([pos_score[("n0", "r0" ,"n1")], pos_score[("n0", "r1", "n2")]])
+    n_score = th.cat([neg_score[("n0", "r0" ,"n1")], neg_score[("n0", "r1", "n2")]])
+    p_loss = -th.log(F.sigmoid(p_score))
+    n_loss = -th.log(1 - F.sigmoid(n_score))
+
+    n_loss = th.softmax(n_score * adversarial_temperature, dim=-1) * n_loss
+    n_loss = th.mean(th.sum(n_loss, dim=-1))
+    p_loss = th.mean(p_loss)
+    gt_loss = (n_loss + p_loss) / 2
+
+    assert_almost_equal(loss.numpy(),gt_loss.numpy())
+
+@pytest.mark.parametrize("num_pos", [1, 8, 32])
+@pytest.mark.parametrize("num_neg", [1, 8, 32])
+def test_WeightedLinkPredictAdvBCELossFunc(num_pos, num_neg):
+    pos_score = {
+        ("n0", "r0" ,"n1"): (th.rand((num_pos,)) + 0.5, th.rand((num_pos,)) + 2),
+        ("n0", "r1", "n2"): (th.rand((num_pos,)) + 0.3, th.rand((num_pos,)) + 2)
+    }
+
+    neg_score = {
+        ("n0", "r0" ,"n1"): (th.rand((num_neg,)) - 0.4, None),
+        ("n0", "r1", "n2"): (th.rand((num_neg,)) - 0.3, None)
+    }
+
+    adversarial_temperature = 0.1
+    loss_func = WeightedLinkPredictAdvBCELossFunc(adversarial_temperature)
+    loss = loss_func(pos_score, neg_score)
+
+    p_score = th.cat([pos_score[("n0", "r0" ,"n1")][0], pos_score[("n0", "r1", "n2")][0]])
+    p_weight = th.cat([pos_score[("n0", "r0" ,"n1")][1], pos_score[("n0", "r1", "n2")][1]])
+    n_score = th.cat([neg_score[("n0", "r0" ,"n1")][0], neg_score[("n0", "r1", "n2")][0]])
+
+    p_loss = -th.log(F.sigmoid(p_score))
+    p_loss = p_loss * p_weight
+    n_loss = -th.log(1 - F.sigmoid(n_score))
+    n_loss = th.softmax(n_score * adversarial_temperature, dim=-1) * n_loss
+
+    n_loss = th.mean(th.sum(n_loss, dim=-1))
+    p_loss = th.mean(p_loss)
+    gt_loss = (n_loss + p_loss) / 2
+
+    assert_almost_equal(loss.numpy(),gt_loss.numpy())
+
+if __name__ == '__main__':
+    test_LinkPredictAdvBCELossFunc(16, 128)
+    test_WeightedLinkPredictAdvBCELossFunc(16, 128)


### PR DESCRIPTION
*Issue #, if available:*
#954 

*Description of changes:*
Add adversarial negative loss to cross-entropy loss for link prediction tasks.

Adversarial negative loss can boast the model performance. The following experiments follow the same setting as in https://github.com/classicsong/graphstorm/blob/focal-loss/examples/paper_experiments/training_configs/link_prediction/lp_also_buy_1_layer_rgcn_dot_entropy_loss_joint_32_negative.yaml.

With adversrial negative loss, the best test MRR increases from 0.380 to 0.8796 using the same setting as in [GraphStorm Paper](https://dl.acm.org/doi/pdf/10.1145/3637528.3671603).


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
