### PR TITLE
Move minimum Python version to 3.8 for GraphStorm

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ provide their own model implementations and use GraphStorm training pipeline to 
 
 ## Get Started
 ### Installation
-GraphStorm is compatible to Python 3.7+. It requires PyTorch 1.13+, DGL 1.0 and transformers 4.3.0+.
+GraphStorm is compatible to Python 3.8+. It requires PyTorch 1.13+, DGL 1.0 and transformers 4.3.0+.
 
 GraphStorm can be installed with pip and it can be used to train GNN models in a standalone mode. To run GraphStorm in a distributed environment, we recommend users to using [Docker](https://docs.docker.com/get-started/overview/) container to reduce envrionment setup efforts. A guideline to setup GraphStorm running environment can be found at [here](https://graphstorm.readthedocs.io/en/latest/install/env-setup.html#setup-graphstorm-docker-environment) and a full instruction on how to setup distributed training can be found [here](https://graphstorm.readthedocs.io/en/latest/scale/distributed.html).
 
@@ -114,5 +114,3 @@ To use multiple samplers on sagemaker please use PyTorch versions <= 1.12.
 
 ## License
 This project is licensed under the Apache-2.0 License.
-
-

--- a/docs/source/install/env-setup.rst
+++ b/docs/source/install/env-setup.rst
@@ -15,7 +15,7 @@ Prerequisites
 
 1. **Linux OS**: The current version of GraphStorm supports Linux as the Operation System. We tested GraphStorm on both Ubuntu (22.04 or later version) and Amazon Linux 2.
 
-2. **Python3**: The current version of GraphStorm requires Python installed with the version larger than **3.7**.
+2. **Python3**: The current version of GraphStorm requires Python installed with the version larger than **3.8**.
 
 3. (Optional) GraphStorm supports **Nvidia GPUs** for using GraphStorm in GPU environments.
 

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ setup(
     # Metadata
     name='graphstorm',
     version=VERSION,
-    python_requires='>=3.7',
+    python_requires='>=3.8',
     description='GraphStorm',
     long_description_content_type='text/markdown',
     license='Apache-2.0',


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

* Python 3.7 went EOL on 2023-06-27, we remove support for it for GraphStorm 0.4.

For a full list of language/library features that can now be used see https://docs.python.org/3/whatsnew/3.8.html

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
