### PR TITLE
[GraphBolt] Add GraphBolt graph construction for GConstruct and GPartition (GraphBolt PR2)

### DIFF
--- a/.github/workflow_scripts/e2e_check.sh
+++ b/.github/workflow_scripts/e2e_check.sh
@@ -9,6 +9,7 @@ sh ./tests/end2end-tests/tools/test_mem_est.sh
 sh ./tests/end2end-tests/data_process/test.sh
 sh ./tests/end2end-tests/data_process/movielens_test.sh
 sh ./tests/end2end-tests/data_process/homogeneous_test.sh
+sh ./tests/end2end-tests/data_process/gpartition_test.sh
 sh ./tests/end2end-tests/custom-gnn/run_test.sh
 bash ./tests/end2end-tests/graphstorm-nc/test.sh
 bash ./tests/end2end-tests/graphstorm-lp/test.sh

--- a/.github/workflow_scripts/e2e_check.sh
+++ b/.github/workflow_scripts/e2e_check.sh
@@ -9,7 +9,7 @@ sh ./tests/end2end-tests/tools/test_mem_est.sh
 sh ./tests/end2end-tests/data_process/test.sh
 sh ./tests/end2end-tests/data_process/movielens_test.sh
 sh ./tests/end2end-tests/data_process/homogeneous_test.sh
-sh ./tests/end2end-tests/data_process/gpartition_test.sh
+bash ./tests/end2end-tests/data_process/gpartition_test.sh
 sh ./tests/end2end-tests/custom-gnn/run_test.sh
 bash ./tests/end2end-tests/graphstorm-nc/test.sh
 bash ./tests/end2end-tests/graphstorm-lp/test.sh

--- a/.github/workflow_scripts/e2e_gb_check.sh
+++ b/.github/workflow_scripts/e2e_gb_check.sh
@@ -1,2 +1,11 @@
-#!/bin/bash
-python3 -c "import dgl; print(dgl.__version__)"
+#!/usr/bin/env bash
+set -Eeux
+
+# Move to parent directory, where the repository was cloned
+cd ../../
+
+GS_HOME=$(pwd)
+# Install graphstorm from checked out code
+pip3 install "$GS_HOME" --upgrade
+
+bash ./tests/end2end-tests/graphstorm-gb/graphbolt-graph-construction.sh

--- a/.github/workflow_scripts/e2e_gb_check.sh
+++ b/.github/workflow_scripts/e2e_gb_check.sh
@@ -8,4 +8,6 @@ GS_HOME=$(pwd)
 # Install graphstorm from checked out code
 pip3 install "$GS_HOME" --upgrade
 
+bash ./tests/end2end-tests/setup.sh
+bash ./tests/end2end-tests/create_data.sh
 bash ./tests/end2end-tests/graphbolt-gs-integration/graphbolt-graph-construction.sh

--- a/.github/workflow_scripts/e2e_gb_check.sh
+++ b/.github/workflow_scripts/e2e_gb_check.sh
@@ -8,4 +8,4 @@ GS_HOME=$(pwd)
 # Install graphstorm from checked out code
 pip3 install "$GS_HOME" --upgrade
 
-bash ./tests/end2end-tests/graphstorm-gb/graphbolt-graph-construction.sh
+bash ./tests/end2end-tests/graphbolt-gs-integration/graphbolt-graph-construction.sh

--- a/docs/source/cli/graph-construction/distributed/gspartition/ec2-clusters.rst
+++ b/docs/source/cli/graph-construction/distributed/gspartition/ec2-clusters.rst
@@ -129,4 +129,5 @@ The arguments that ``graphstorm.gpartition.dist_partition_graph`` accepts are th
 * ``--ip-config str``: A file storing a list of IPs, one line for each instance of the partition cluster.
 * ``--partition-assignment-only``: Only generate partition assignments for nodes, the process will not build the partitioned DGL graph.
 * ``--logging-level str``: The logging level. The possible values: debug, info, warning, error. The default value is info. (default: info)
-* ``--use-graphbolt "true"/"false"``: ``New in v0.4``. Whether to convert the partitioned data to the GraphBolt format after creating the DistDGL graph. (default: ``"false"``)
+* ``--use-graphbolt "true"/"false"``: ``New in v0.4``. Whether to convert the partitioned data to the GraphBolt format after creating the DistDGL graph.
+  Requires installed DGL version to be at least ``2.1.0``. (default: ``"false"``)

--- a/docs/source/cli/graph-construction/distributed/gspartition/ec2-clusters.rst
+++ b/docs/source/cli/graph-construction/distributed/gspartition/ec2-clusters.rst
@@ -121,7 +121,6 @@ The arguments that ``graphstorm.gpartition.dist_partition_graph`` accepts are th
 * ``--input-path str``: Path to input DGL chunked data directory. (required). The format for the data
   is available at : https://docs.dgl.ai/guide/distributed-preprocessing.html#chunked-graph-format
 * ``--output-path str``: Path to store the partitioned data. (required)
-* ``--output-path str``: Path to store the partitioned data under. (required)
 * ``--num-parts int``: Number of partitions to generate. (required)
 * ``--metadata-filename str``: Name for the chunked DGL data metadata file. (default: ``metadata.json``)
 * ``--ssh-port int``: SSH Port. (default: 22)

--- a/docs/source/cli/graph-construction/distributed/gspartition/ec2-clusters.rst
+++ b/docs/source/cli/graph-construction/distributed/gspartition/ec2-clusters.rst
@@ -103,7 +103,7 @@ Now we can ssh into the **leader node** of the EC2 cluster, and start GSPartitio
 
 .. code:: bash
 
-    python3 -m graphstorm.gpartition.dist_partition_graph
+    python3 -m graphstorm.gpartition.dist_partition_graph \
         --input-path ${LOCAL_INPUT_DATAPATH} \
         --metadata-filename ${METADATA_FILE} \
         --output-path ${LOCAL_OUTPUT_DATAPATH} \
@@ -116,4 +116,16 @@ Now we can ssh into the **leader node** of the EC2 cluster, and start GSPartitio
     2. The number of instances in the cluster should be equal to ``NUM_PARTITIONS``.
     3. For users who only want to generate partition assignments instead of the partitioned DGL graph, please add ``--partition-assignment-only`` flag.
 
