### PR TITLE
Support for launching jobs with GraphBolt enabled (GraphBolt support PR1)

### DIFF
--- a/docs/source/cli/model-training-inference/configuration-run.rst
+++ b/docs/source/cli/model-training-inference/configuration-run.rst
@@ -45,7 +45,7 @@ Environment Configurations
   See https://docs.dgl.ai/stochastic_training/ for more details.
 
     - Yaml: ``use_graphbolt: true``
-    - Argument: ``--use_graphbolt true``
+    - Argument: ``--use-graphbolt true``
     - Default value: ``false``
 
 .. _configurations-model:

--- a/docs/source/cli/model-training-inference/configuration-run.rst
+++ b/docs/source/cli/model-training-inference/configuration-run.rst
@@ -41,6 +41,12 @@ Environment Configurations
     - Yaml: ``verbose: false``
     - Argument: ``--verbose false``
     - Default value: ``false``
+- **use_graphbolt**: Set true to use the GraphBolt graph representation during training.
+  See https://docs.dgl.ai/stochastic_training/ for more details.
+
+    - Yaml: ``use_graphbolt: true``
+    - Argument: ``--use_graphbolt true``
+    - Default value: ``false``
 
 .. _configurations-model:
 

--- a/python/graphstorm/config/argument.py
+++ b/python/graphstorm/config/argument.py
@@ -663,6 +663,7 @@ class GSConfig:
         _ = self.edge_id_mapping_file
         _ = self.verbose
         _ = self.use_wholegraph_embed
+        _ = self.use_graphbolt
 
         # Data
         _ = self.node_feat_name
@@ -951,6 +952,18 @@ class GSConfig:
             return self._use_wholegraph_embed
         else:
             return None
+
+    @property
+    def use_graphbolt(self):
+        """ Whether to use GraphBolt in-memory graph representation.
+            See https://docs.dgl.ai/stochastic_training/ for details.
+        """
+        if hasattr(self, "_use_graphbolt"):
+            assert self._use_graphbolt in [True, False], \
+                "Invalid value for _use_graphbolt. Must be either True or False."
+            return self._use_graphbolt
+        else:
+            return False
 
     ###################### language model support #########################
     # Bert related
@@ -2766,6 +2779,15 @@ def _add_initialization_args(parser):
         default=argparse.SUPPRESS,
         help="Whether to use WholeGraph to store intermediate embeddings/tensors generated \
             during training or inference, e.g., cache_lm_emb, sparse_emb, etc."
+    )
+    group.add_argument(
+        "--use-graphbolt",
+        type=lambda x: (str(x).lower() in ['true', '1']),
+        default=argparse.SUPPRESS,
+        help=(
+            "Whether to use GraphBolt graph representation. "
+            "See https://docs.dgl.ai/stochastic_training/ for details"
+        )
     )
     return parser
 

--- a/python/graphstorm/run/gsgnn_dt/distill_gnn.py
+++ b/python/graphstorm/run/gsgnn_dt/distill_gnn.py
@@ -33,7 +33,9 @@ def main(config_args):
     config = GSConfig(config_args)
     config.verify_arguments(True)
     gs.initialize(ip_config=config.ip_config, backend=config.backend,
-                  local_rank=config.local_rank)
+                  local_rank=config.local_rank,
+                  use_graphbolt=config.use_graphbolt,
+    )
 
     # initiate model
     student_model = GSDistilledModel(lm_type=config.distill_lm_configs[0]["lm_type"],

--- a/python/graphstorm/run/gsgnn_emb/gsgnn_node_emb.py
+++ b/python/graphstorm/run/gsgnn_emb/gsgnn_node_emb.py
@@ -44,7 +44,9 @@ def main(config_args):
     use_wg_feats = use_wholegraph(config.part_config)
     gs.initialize(ip_config=config.ip_config, backend=config.backend,
                   local_rank=config.local_rank,
-                  use_wholegraph=config.use_wholegraph_embed or use_wg_feats)
+                  use_wholegraph=config.use_wholegraph_embed or use_wg_feats,
+                  use_graphbolt=config.use_graphbolt,
+    )
     rt_profiler.init(config.profile_path, rank=gs.get_rank())
     sys_tracker.init(config.verbose, rank=gs.get_rank())
     tracker = gs.create_builtin_task_tracker(config)

