### PR TITLE
[Bugfix] Excluding valid/test edges during link prediction training in multi-task learning setting

### DIFF
--- a/python/graphstorm/dataloading/dataloading.py
+++ b/python/graphstorm/dataloading/dataloading.py
@@ -375,7 +375,7 @@ class GSgnnEdgeDataLoader(GSgnnEdgeDataLoaderBase):
     Examples
     ------------
     To train a 2-layer GNN for edge prediction on a set of edges ``target_idx`` on
-    a graph where each edge (source and destination node pair) takes messages from 15 
+    a graph where each edge (source and destination node pair) takes messages from 15
     neighbors on the first layer and 10 neighbors on the second.
 
     .. code:: python
@@ -576,7 +576,7 @@ class GSgnnLinkPredictionDataLoaderBase():
               More detailed information about DGL MFG can be found in `DGL Neighbor Sampling
               Overview
               <https://docs.dgl.ai/stochastic_training/neighbor_sampling_overview.html>`_.
-        
+
         """
 
     def __len__(self):
@@ -652,8 +652,8 @@ class GSgnnLinkPredictionDataLoader(GSgnnLinkPredictionDataLoaderBase):
 
     ``GSgnnLinkPredictionDataLoader`` samples GraphStorm data into an iterable over mini-batches
     of samples. In each batch, ``pos_graph`` and ``neg_graph`` are sampled subgraph for positive
-    and negative edges, which will be used by GraphStorm Trainers and Inferrers. 
-    
+    and negative edges, which will be used by GraphStorm Trainers and Inferrers.
+
     Given a positive edge, a negative edge is composed of the source node and a random negative
     destination nodes according to a uniform distribution.
 
@@ -713,7 +713,7 @@ class GSgnnLinkPredictionDataLoader(GSgnnLinkPredictionDataLoaderBase):
     ------------
     To train a 2-layer GNN for link prediction on a set of positive edges ``target_idx`` on
     a graph where each edge (a source and destination node pair) takes messages from 15 neighbors
-    on the first layer and 10 neighbors on the second. 
+    on the first layer and 10 neighbors on the second.
     We use 10 negative edges per positive in this example.
 
     .. code:: python
@@ -747,6 +747,12 @@ class GSgnnLinkPredictionDataLoader(GSgnnLinkPredictionDataLoaderBase):
                 train_task=train_task,
                 exclude_training_targets=exclude_training_targets,
                 reverse_edge_types_map=reverse_edge_types_map,
+                # If the edge_mask_for_gnn_embeddings exists as an edge feature
+                # of an edge type, then when sampling edges from that edge type,
+                # only the edges with the mask (set to 1) will be sampled.
+                # if the edge_mask_for_gnn_embeddings does not exist as the edge feature
+                # of an edge type, then when sampling edges from that edge type,
+                # all the edges can be sampled.
                 edge_mask_for_gnn_embeddings=edge_mask_for_gnn_embeddings,
                 construct_feat_ntype=construct_feat_ntype,
                 construct_feat_fanout=construct_feat_fanout,
@@ -1762,10 +1768,10 @@ class GSgnnNodeSemiSupDataLoader(GSgnnNodeDataLoader):
 
     def __len__(self):
         """
-        Follow the 
+        Follow the
         https://github.com/dmlc/dgl/blob/1.0.x/python/dgl/distributed/dist_dataloader.py#L116.
         In DGL, ``DistDataLoader.expected_idxs`` is the length (number of batches)
-        of the dataloader. As it uses two dataloader, either one throws an End of Iter error 
+        of the dataloader. As it uses two dataloader, either one throws an End of Iter error
         will stop the dataloader.
 
         Returns:

--- a/python/graphstorm/run/gsgnn_mt/gsgnn_mt.py
+++ b/python/graphstorm/run/gsgnn_mt/gsgnn_mt.py
@@ -108,6 +108,9 @@ def create_task_train_dataloader(task, config, train_data):
                               train_task=True,
                               reverse_edge_types_map=task_config.reverse_edge_types_map,
                               exclude_training_targets=task_config.exclude_training_targets,
+                              # Only use training edges in message passing during training.
+                              # Overwrite the default mask name "train_mask"
+                              edge_mask_for_gnn_embeddings=config.train_mask,
                               edge_dst_negative_field=task_config.train_etypes_negative_dstnode,
                               num_hard_negs=task_config.num_train_hard_negatives)
     elif task.task_type in [BUILTIN_TASK_RECONSTRUCT_NODE_FEAT]:

--- a/python/graphstorm/run/gsgnn_mt/gsgnn_mt.py
+++ b/python/graphstorm/run/gsgnn_mt/gsgnn_mt.py
@@ -110,7 +110,7 @@ def create_task_train_dataloader(task, config, train_data):
                               exclude_training_targets=task_config.exclude_training_targets,
                               # Only use training edges in message passing during training.
                               # Overwrite the default mask name "train_mask"
-                              edge_mask_for_gnn_embeddings=config.train_mask,
+                              edge_mask_for_gnn_embeddings=task_config.train_mask,
                               edge_dst_negative_field=task_config.train_etypes_negative_dstnode,
                               num_hard_negs=task_config.num_train_hard_negatives)
     elif task.task_type in [BUILTIN_TASK_RECONSTRUCT_NODE_FEAT]:


### PR DESCRIPTION
*Issue #, if available:*
The training dataloader for link prediction use the default "train_mask" as the edge mask for gnn embedding computation. However, this assumption does not hold in multi-task learning.

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