-Currently we support both ``random`` and ``parmetis`` as the partitioning algorithm for EC2 clusters.
+The arguments that ``graphstorm.gpartition.dist_partition_graph`` accepts are the following:
+
+* ``--input-path str``: Path to input DGL chunked data directory. (required)
+* ``--output-path str``: Path to store the partitioned data under. (required)
+* ``--num-parts int``: Number of partitions to generate. (required)
+* ``--metadata-filename str``: Name for the chunked DGL data metadata file. (default: ``metadata.json``)
+* ``--ssh-port int``: SSH Port. (default: 22)
+* ``--dgl-tool-path str``: The path to `dgl/tools` code. (default: ``/root/dgl/tools``)
+* ``--partition-algorithm str``: Partition algorithm to use. (choices: ``random``, ``parmetis``, default: ``random``)
+* ``--ip-config str``: A file storing a list of IPs, one line for each instance of the partition cluster.
+* ``--partition-assignment-only``: Only generate partition assignments for nodes, the process will not build the partitioned DGL graph.
+* ``--logging-level str``: The logging level. The possible values: debug, info, warning, error. The default value is info. (default: info)
+* ``--use-graphbolt "true"/"false"``: ``New in v0.4``. Whether to convert the partitioned data to the GraphBolt format after creating the DistDGL graph. (default: ``"false"``)

--- a/docs/source/cli/graph-construction/distributed/gspartition/ec2-clusters.rst
+++ b/docs/source/cli/graph-construction/distributed/gspartition/ec2-clusters.rst
@@ -118,7 +118,9 @@ Now we can ssh into the **leader node** of the EC2 cluster, and start GSPartitio
 
 The arguments that ``graphstorm.gpartition.dist_partition_graph`` accepts are the following:
 
-* ``--input-path str``: Path to input DGL chunked data directory. (required)
+* ``--input-path str``: Path to input DGL chunked data directory. (required). The format for the data
+  is available at : https://docs.dgl.ai/guide/distributed-preprocessing.html#chunked-graph-format
+* ``--output-path str``: Path to store the partitioned data. (required)
 * ``--output-path str``: Path to store the partitioned data under. (required)
 * ``--num-parts int``: Number of partitions to generate. (required)
 * ``--metadata-filename str``: Name for the chunked DGL data metadata file. (default: ``metadata.json``)

--- a/docs/source/cli/graph-construction/single-machine-gconstruct.rst
+++ b/docs/source/cli/graph-construction/single-machine-gconstruct.rst
@@ -43,7 +43,8 @@ Full argument list of the ``gconstruct.construct_graph`` command
 * **-\-ext-mem-feat-size**: the minimal number of feature dimensions that features can be stored in external memory. Default is 64.
 * **-\-output-conf-file**: The output file with the updated configurations that records the details of data transformation, e.g., convert to categorical value mappings, and max-min normalization ranges. If not specified, will save the updated configuration file in the **-\-output-dir** with name `data_transform_new.json`.
 * **-\-use-graphbolt**:  ``New in version 0.4``. When set to ``"true"``, will convert the partitioned graph data to the GraphBolt format after
-  partitioning, allowing GraphBolt training/inference jobs to be used downstream. Default: ``"false"``.
+  partitioning, allowing GraphBolt training/inference jobs to be used downstream.
+  Requires installed DGL version to be at least ``2.1.0``. Default is ``"false"``.
 
 .. _gconstruction-json:
 

--- a/docs/source/cli/graph-construction/single-machine-gconstruct.rst
+++ b/docs/source/cli/graph-construction/single-machine-gconstruct.rst
@@ -10,7 +10,7 @@ Prerequisites
 2. Following the :ref:`Setup GraphStorm with pip Packages <setup_pip>` guideline to install GraphStorm and its dependencies.
 3. Following the :ref:`Input Raw Data Explanations <input_raw_data>` guideline to prepare the input raw data.
 
-Graph consturction command
+Graph construction command
 ****************************
 
 GraphStorm provides a ``gconstruct.construct_graph`` module for graph construction in a signle machine. Users can run the ``gconstruct.construct_graph`` command by following the command template below.
@@ -23,7 +23,27 @@ GraphStorm provides a ``gconstruct.construct_graph`` module for graph constructi
           --num-parts 1 \
           --graph-name a_name
 
-This template provides the actual Python command, and it also indicates the three required command arguments, i.e., ``--conf-file`` specifies a JSON file containing graph construction configurations, ``--output-dir`` specifies the directory for outputs, and ``--graph-name`` specifies a string as a name given to the constructed graph. The ``--num-parts`` whose default given value is ``1`` is also an important argument. It determines how many partitions to be constructed. In distrusted model training and inference, the number of machines is determined by the number of partitions.
+This template provides the actual Python command, and it also indicates the three required command arguments, i.e., ``--conf-file`` specifies a JSON file containing graph construction configurations, ``--output-dir`` specifies the directory for outputs, and ``--graph-name`` specifies a string as a name given to the constructed graph. The ``--num-parts`` whose default given value is ``1`` is also an important argument. It determines how many partitions to be constructed. In distributed model training and inference, the number of machines is determined by the number of partitions.
+
+Full argument list of the ``gconstruct.construct_graph`` command
+................................................................
+
+* **-\-conf-file**: (**Required**) the path of the configuration JSON file.
+* **-\-num-processes**: the number of processes to process the data simultaneously. Default is 1. Increase this number can speed up data processing, but will also increase the CPU memory consumption.
+* **-\-num-processes-for-nodes**: the number of processes to process node data simultaneously. Increase this number can speed up node data processing.
+* **-\-num-processes-for-edges**: the number of processes to process edge data simultaneously. Increase this number can speed up edge data processing.
+* **-\-output-dir**: (**Required**) the path of the output data files.
+* **-\-graph-name**: (**Required**) the name assigned for the graph.
+* **-\-remap-node-id**: boolean value to decide whether to rename node IDs or not. Adding this argument will set it to be true, otherwise false.
+* **-\-add-reverse-edges**: boolean value to decide whether to add reverse edges for the given graph. Adding this argument sets it to true; otherwise, it defaults to false. It is **strongly** suggested to include this argument for graph construction, as some nodes in the original data may not have in-degrees, and thus cannot update their presentations by aggregating messages from their neighbors. Adding this arugment helps prevent this issue.
+* **-\-output-format**: the format of constructed graph, options are ``DGL``,  ``DistDGL``.  Default is ``DistDGL``. It also accepts multiple graph formats at the same time separated by an space, for example ``--output-format "DGL DistDGL"``. The output format is explained in the :ref:`Output <gcon-output-format>` section above.
+* **-\-num-parts**: an integer value that specifies the number of graph partitions to produce. This is only valid if the output format is ``DistDGL``.
+* **-\-skip-nonexist-edges**: boolean value to decide whether skip edges whose endpoint nodes don't exist. Default is true.
+* **-\-ext-mem-workspace**: the directory where the tool can store intermediate data during graph construction. Suggest to use high-speed SSD as the external memory workspace.
+* **-\-ext-mem-feat-size**: the minimal number of feature dimensions that features can be stored in external memory. Default is 64.
+* **-\-output-conf-file**: The output file with the updated configurations that records the details of data transformation, e.g., convert to categorical value mappings, and max-min normalization ranges. If not specified, will save the updated configuration file in the **-\-output-dir** with name `data_transform_new.json`.
+* **-\-use-graphbolt**:  ``New in version 0.4``. When set to ``"true"``, will convert the partitioned graph data to the GraphBolt format after
+  partitioning, allowing GraphBolt training/inference jobs to be used downstream. Default: ``"false"``.
 
 .. _gconstruction-json:
 