--- a/python/graphstorm/run/gsgnn_ep/ep_infer_gnn.py
+++ b/python/graphstorm/run/gsgnn_ep/ep_infer_gnn.py
@@ -47,7 +47,8 @@ def main(config_args):
     use_wg_feats = use_wholegraph(config.part_config)
     gs.initialize(ip_config=config.ip_config, backend=config.backend,
                   local_rank=config.local_rank,
-                  use_wholegraph=config.use_wholegraph_embed or use_wg_feats)
+                  use_wholegraph=config.use_wholegraph_embed or use_wg_feats,
+                  use_graphbolt=config.use_graphbolt)
 
     infer_data = GSgnnData(config.part_config,
                            node_feat_field=config.node_feat_name,

--- a/python/graphstorm/run/gsgnn_ep/ep_infer_lm.py
+++ b/python/graphstorm/run/gsgnn_ep/ep_infer_lm.py
@@ -46,7 +46,7 @@ def main(config_args):
     config.verify_arguments(False)
 
     gs.initialize(ip_config=config.ip_config, backend=config.backend,
-                  local_rank=config.local_rank)
+                  local_rank=config.local_rank, use_graphbolt=config.use_graphbolt)
     # The model only uses language model(s) as its encoder
     # It will not use node or edge features
     # except LM related features.

--- a/python/graphstorm/run/gsgnn_ep/gsgnn_ep.py
+++ b/python/graphstorm/run/gsgnn_ep/gsgnn_ep.py
@@ -61,7 +61,8 @@ def main(config_args):
     use_wg_feats = use_wholegraph(config.part_config)
     gs.initialize(ip_config=config.ip_config, backend=config.backend,
                   local_rank=config.local_rank,
-                  use_wholegraph=config.use_wholegraph_embed or use_wg_feats)
+                  use_wholegraph=config.use_wholegraph_embed or use_wg_feats,
+                  use_graphbolt=config.use_graphbolt)
     rt_profiler.init(config.profile_path, rank=gs.get_rank())
     sys_tracker.init(config.verbose, rank=gs.get_rank())
     # edge predict only handle edge feature in decoder

--- a/python/graphstorm/run/gsgnn_ep/gsgnn_lm_ep.py
+++ b/python/graphstorm/run/gsgnn_ep/gsgnn_lm_ep.py
@@ -58,7 +58,7 @@ def main(config_args):
     config.verify_arguments(True)
 
     gs.initialize(ip_config=config.ip_config, backend=config.backend,
-                  local_rank=config.local_rank)
+                  local_rank=config.local_rank, use_graphbolt=config.use_graphbolt,)
     rt_profiler.init(config.profile_path, rank=gs.get_rank())
     sys_tracker.init(config.verbose, rank=gs.get_rank())
     # The model only uses language model(s) as its encoder

--- a/python/graphstorm/run/gsgnn_lp/gsgnn_lm_lp.py
+++ b/python/graphstorm/run/gsgnn_lp/gsgnn_lm_lp.py
@@ -82,7 +82,7 @@ def main(config_args):
     config.verify_arguments(True)
 
     gs.initialize(ip_config=config.ip_config, backend=config.backend,
-                  local_rank=config.local_rank)
+                  local_rank=config.local_rank, use_graphbolt=config.use_graphbolt)
     rt_profiler.init(config.profile_path, rank=gs.get_rank())
     sys_tracker.init(config.verbose, rank=gs.get_rank())
     # The model only uses language model(s) as its encoder

--- a/python/graphstorm/run/gsgnn_lp/gsgnn_lp.py
+++ b/python/graphstorm/run/gsgnn_lp/gsgnn_lp.py
@@ -91,7 +91,8 @@ def main(config_args):
     use_wg_feats = use_wholegraph(config.part_config)
     gs.initialize(ip_config=config.ip_config, backend=config.backend,
                   local_rank=config.local_rank,
-                  use_wholegraph=config.use_wholegraph_embed or use_wg_feats)
+                  use_wholegraph=config.use_wholegraph_embed or use_wg_feats,
+                  use_graphbolt=config.use_graphbolt)
     rt_profiler.init(config.profile_path, rank=gs.get_rank())
     sys_tracker.init(config.verbose, rank=gs.get_rank())
     train_data = GSgnnData(config.part_config,

--- a/python/graphstorm/run/gsgnn_lp/lp_infer_gnn.py
+++ b/python/graphstorm/run/gsgnn_lp/lp_infer_gnn.py
@@ -44,7 +44,8 @@ def main(config_args):
     use_wg_feats = use_wholegraph(config.part_config)
     gs.initialize(ip_config=config.ip_config, backend=config.backend,
                   local_rank=config.local_rank,
-                  use_wholegraph=config.use_wholegraph_embed or use_wg_feats)
+                  use_wholegraph=config.use_wholegraph_embed or use_wg_feats,
+                  use_graphbolt=config.use_graphbolt)
 
     infer_data = GSgnnData(config.part_config,
                            node_feat_field=config.node_feat_name,

--- a/python/graphstorm/run/gsgnn_lp/lp_infer_lm.py
+++ b/python/graphstorm/run/gsgnn_lp/lp_infer_lm.py
@@ -40,7 +40,7 @@ def main(config_args):
     config.verify_arguments(False)
 
     gs.initialize(ip_config=config.ip_config, backend=config.backend,
-                  local_rank=config.local_rank)
+                  local_rank=config.local_rank, use_graphbolt=config.use_graphbolt)
     # The model only uses language model(s) as its encoder
     # It will not use node or edge features
     # except LM related features.

