### PR TITLE
Add entry point for standalone GraphBolt conversion.

### DIFF
--- a/python/graphstorm/gconstruct/utils.py
+++ b/python/graphstorm/gconstruct/utils.py
@@ -29,6 +29,7 @@ import uuid
 
 import numpy as np
 import dgl
+from dgl import distributed as dgl_distributed
 from packaging import version
 import torch as th
 from torch import multiprocessing
@@ -1028,8 +1029,7 @@ def partition_graph(g, node_data, edge_data, graph_name, num_partitions, output_
                 f"use_graphbolt was 'true' but but DGL version was {dgl_version}. "
                 "GraphBolt graph construction requires DGL version >= 2.1.0"
             )
-    mapping = dgl.distributed.partition_graph(**partition_kwargs)
-
+    mapping = dgl_distributed.partition_graph(**partition_kwargs)
 
     sys_tracker.check('Graph partitioning')
 

--- a/python/graphstorm/gpartition/convert_to_graphbolt.py
+++ b/python/graphstorm/gpartition/convert_to_graphbolt.py
@@ -1,0 +1,75 @@
+"""
+    Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+    Convert existing partitioned data to GraphBolt format.
+"""
+
+import argparse
+import importlib.metadata
+import logging
+import os
+import time
+
+from dgl import distributed as dgl_distributed
+from packaging import version
+
+
+def parse_gbconv_args() -> argparse.Namespace:
+    """Parses GraphBolt conversion arguments"""
+    parser = argparse.ArgumentParser("Convert partitioned DGL graph to GraphBolt format.")
+    parser.add_argument("--input-path", type=str, required=True,
+                           help="Path to input DGL partitioned data.")
+    parser.add_argument("--metadata-filename", type=str, default="metadata.json",
+                           help="Name for the partitioned DGL metadata file.")
+    parser.add_argument("--logging-level", type=str, default="info",
+                           help="The logging level. The possible values: debug, info, warning, \
+                                   error. The default value is info.")
+
+    return parser.parse_args()
+
+
+def main():
+    """ Entry point
+    """
+    gb_conv_args = parse_gbconv_args()
+    # set logging level
+    logging.basicConfig(
+        format="%(asctime)s %(levelname)s %(message)s",
+        level=getattr(logging, gb_conv_args.logging_level.upper()),
+    )
+
+
+    part_config = os.path.join(gb_conv_args.input_path, gb_conv_args.metadata_filename)
+    dgl_version = importlib.metadata.version('dgl')
+    if version.parse(dgl_version) < version.parse("2.1.0"):
+        raise ValueError(
+                "GraphBolt conversion requires DGL version >= 2.1.0, "
+                f"but DGL version was {dgl_version}. "
+            )
+
+    gb_start = time.time()
+    logging.info("Converting partitions to GraphBolt format")
+
+    dgl_distributed.dgl_partition_to_graphbolt(
+            part_config,
+            store_eids=True,
+            graph_formats="coo",
+        )
+
+    logging.info("GraphBolt conversion took %f sec.",
+                    time.time() - gb_start)
+
+if __name__ == '__main__':
+    main()

--- a/python/graphstorm/gpartition/dist_partition_graph.py
+++ b/python/graphstorm/gpartition/dist_partition_graph.py
@@ -31,7 +31,7 @@ import importlib.metadata
 from typing import Dict
 from threading import Thread
 
-import dgl
+from dgl import distributed as dgl_distributed
 from packaging import version
 
 from graphstorm.gpartition import (
@@ -165,7 +165,7 @@ def main():
                 logging.info("Converting partitions to GraphBolt format")
                 # NOTE: The partition conversion happens on just the leader
                 # and a shared filesystem is assumed to hold the graph data.
-                dgl.distributed.dgl_partition_to_graphbolt(
+                dgl_distributed.dgl_partition_to_graphbolt(
                     os.path.join(output_path, "dist_graph", "metadata.json"),
                     store_eids=True,
                     graph_formats="coo",

--- a/tests/end2end-tests/graphbolt-gs-integration/graphbolt-graph-construction.sh
+++ b/tests/end2end-tests/graphbolt-gs-integration/graphbolt-graph-construction.sh
@@ -65,7 +65,8 @@ cp -R "$INPUT_PATH" "$OUTPUT_PATH"
 
 # Ensure ip_list.txt exists and self-ssh works
 echo "127.0.0.1" > ip_list.txt
-ssh -o PreferredAuthentications=publickey -p 2222 127.0.0.1 /bin/true || service ssh restart
+ssh -o PreferredAuthentications=publickey StrictHostKeyChecking=no \
+    -p 2222 127.0.0.1 /bin/true || service ssh restart
 
 
 # Ensure test data have been generated

--- a/tests/end2end-tests/graphbolt-gs-integration/graphbolt-graph-construction.sh
+++ b/tests/end2end-tests/graphbolt-gs-integration/graphbolt-graph-construction.sh
@@ -104,8 +104,7 @@ for i in $(seq 0 1); do
 done
 
 python3 -m graphstorm.gpartition.convert_to_graphbolt \
-    --input-path "${GCONS_GRAPHBOLT_PATH}" \
-    --metadata-filename ml.json
+    --metadata-filepath "${GCONS_GRAPHBOLT_PATH}/ml.json"
 
 # Ensure GraphBolt files were re-created by standalone script
 for i in $(seq 0 1); do

--- a/tests/end2end-tests/graphbolt-gs-integration/graphbolt-graph-construction.sh
+++ b/tests/end2end-tests/graphbolt-gs-integration/graphbolt-graph-construction.sh
@@ -97,6 +97,26 @@ for i in $(seq 0 1); do
     fi
 done
 
+echo "********* Test GraphBolt standalone conversion ********"
+# We remove the previously generated GraphBolt files to test the standalone generation
+for i in $(seq 0 1); do
+    rm "$GCONS_GRAPHBOLT_PATH/part${i}/fused_csc_sampling_graph.pt"
+done
+
+python3 -m graphstorm.gpartition.convert_to_graphbolt \
+    --input-path "${GCONS_GRAPHBOLT_PATH}" \
+    --metadata-filename ml.json
+
+# Ensure GraphBolt files were re-created by standalone script
+for i in $(seq 0 1); do
+    if [ ! -f "$GCONS_GRAPHBOLT_PATH/part${i}/fused_csc_sampling_graph.pt" ]
+    then
+        echo "$GCONS_GRAPHBOLT_PATH/part${i}/fused_csc_sampling_graph.pt must exist"
+        exit 1
+    fi
+done
+
+
 echo "********* Test GSPartition with GraphBolt graph format ********"
 
 DIST_GRAPHBOLT_PATH="${OUTPUT_PATH}/graphbolt-part"


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

* Standalone entry point for conversion of DistDGL data to GraphBolt format. This can be used to convert existing data to GB, DGL does not provide an entry point for that.
* We'll also use this in our example/tutorial.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