@@ -108,13 +128,13 @@ GraphStorm provides a set of transformation operations for different types of fe
                   "bert_model": "roberta-base",
                   "max_seq_length": 256},
 
-* **Numerical MAX_MIN transformation** normalizes numerical input features with `val = (val-min)/(max-min)`, where `val` is the feature value, `max` is the maximum value in the feature and `min` is the minimum value in the feature. The ``name`` field in the feature transformation dictionary is ``max_min_norm``. The dictionary can contain four optional fields: ``max_bound``, ``min_bound``, ``max_val`` and ``min_val``. 
+* **Numerical MAX_MIN transformation** normalizes numerical input features with `val = (val-min)/(max-min)`, where `val` is the feature value, `max` is the maximum value in the feature and `min` is the minimum value in the feature. The ``name`` field in the feature transformation dictionary is ``max_min_norm``. The dictionary can contain four optional fields: ``max_bound``, ``min_bound``, ``max_val`` and ``min_val``.
 
   - ``max_bound`` specifies the maximum value allowed in the feature. Any number larger than ``max_bound`` will be set to ``max_bound``. Here, `max = min(np.amax(feats), ``max_bound``)`.
-  - ``min_bound`` specifies the minimum value allowed in the feature. Any number smaller than ``min_bound`` will be set to ``min_bound``. Here, `min` = max(np.amin(feats), ``min_bound``). 
+  - ``min_bound`` specifies the minimum value allowed in the feature. Any number smaller than ``min_bound`` will be set to ``min_bound``. Here, `min` = max(np.amin(feats), ``min_bound``).
   - ``max_val`` defines the `max` in the transformation formula. When ``max_val`` is provided, `max` is always equal to ``max_val``.
   - ``min_val`` defines the `min` in the transformation formula.  When ``min_val`` is provided, `min` is always equal to ``min_val``.
-  
+
   ``max_val`` and ``min_val`` are mainly used in the inference stage, where we want to use the same `max` and `min` values computed in the training stage to normalize inference data.
 
   Example:
@@ -165,9 +185,9 @@ GraphStorm provides a set of transformation operations for different types of fe
 
 .. _gcon-output-format:
 
-Outputs of the graph consturction command
+Outputs of the graph construction command
 ............................................
-The graph construction command outputs two formats: ``DistDGL`` or ``DGL`` specified by the argument **-\-output-format**. 
+The graph construction command outputs two formats: ``DistDGL`` or ``DGL`` specified by the argument **-\-output-format**.
 
 If select ``DGL``, the output includes an `DGLGraph <https://docs.dgl.ai/en/1.0.x/generated/dgl.save_graphs.html>`_ file, named ``<graph_name>.dgl`` under the folder specified by the **-\-output-dir** argument, where `<graph_name>` is the value of argument **-\-graph-name**.
 
@@ -190,7 +210,7 @@ Besides the graph data, the graph construction command also generate other files
       If users provide a value of the **-\-output-conf-file** argument, the newly generated configuration file will use this value as the file name. Otherwise GraphStorm will save the configuration JSON file in the **-\-output-dir** with name ``data_transform_new.json``.
 
     - **Label Statistic Summary JSONs:**
-      If required in the ``label_stats_type`` field, the graph construction command will compute statistics of labels and save them in a ``node_label_stats.json`` or a ``edge_label_stats.json``. 
+      If required in the ``label_stats_type`` field, the graph construction command will compute statistics of labels and save them in a ``node_label_stats.json`` or a ``edge_label_stats.json``.
 
 .. note:: These mapping files are important for mapping the training and inference outputs. Therefore, DO NOT move or delete them.
 