--- a/python/graphstorm/run/gsgnn_mt/gsgnn_mt.py
+++ b/python/graphstorm/run/gsgnn_mt/gsgnn_mt.py
@@ -317,7 +317,8 @@ def main(config_args):
     use_wg_feats = use_wholegraph(config.part_config)
     gs.initialize(ip_config=config.ip_config, backend=config.backend,
                   local_rank=config.local_rank,
-                  use_wholegraph=config.use_wholegraph_embed or use_wg_feats)
+                  use_wholegraph=config.use_wholegraph_embed or use_wg_feats,
+                  use_graphbolt=config.use_graphbolt)
     rt_profiler.init(config.profile_path, rank=gs.get_rank())
     sys_tracker.init(config.verbose, rank=gs.get_rank())
     train_data = GSgnnData(config.part_config,

--- a/python/graphstorm/run/gsgnn_mt/mt_infer_gnn.py
+++ b/python/graphstorm/run/gsgnn_mt/mt_infer_gnn.py
@@ -170,7 +170,8 @@ def main(config_args):
     use_wg_feats = use_wholegraph(config.part_config)
     gs.initialize(ip_config=config.ip_config, backend=config.backend,
                   local_rank=config.local_rank,
-                  use_wholegraph=config.use_wholegraph_embed or use_wg_feats)
+                  use_wholegraph=config.use_wholegraph_embed or use_wg_feats,
+                  use_graphbolt=config.use_graphbolt)
 
     infer_data = GSgnnData(config.part_config,
                            node_feat_field=config.node_feat_name,

--- a/python/graphstorm/run/gsgnn_np/gsgnn_np.py
+++ b/python/graphstorm/run/gsgnn_np/gsgnn_np.py
@@ -65,7 +65,8 @@ def main(config_args):
     use_wg_feats = use_wholegraph(config.part_config)
     gs.initialize(ip_config=config.ip_config, backend=config.backend,
                   local_rank=config.local_rank,
-                  use_wholegraph=config.use_wholegraph_embed or use_wg_feats)
+                  use_wholegraph=config.use_wholegraph_embed or use_wg_feats,
+                  use_graphbolt=config.use_graphbolt)
     rt_profiler.init(config.profile_path, rank=gs.get_rank())
     sys_tracker.init(config.verbose, rank=gs.get_rank())
     train_data = GSgnnData(config.part_config,

--- a/python/graphstorm/run/gsgnn_np/np_infer_gnn.py
+++ b/python/graphstorm/run/gsgnn_np/np_infer_gnn.py
@@ -47,7 +47,8 @@ def main(config_args):
     use_wg_feats = use_wholegraph(config.part_config)
     gs.initialize(ip_config=config.ip_config, backend=config.backend,
                   local_rank=config.local_rank,
-                  use_wholegraph=config.use_wholegraph_embed or use_wg_feats)
+                  use_wholegraph=config.use_wholegraph_embed or use_wg_feats,
+                  use_graphbolt=config.use_graphbolt)
 
     infer_data = GSgnnData(config.part_config,
                            node_feat_field=config.node_feat_name,


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

* We introduce support for GraphBolt training and inference, see https://docs.dgl.ai/stochastic_training/index.html for details
* We add a new optional argument `--use-graphbolt` to the configuration. When set to true that sets the dgl.initialize call to include `use_graphbolt=True`, on supported DGL versions.
* For versions of DGL < 2, we print a warning and run regular distributed environment init.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