@@ -303,24 +323,6 @@ This section provides a construction configuration JSON associated to the :ref:`
 
 .. note:: For a real runnable example, please refer to the :ref:`input JSON file <input-config>` used in the :ref:`Use Your Own Graphs Tutorial <use-own-data>`.
 
-A full argument list of the ``gconstruct.construct_graph`` command
-...................................................................
-
-* **-\-conf-file**: (**Required**) the path of the configuration JSON file.
-* **-\-num-processes**: the number of processes to process the data simulteneously. Default is 1. Increase this number can speed up data processing, but will also increase the CPU memory consumption.
-* **-\-num-processes-for-nodes**: the number of processes to process node data simulteneously. Increase this number can speed up node data processing.
-* **-\-num-processes-for-edges**: the number of processes to process edge data simulteneously. Increase this number can speed up edge data processing.
-* **-\-output-dir**: (**Required**) the path of the output data files.
-* **-\-graph-name**: (**Required**) the name assigned for the graph.
-* **-\-remap-node-id**: boolean value to decide whether to rename node IDs or not. Adding this argument will set it to be true, otherwise false.
-* **-\-add-reverse-edges**: boolean value to decide whether to add reverse edges for the given graph. Adding this argument sets it to true; otherwise, it defaults to false. It is **strongly** suggested to include this argument for graph construction, as some nodes in the original data may not have in-degrees, and thus cannot update their presentations by aggregating messages from their neighbors. Adding this arugment helps prevent this issue.
-* **-\-output-format**: the format of constructed graph, options are ``DGL``,  ``DistDGL``.  Default is ``DistDGL``. It also accepts multiple graph formats at the same time separated by an space, for example ``--output-format "DGL DistDGL"``. The output format is explained in the :ref:`Output <gcon-output-format>` section above.
-* **-\-num-parts**: an integer value that specifies the number of graph partitions to produce. This is only valid if the output format is ``DistDGL``.
-* **-\-skip-nonexist-edges**: boolean value to decide whether skip edges whose endpoint nodes don't exist. Default is true.
-* **-\-ext-mem-workspace**: the directory where the tool can store intermediate data during graph construction. Suggest to use high-speed SSD as the external memory workspace.
-* **-\-ext-mem-feat-size**: the minimal number of feature dimensions that features can be stored in external memory. Default is 64.
-* **-\-output-conf-file**: The output file with the updated configurations that records the details of data transformation, e.g., convert to categorical value mappings, and max-min normalization ranges. If not specified, will save the updated configuration file in the **-\-output-dir** with name `data_transform_new.json`.
-
 .. _configurations-partition:
 
 Graph Partition for DGL Graphs
@@ -347,7 +349,7 @@ For users who are already familiar with DGL and know how to construct DGL graphs
 - **-\-generate-new-node-split**: a boolean value, required if need the partition script to split nodes for training/validation/test sets. If this argument is set to ``true``, the **target-ntype** argument **must** also be set.
 - **-\-generate-new-edge-split**: a boolean value, required if need the partition script to split edges for training/validation/test sets. If this argument is set to ``true``, the **target-etype** argument **must** also be set.
 - **-\-train-pct**: a float value (\>0. and \<1.) with default value ``0.8``. If you want the partition script to split nodes/edges for training/validation/test sets, you can set this value to control the percentage of nodes/edges for training.
-- **-\-val-pct**: a float value (\>0. and \<1.) with default value ``0.1``. You can set this value to control the percentage of nodes/edges for validation. 
+- **-\-val-pct**: a float value (\>0. and \<1.) with default value ``0.1``. You can set this value to control the percentage of nodes/edges for validation.
 
 .. Note::
     The sum of the **train-pct** and **val-pct** should be less than 1. And the percentage of test nodes/edges is the result of 1-(train_pct + val_pct).
@@ -362,9 +364,9 @@ For users who are already familiar with DGL and know how to construct DGL graphs
 - **-\-filepath**: (**Required**) the file path of the saved DGL graph file.
 - **-\-target-etypes**: (**Required**) the canonical edge types for making prediction. GraphStorm supports multiple predict edge types that are separated by a white space. The format is ``src_ntype1,etype1,dst_ntype1 src_ntype2,etype2,dst_ntype2``, e.g., `"author,write,paper paper,citing,paper"`.
 - **-\-train-pct**: a float value (\>0. and \<1.) with default value ``0.8``. If you want the partition script to split edges for training/validation/test sets, you can set this value to control the percentage of edges for training.
-- **-\-val-pct**: a float value (\>0. and \<1.) with default value ``0.1``. You can set this value to control the percentage of edges for validation. 
+- **-\-val-pct**: a float value (\>0. and \<1.) with default value ``0.1``. You can set this value to control the percentage of edges for validation.
 
-.. Note:: 
+.. Note::
     The sum of the **train-pct** and **val-pct** should less than 1. And the percentage of test edges is the result of 1-(train_pct + val_pct).
 
 - **-\-add-reverse-edges**: if add this argument, will add reverse edges to the given graphs.

--- a/python/graphstorm/gconstruct/construct_graph.py
+++ b/python/graphstorm/gconstruct/construct_graph.py
@@ -859,7 +859,8 @@ def process_graph(args):
         partition_graph(g, node_data, edge_data, args.graph_name,
                         args.num_parts, args.output_dir,
                         save_mapping=True, # always save mapping
-                        part_method=args.part_method)
+                        part_method=args.part_method,
+                        use_graphbolt=args.use_graphbolt)
 
         # There are hard negatives, we need to do NID remapping
         if len(hard_edge_neg_ops) > 0:
@@ -933,4 +934,8 @@ if __name__ == '__main__':
     argparser.add_argument("--logging-level", type=str, default="info",
                            help="The logging level. The possible values: debug, info, warning, \
                                    error. The default value is info.")
+    argparser.add_argument("--use-graphbolt", type=lambda x: (str(x).lower() in ['true', '1']),
+                           default="false",
+                           help=("Whether to convert the partitioned data to the GraphBolt format "
+                               "after creating the DistDGL graph."))
     process_graph(argparser.parse_args())

--- a/python/graphstorm/gconstruct/utils.py
+++ b/python/graphstorm/gconstruct/utils.py
@@ -1006,15 +1006,15 @@ def partition_graph(g, node_data, edge_data, graph_name, num_partitions, output_
             balance_arr -= 1
         balance_ntypes[ntype] = balance_arr
 
-
     # Call DGL's partition graph, using the appropriate arg list
     # for each version
     dgl_version_str = importlib.metadata.version("dgl")
     dgl_version = version.parse(dgl_version_str)
-    part_position_args = [
-        g, graph_name, num_partitions, output_dir,
-    ]
-    part_kwargs = {
+    partition_kwargs = {
+        "g": g,
+        "graph_name": graph_name,
+        "num_parts": num_partitions,
+        "out_path": output_dir,
         'part_method': part_method,
         'balance_ntypes': balance_ntypes,
         'balance_edges': True,
@@ -1022,17 +1022,14 @@ def partition_graph(g, node_data, edge_data, graph_name, num_partitions, output_
     }
 
     if dgl_version >= version.parse("2.0.0"):
-        part_kwargs['use_graphbolt'] = use_graphbolt
+        partition_kwargs['use_graphbolt'] = use_graphbolt
     else:
         if use_graphbolt:
-            logging.warning(
-                (
-                    "use_graphbolt was 'true' but but DGL version was %s. "
-                    "GraphBolt requires DGL version >= 2.x."
-                ),
-                dgl_version
+            raise ValueError(
+                f"use_graphbolt was 'true' but but DGL version was {dgl_version}. "
+                "GraphBolt requires DGL version >= 2.x."
             )
-    mapping = dgl.distributed.partition_graph(*part_position_args, **part_kwargs)
+    mapping = dgl.distributed.partition_graph(**partition_kwargs)
 
 
     sys_tracker.check('Graph partitioning')

--- a/python/graphstorm/gconstruct/utils.py
+++ b/python/graphstorm/gconstruct/utils.py
@@ -19,14 +19,17 @@
 import os
 import queue
 import gc
+import importlib.metadata
 import logging
 import copy
 import traceback
 import shutil
 import uuid
 
+
 import numpy as np
 import dgl
+from packaging import version
 import torch as th
 from torch import multiprocessing
 from torch.multiprocessing import Process
@@ -914,7 +917,7 @@ def load_maps(output_dir, fname):
     return th.load(map_file)
 
 def partition_graph(g, node_data, edge_data, graph_name, num_partitions, output_dir,
-                    part_method=None, save_mapping=True):
+                    part_method=None, save_mapping=True, use_graphbolt=False):
     """ Partition a graph
 
     This takes advantage of the graph partition function in DGL.
@@ -943,6 +946,11 @@ def partition_graph(g, node_data, edge_data, graph_name, num_partitions, output_
     save_mapping: bool
         Whether to store the mappings for the edges and nodes after partition.
         Default: True
+    use_graphbolt: bool
+        Whether the convert the partitioned graph into the GraphBolt format
+        after partitioning.
+
+        .. versionadded:: 0.4.0
     """
     from dgl.distributed.graph_partition_book import _etype_tuple_to_str
     orig_id_name = "__gs_orig_id"
@@ -997,12 +1005,35 @@ def partition_graph(g, node_data, edge_data, graph_name, num_partitions, output_
                  num_test != g.number_of_nodes(ntype)):
             balance_arr -= 1
         balance_ntypes[ntype] = balance_arr
-    mapping = \
-        dgl.distributed.partition_graph(g, graph_name, num_partitions, output_dir,
-                                        part_method=part_method,
-                                        balance_ntypes=balance_ntypes,
-                                        balance_edges=True,
-                                        return_mapping=save_mapping)
+    dgl_version = importlib.metadata.version("dgl")
+    if version.parse(dgl_version) >= version.parse("2.0.0"):
+        mapping = dgl.distributed.partition_graph(
+            g, graph_name, num_partitions, output_dir,
+            part_method=part_method,
+            balance_ntypes=balance_ntypes,
+            balance_edges=True,
+            return_mapping=save_mapping,
+            use_graphbolt=use_graphbolt,
+        )
+    else:
+        if use_graphbolt:
+            logging.warning(
+                (
+                    "use_graphbolt was 'true' but but DGL version was %s. "
+                    "GraphBolt requires DGL version >= 2.x."
+                ),
+                dgl_version
+            )
+
+        mapping = dgl.distributed.partition_graph(
+            g, graph_name, num_partitions, output_dir,
+            part_method=part_method,
+            balance_ntypes=balance_ntypes,
+            balance_edges=True,
+            return_mapping=save_mapping,
+        )
+
+
     sys_tracker.check('Graph partitioning')
 
     # If num_partitions is 1, node IDs are not shuffled.

--- a/python/graphstorm/gconstruct/utils.py
+++ b/python/graphstorm/gconstruct/utils.py
@@ -1008,8 +1008,6 @@ def partition_graph(g, node_data, edge_data, graph_name, num_partitions, output_
 
     # Call DGL's partition graph, using the appropriate arg list
     # for each version
-    dgl_version_str = importlib.metadata.version("dgl")
-    dgl_version = version.parse(dgl_version_str)
     partition_kwargs = {
         "g": g,
         "graph_name": graph_name,
@@ -1021,13 +1019,14 @@ def partition_graph(g, node_data, edge_data, graph_name, num_partitions, output_
         'return_mapping': save_mapping,
     }
 
-    if dgl_version >= version.parse("2.0.0"):
+    dgl_version = importlib.metadata.version("dgl")
+    if version.parse(dgl_version) >= version.parse("2.1.0"):
         partition_kwargs['use_graphbolt'] = use_graphbolt
     else:
         if use_graphbolt:
             raise ValueError(
                 f"use_graphbolt was 'true' but but DGL version was {dgl_version}. "
-                "GraphBolt requires DGL version >= 2.x."
+                "GraphBolt graph construction requires DGL version >= 2.1.0"
             )
     mapping = dgl.distributed.partition_graph(**partition_kwargs)
 

--- a/python/graphstorm/gpartition/dist_partition_graph.py
+++ b/python/graphstorm/gpartition/dist_partition_graph.py
@@ -115,8 +115,6 @@ def main():
     # Configure logging
     logging.basicConfig(level=get_log_level(args.logging_level))
 
-    start = time.time()
-
     output_path: str = args.output_path
     metadata_file: str = args.metadata_filename
 

--- a/python/graphstorm/gpartition/dist_partition_graph.py
+++ b/python/graphstorm/gpartition/dist_partition_graph.py
@@ -164,6 +164,8 @@ def main():
             # TODO: Implement distributed conversion using
             # dgl.distributed.partition.gb_convert_single_dgl_partition()
             logging.info("Converting partitions to GraphBolt format")
+            # NOTE: The partition conversion happens on just the leader
+            # and a shared filesystem is assumed to hold the graph data.
             dgl.distributed.dgl_partition_to_graphbolt(
                 os.path.join(output_path, "dist_graph", "metadata.json"),
                 store_eids=True,

--- a/python/graphstorm/gpartition/dist_partition_graph.py
+++ b/python/graphstorm/gpartition/dist_partition_graph.py
@@ -161,8 +161,8 @@ def main():
     if args.use_graphbolt:
         dgl_version = importlib.metadata.version('dgl')
         if version.parse(dgl_version) >= version.parse("2.0.0"):
-            # TODO: Use dgl.distributed.partition.gb_convert_single_dgl_partition()
-            # to run distributed conversion
+            # TODO: Implement distributed conversion using
+            # dgl.distributed.partition.gb_convert_single_dgl_partition()
             logging.info("Converting partitions to GraphBolt format")
             dgl.distributed.dgl_partition_to_graphbolt(
                 os.path.join(output_path, "dist_graph", "metadata.json"),
@@ -170,12 +170,9 @@ def main():
                 graph_formats="coo",
             )
         else:
-            logging.warning(
-                (
-                    "use_graphbolt was 'true' but but DGL version was %s. "
-                    "GraphBolt requires DGL version >= 2.x."
-                ),
-                dgl_version
+            raise ValueError(
+                f"use_graphbolt was 'true' but but DGL version was {dgl_version}. "
+                "GraphBolt requires DGL version >= 2.x."
             )
 
     # Copy raw_id_mappings to dist_graph if they exist in the input

--- a/python/graphstorm/gsf.py
+++ b/python/graphstorm/gsf.py
@@ -170,8 +170,12 @@ def initialize(
         if use_graphbolt:
             raise ValueError(
                 f"use_graphbolt was 'true' but but DGL version was {dgl_version}. "
-                "GraphBolt graph construction requires DGL version >= 2.1.0"
+                "GraphBolt DGL initialization requires DGL version >= 2.1.0"
             )
+        dgl.distributed.initialize(
+            ip_config,
+            net_type='socket',
+        )
     assert th.cuda.is_available() or backend == "gloo", "Gloo backend required for a CPU setting."
     if ip_config is not None:
         th.distributed.init_process_group(backend=backend)

--- a/python/graphstorm/gsf.py
+++ b/python/graphstorm/gsf.py
@@ -18,15 +18,16 @@
 
 import os
 import logging
-from importlib.metadata import version
+import importlib.metadata
 
 import numpy as np
 import dgl
 import torch as th
 import torch.nn.functional as F
-from dgl.distributed import role
+
 from dgl.distributed.constants import DEFAULT_NTYPE
 from dgl.distributed.constants import DEFAULT_ETYPE
+from packaging import version
 
 from .utils import sys_tracker, get_rank
 from .utils import setup_device
@@ -153,10 +154,13 @@ def initialize(
         Default: False.
     use_graphbolt: bool
         Whether to use GraphBolt graph representation.
+        Requires installed DGL version to be at least ``2.1.0``.
         Default: False.
+
+        .. versionadded:: 0.4
     """
-    dgl_version = version('dgl')
-    if int(dgl_version.split('.')[0]) > 1:
+    dgl_version = importlib.metadata.version('dgl')
+    if version.parse(dgl_version) >= version.parse("2.1.0"):
         dgl.distributed.initialize(
             ip_config,
             net_type='socket',
@@ -164,19 +168,10 @@ def initialize(
         )
     else:
         if use_graphbolt:
-            logging.warning(
-                (
-                    "use_graphbolt was 'true' but but DGL version was %s. "
-                    "GraphBolt requires DGL version >= 2.x."
-                ),
-                dgl_version
-                )
-        # We need to use socket for communication in DGL 0.8. The tensorpipe backend has a bug.
-        # This problem will be fixed in the future.
-        dgl.distributed.initialize(
-            ip_config,
-            net_type='socket',
-        )
+            raise ValueError(
+                f"use_graphbolt was 'true' but but DGL version was {dgl_version}. "
+                "GraphBolt graph construction requires DGL version >= 2.1.0"
+            )
     assert th.cuda.is_available() or backend == "gloo", "Gloo backend required for a CPU setting."
     if ip_config is not None:
         th.distributed.init_process_group(backend=backend)

--- a/python/graphstorm/run/launch.py
+++ b/python/graphstorm/run/launch.py
@@ -280,7 +280,7 @@ def execute_remote(
             state_q,
         ),
     )
-    thread.setDaemon(True)
+    thread.daemon = True
     thread.start()
     # sleep for a while in case of ssh is rejected by peer due to busy connection
     time.sleep(0.2)
@@ -321,7 +321,7 @@ def execute_local(
             state_q,
         ),
     )
-    thread.setDaemon(True)
+    thread.daemon = True
     thread.start()
     # sleep for a while in case of ssh is rejected by peer due to busy connection
     time.sleep(0.2)

--- a/setup.py
+++ b/setup.py
@@ -32,6 +32,7 @@ requirements = [
     'pandas',
     'scikit-learn',
     'ogb==1.3.6',
+    'packaging',
     'psutil'
 ]
 

--- a/tests/end2end-tests/create_data.sh
+++ b/tests/end2end-tests/create_data.sh
@@ -1,3 +1,6 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
 date
 GS_HOME=$(pwd)
 export PYTHONPATH=$GS_HOME/python/
@@ -46,7 +49,8 @@ python3 -m graphstorm.gconstruct.construct_graph \
 	--num-processes 1 \
 	--output-dir movielen_100k_lp_train_val_1p_4t \
 	--graph-name movie-lens-100k \
-	--add-reverse-edges
+	--add-reverse-edges \
+    --use-graphbolt true
 cp -R /data/ml-100k/raw_id_mappings/ movielen_100k_lp_train_val_1p_4t/
 
 # movielens link prediction - hard negative and fixed negative for inference

--- a/tests/end2end-tests/create_data.sh
+++ b/tests/end2end-tests/create_data.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -Eeuo pipefail
+set -Eeu
 
 date
 GS_HOME=$(pwd)
@@ -49,8 +49,7 @@ python3 -m graphstorm.gconstruct.construct_graph \
 	--num-processes 1 \
 	--output-dir movielen_100k_lp_train_val_1p_4t \
 	--graph-name movie-lens-100k \
-	--add-reverse-edges \
-    --use-graphbolt true
+	--add-reverse-edges
 cp -R /data/ml-100k/raw_id_mappings/ movielen_100k_lp_train_val_1p_4t/
 
 # movielens link prediction - hard negative and fixed negative for inference

--- a/tests/end2end-tests/data_process/gpartition_test.sh
+++ b/tests/end2end-tests/data_process/gpartition_test.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+trap cleanup SIGINT SIGTERM ERR EXIT
+
+service ssh restart
+
+GS_HOME=$(pwd)
+export PYTHONPATH=$GS_HOME/python/
+
+INPUT_PATH=/data/ml-100k/
+OUTPUT_PATH=/tmp/gpartition-e2e-tests
+
+echo "127.0.0.1" > ip_list.txt
+
+
+cleanup() {
+  trap - SIGINT SIGTERM ERR EXIT
+  # script cleanup here
+  if [[ -d "${OUTPUT_PATH}" ]]; then
+    echo "Cleaning up ${OUTPUT_PATH}"
+    rm -rf "${OUTPUT_PATH}"
+  fi
+}
+
+# Ensure test data have been generated
+if [ ! -f "${INPUT_PATH}/chunked_graph_meta.json" ]; then
+    python3 "$GS_HOME/tests/end2end-tests/data_gen/process_movielens.py"
+fi
+
+echo "********* Test partition creation with DistDGL graph format ********"
+
+DIST_DGL_PATH="${OUTPUT_PATH}/dist-dgl-part"
+python3 -m graphstorm.gpartition.dist_partition_graph \
+    --input-path ${INPUT_PATH} \
+    --ip-config ip_list.txt \
+    --metadata-filename chunked_graph_meta.json \
+    --num-parts 2 \
+    --output-path ${DIST_DGL_PATH} \
+    --ssh-port 2222
+
+# Ensure expected files and directories were created
+if [ ! -f "${DIST_DGL_PATH}/dist_graph/metadata.json" ];
+    then
+    echo "${DIST_DGL_PATH}/dist_graph/metadata.json does not exist"
+fi
+
+for i in $(seq 0 1); do
+    if [ ! -f "${DIST_DGL_PATH}/dist_graph/part${i}/graph.dgl" ];
+    then
+        echo "${DIST_DGL_PATH}/dist_graph/part${i}/graph.dgl must exist"
+        exit 1
+    fi
+done
+
+
+echo "********* Test partition creation with GraphBolt graph format ********"
+
+GRAPHBOLT_PATH="${OUTPUT_PATH}/graphbolt-part"
+python3 -m graphstorm.gpartition.dist_partition_graph \
+    --input-path "${INPUT_PATH}" \
+    --ip-config ip_list.txt \
+    --metadata-filename chunked_graph_meta.json \
+    --num-parts 2 \
+    --output-path $GRAPHBOLT_PATH \
+    --ssh-port 2222 \
+    --use-graphbolt "true"
+
+
+# Ensure GraphBolt files were created
+for i in $(seq 0 1); do
+    if [ ! -f "$GRAPHBOLT_PATH/dist_graph/part${i}/fused_csc_sampling_graph.pt" ]
+    then
+        echo "$GRAPHBOLT_PATH/dist_graph/part${i}/fused_csc_sampling_graph.pt must exist"
+        exit 1
+    fi
+done

--- a/tests/end2end-tests/data_process/gpartition_test.sh
+++ b/tests/end2end-tests/data_process/gpartition_test.sh
@@ -51,26 +51,3 @@ for i in $(seq 0 1); do
         exit 1
     fi
 done
-
-
-echo "********* Test partition creation with GraphBolt graph format ********"
-
-GRAPHBOLT_PATH="${OUTPUT_PATH}/graphbolt-part"
-python3 -m graphstorm.gpartition.dist_partition_graph \
-    --input-path "${INPUT_PATH}" \
-    --ip-config ip_list.txt \
-    --metadata-filename chunked_graph_meta.json \
-    --num-parts 2 \
-    --output-path $GRAPHBOLT_PATH \
-    --ssh-port 2222 \
-    --use-graphbolt "true"
-
-
-# Ensure GraphBolt files were created
-for i in $(seq 0 1); do
-    if [ ! -f "$GRAPHBOLT_PATH/dist_graph/part${i}/fused_csc_sampling_graph.pt" ]
-    then
-        echo "$GRAPHBOLT_PATH/dist_graph/part${i}/fused_csc_sampling_graph.pt must exist"
-        exit 1
-    fi
-done

--- a/tests/end2end-tests/data_process/gpartition_test.sh
+++ b/tests/end2end-tests/data_process/gpartition_test.sh
@@ -13,11 +13,22 @@ OUTPUT_PATH=/tmp/gpartition-e2e-tests
 echo "127.0.0.1" > ip_list.txt
 
 
+msg() {
+  echo >&2 -e "${1-}"
+}
+
+die() {
+  local msg=$1
+  local code=${2-1} # default exit status 1
+  msg "$msg"
+  exit "$code"
+}
+
 cleanup() {
   trap - SIGINT SIGTERM ERR EXIT
   # script cleanup here
   if [[ -d "${OUTPUT_PATH}" ]]; then
-    echo "Cleaning up ${OUTPUT_PATH}"
+    msg "Cleaning up ${OUTPUT_PATH}"
     rm -rf "${OUTPUT_PATH}"
   fi
 }
@@ -41,13 +52,39 @@ python3 -m graphstorm.gpartition.dist_partition_graph \
 # Ensure expected files and directories were created
 if [ ! -f "${DIST_DGL_PATH}/dist_graph/metadata.json" ];
     then
-    echo "${DIST_DGL_PATH}/dist_graph/metadata.json does not exist"
+    die "${DIST_DGL_PATH}/dist_graph/metadata.json does not exist"
 fi
 
 for i in $(seq 0 1); do
     if [ ! -f "${DIST_DGL_PATH}/dist_graph/part${i}/graph.dgl" ];
     then
-        echo "${DIST_DGL_PATH}/dist_graph/part${i}/graph.dgl must exist"
-        exit 1
+        die "${DIST_DGL_PATH}/dist_graph/part${i}/graph.dgl must exist"
     fi
 done
+
+echo "********* Test partition assignment only creation ********"
+
+PART_ONLY_PATH="${OUTPUT_PATH}/part-assign-only"
+python3 -m graphstorm.gpartition.dist_partition_graph \
+    --input-path ${INPUT_PATH} \
+    --ip-config ip_list.txt \
+    --metadata-filename chunked_graph_meta.json \
+    --num-parts 2 \
+    --output-path ${PART_ONLY_PATH} \
+    --partition-assignment-only \
+    --ssh-port 2222
+
+# Ensure expected files and directories were created
+for NTYPE in user movie; do
+    if [ ! -f "${PART_ONLY_PATH}/partition_assignment/$NTYPE.txt" ];
+        then
+        die "${PART_ONLY_PATH}/partition_assignment/$NTYPE.txt does not exist"
+    fi
+done
+
+if [ -f "${PART_ONLY_PATH}/dist_graph/metadata.json" ];
+    then
+    die "${PART_ONLY_PATH}/dist_graph/metadata.json should not exist"
+fi
+
+msg "********* Distributed partitioning tests passed *********"

--- a/tests/end2end-tests/data_process/movielens_test.sh
+++ b/tests/end2end-tests/data_process/movielens_test.sh
@@ -16,7 +16,7 @@ error_and_exit () {
 
 	if test $status -ne 0
 	then
-		exit -1
+		exit 1
 	fi
 }
 
@@ -27,6 +27,26 @@ python3 -m graphstorm.gconstruct.construct_graph --conf-file $GS_HOME/tests/end2
 
 error_and_exit $?
 
+echo "********* Test generating the GraphBolt graph format with GConstruct ********"
+
+python3 -m graphstorm.gconstruct.construct_graph \
+    --add-reverse-edges \
+    --conf-file $GS_HOME/tests/end2end-tests/data_gen/movielens_text.json \
+    --graph-name ml \
+    --num-processes 1 \
+    --output-dir /tmp/movielens_graphbolt \
+    --part-method random \
+    --use-graphbolt "true"
+
+error_and_exit $?
+
+# check if graphbolt representation was created
+if test -f /tmp/movielens_graphbolt/part0/fused_csc_sampling_graph.pt -ne 0
+then
+	echo "/tmp/movielens_graphbolt/part0/fused_csc_sampling_graph.pt must exist"
+	exit 1
+fi
+
 echo "********* Test the DistDGL graph format with BERT embeddings ********"
 python3 -m graphstorm.gconstruct.construct_graph --conf-file $GS_HOME/tests/end2end-tests/data_gen/movielens.json --num-processes 1 --output-dir /tmp/movielens_bert_emb --graph-name ml --add-reverse-edges
 
@@ -36,13 +56,13 @@ error_and_exit $?
 if test -f /tmp/movielens_bert_emb/node_mapping.pt -ne 0
 then
 	echo "/tmp/movielens_bert_emb/node_mapping.pt must exist"
-	exit -1
+	exit 1
 fi
 
 if test -f /tmp/movielens_bert_emb/edge_mapping.pt -ne 0
 then
 	echo "/tmp/movielens_bert_emb/edge_mapping.pt must exist"
-	exit -1
+	exit 1
 fi
 
 echo "**************dataset: Test edge classification, RGCN layer: 1, node feat: BERT embeddings, inference: mini-batch"
@@ -57,7 +77,7 @@ cnt=$(ls /tmp/movielens_bert_emb/emb/ | wc -l)
 if test $cnt -lt 2
 then
 	echo "Must have node embeddings for movie and user."
-	exit -1
+	exit 1
 fi
 
 echo "**************dataset: Test edge classification, RGCN layer: 1, node feat: HF BERT, BERT nodes: movie, inference: mini-batch"

--- a/tests/end2end-tests/data_process/movielens_test.sh
+++ b/tests/end2end-tests/data_process/movielens_test.sh
@@ -27,26 +27,6 @@ python3 -m graphstorm.gconstruct.construct_graph --conf-file $GS_HOME/tests/end2
 
 error_and_exit $?
 
-echo "********* Test generating the GraphBolt graph format with GConstruct ********"
-
-python3 -m graphstorm.gconstruct.construct_graph \
-    --add-reverse-edges \
-    --conf-file $GS_HOME/tests/end2end-tests/data_gen/movielens_text.json \
-    --graph-name ml \
-    --num-processes 1 \
-    --output-dir /tmp/movielens_graphbolt \
-    --part-method random \
-    --use-graphbolt "true"
-
-error_and_exit $?
-
-# check if graphbolt representation was created
-if test -f /tmp/movielens_graphbolt/part0/fused_csc_sampling_graph.pt -ne 0
-then
-	echo "/tmp/movielens_graphbolt/part0/fused_csc_sampling_graph.pt must exist"
-	exit 1
-fi
-
 echo "********* Test the DistDGL graph format with BERT embeddings ********"
 python3 -m graphstorm.gconstruct.construct_graph --conf-file $GS_HOME/tests/end2end-tests/data_gen/movielens.json --num-processes 1 --output-dir /tmp/movielens_bert_emb --graph-name ml --add-reverse-edges
 

--- a/tests/end2end-tests/graphbolt-gs-integration/graphbolt-graph-construction.sh
+++ b/tests/end2end-tests/graphbolt-gs-integration/graphbolt-graph-construction.sh
@@ -1,0 +1,120 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+trap cleanup SIGINT SIGTERM ERR EXIT
+
+usage() {
+  cat <<EOF
+Usage: $(basename "${BASH_SOURCE[0]}") [-h] [-x] [-i /path/to/ml-100k] [-o /path/to/output/data]
+
+Converts the raw ml-100k data to format used for integration tests
+
+Available options:
+
+-h, --help          Print this help and exit
+-x, --verbose       Print script debug info (set -x)
+-i, --ml100k-path   Path to the processed ml-100k data, created by tests/end2end-tests/data_gen/process_movielens.py
+-o, --output-path   Path under which the converted data will be created.
+
+EOF
+  exit
+}
+
+# Parse command-line arguments
+parse_params() {
+    # Default values for input and output paths
+    INPUT_PATH="/storage/ml-100k"
+    OUTPUT_PATH="/tmp/gb-graphconstruction-e2e-tests"
+
+    while :; do
+    case "${1-}" in
+    -h | --help) usage ;;
+    -x | --verbose) set -x ;;
+    -i | --ml100k-path)
+        INPUT_PATH="${2-}"
+        shift
+        ;;
+    -o | --output-path)
+        OUTPUT_PATH="${2-}"
+        shift
+        ;;
+    -?*) die "Unknown option: $1" ;;
+    *) break ;;
+    esac
+    shift
+    done
+
+    return 0
+}
+
+cleanup() {
+    trap - SIGINT SIGTERM ERR EXIT
+    # script cleanup here
+    if [[ -d "${OUTPUT_PATH}" ]]; then
+        echo "Cleaning up ${OUTPUT_PATH}"
+        rm -rf "${OUTPUT_PATH}"
+    fi
+}
+
+parse_params "$@"
+
+GS_HOME=$(pwd)
+
+mkdir -p "$OUTPUT_PATH"
+cd "$OUTPUT_PATH" || exit
+cp -R "$INPUT_PATH" "$OUTPUT_PATH"
+
+# Ensure ip_list.txt exists and self-ssh works
+echo "127.0.0.1" > ip_list.txt
+ssh -o PreferredAuthentications=publickey -p 2222 127.0.0.1 /bin/true || service ssh restart
+
+
+# Ensure test data have been generated
+if [ ! -f "${INPUT_PATH}/chunked_graph_meta.json" ]; then
+    python3 "$GS_HOME/tests/end2end-tests/data_gen/process_movielens.py"
+fi
+
+echo "********* Test GConstruct with GraphBolt graph format ********"
+
+GCONS_GRAPHBOLT_PATH="${OUTPUT_PATH}/graphbolt-gconstruct"
+python3 -m graphstorm.gconstruct.construct_graph \
+    --add-reverse-edges \
+    --conf-file $GS_HOME/tests/end2end-tests/data_gen/movielens_text.json \
+    --graph-name ml \
+    --num-parts 2 \
+    --num-processes 1 \
+    --output-dir "$GCONS_GRAPHBOLT_PATH" \
+    --part-method random \
+    --use-graphbolt "true"
+
+
+# Ensure GraphBolt files were created by GConstruct
+for i in $(seq 0 1); do
+    if [ ! -f "$GCONS_GRAPHBOLT_PATH/part${i}/fused_csc_sampling_graph.pt" ]
+    then
+        echo "$GCONS_GRAPHBOLT_PATH/part${i}/fused_csc_sampling_graph.pt must exist"
+        exit 1
+    fi
+done
+
+echo "********* Test GSPartition with GraphBolt graph format ********"
+
+DIST_GRAPHBOLT_PATH="${OUTPUT_PATH}/graphbolt-part"
+python3 -m graphstorm.gpartition.dist_partition_graph \
+    --input-path "${INPUT_PATH}" \
+    --ip-config ip_list.txt \
+    --metadata-filename chunked_graph_meta.json \
+    --num-parts 2 \
+    --output-path "$DIST_GRAPHBOLT_PATH" \
+    --ssh-port 2222 \
+    --use-graphbolt "true"
+
+# Ensure GraphBolt files were created by GSPartition
+for i in $(seq 0 1); do
+    if [ ! -f "$DIST_GRAPHBOLT_PATH/dist_graph/part${i}/fused_csc_sampling_graph.pt" ]
+    then
+        echo "$DIST_GRAPHBOLT_PATH/dist_graph/part${i}/fused_csc_sampling_graph.pt must exist"
+        exit 1
+    fi
+done
+
+echo "********* GraphBolt graph construction and partitioning tests passed *********"

--- a/tests/end2end-tests/graphbolt-gs-integration/graphbolt-graph-construction.sh
+++ b/tests/end2end-tests/graphbolt-gs-integration/graphbolt-graph-construction.sh
@@ -22,7 +22,7 @@ EOF
 # Parse command-line arguments
 parse_params() {
     # Default values for input and output paths
-    INPUT_PATH="/storage/ml-100k"
+    INPUT_PATH="/data/ml-100k"
     OUTPUT_PATH="/tmp/gb-graphconstruction-e2e-tests"
 
     while :; do


### PR DESCRIPTION

*Issue #, if available:*

*Description of changes:*

* Add `--use-graphbolt` argument to GConstruct and GSPartition entry points. When set to `true`, we convert the graph data to GraphBolt format after partitioning.
* Add new `gpartition_test.sh` set of integration tests for GSPartition entry point. 
* Add new tests/end2end-tests/graphbolt-gs-integration/graphbolt-graph-construction.sh set of integration tests for graph construction with GraphBolt enabled. Requires DGL >= 2.x.
  * To accommodate this, we we modify `tests/end2end-tests/data_gen/process_movielens.py` so that it also produces a JSON file that can be used as input the the DistPart DGL pipeline.
* To parse and handle different DGL versions we use `importlib.metadata` and the `packaging` modules. We introduce an explicit dependency on `packaging` to GSF. This shouldn't change the user environment, as we already had a transitive dependency on `packaging` through the `transformers` lib.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
