### PR TITLE
[Bugfix] Link prediction contrastive loss does not work with edge weight for lp loss

### DIFF
--- a/python/graphstorm/config/argument.py
+++ b/python/graphstorm/config/argument.py
@@ -2348,7 +2348,7 @@ class GSConfig:
                 "Edge weight for loss only works with link prediction"
 
             if self.lp_loss_func in [ BUILTIN_LP_LOSS_CONTRASTIVELOSS]:
-                logging.warning("p_edge_weight_for_loss does not work with "
+                logging.warning("lp_edge_weight_for_loss does not work with "
                                 "%s loss in link prediction."
                                 "Disable edge weight for link prediction loss.",
                                 BUILTIN_LP_LOSS_CONTRASTIVELOSS)

--- a/python/graphstorm/config/argument.py
+++ b/python/graphstorm/config/argument.py
@@ -90,17 +90,17 @@ def get_argument_parser():
     .. code:: python
 
         from graphstorm.config import get_argument_parser, GSConfig
-        
+
         if __name__ == '__main__':
             # use GraphStorm argument parser to accept configuration yaml file and other arguments
             arg_parser = get_argument_parser()
-       
+
             # parse all arguments and split GraphStorm's built-in arguments from the customized ones
             gs_args, unknown_args = arg_parser.parse_known_args()
-       
+
             print(f'GS arguments: {gs_args}')
             print(f'Non GS arguments: {unknown_args}')
-            
+
             # use gs_args to create a GSConfig object
             config = GSConfig(gs_args)
 
@@ -2346,6 +2346,14 @@ class GSConfig:
         if hasattr(self, "_lp_edge_weight_for_loss"):
             assert self.task_type == BUILTIN_TASK_LINK_PREDICTION, \
                 "Edge weight for loss only works with link prediction"
+
+            if self.lp_loss_func in [ BUILTIN_LP_LOSS_CONTRASTIVELOSS]:
+                logging.warning("p_edge_weight_for_loss does not work with "
+                                "%s loss in link prediction."
+                                "Disable edge weight for link prediction loss.",
+                                BUILTIN_LP_LOSS_CONTRASTIVELOSS)
+                return None
+
             edge_weights = self._lp_edge_weight_for_loss
             if len(edge_weights) == 1 and \
                 ":" not in edge_weights[0]:

--- a/tests/unit-tests/test_config.py
+++ b/tests/unit-tests/test_config.py
@@ -986,8 +986,7 @@ def create_lp_config(tmp_path, file_name):
         "eval_metric": ["mrr"],
         "gamma": 1.0,
         "alpha": 2.0,
-        "lp_loss_func": BUILTIN_LP_LOSS_CONTRASTIVELOSS,
-        "lp_edge_weight_for_loss": ["query,exactmatch,asin:weight0", "query,click,asin:weight1"]
+        "lp_loss_func": BUILTIN_LP_LOSS_CONTRASTIVELOSS
     }
     with open(os.path.join(tmp_path, file_name+"2.yaml"), "w") as f:
         yaml.dump(yaml_object, f)
@@ -1111,8 +1110,7 @@ def test_lp_info():
         assert config.eval_metric[0] == "mrr"
         assert config.gamma == 1.0
         assert config.alpha == 2.0
-        assert config.lp_edge_weight_for_loss[ ("query", "exactmatch", "asin")] == ["weight0"]
-        assert config.lp_edge_weight_for_loss[ ("query", "click", "asin")] == ["weight1"]
+        assert config.lp_edge_weight_for_loss is None
         assert config.model_select_etype == LINK_PREDICTION_MAJOR_EVAL_ETYPE_ALL
 
         args = Namespace(yaml_config_file=os.path.join(Path(tmpdirname), 'lp_test_fail1.yaml'), local_rank=0)


### PR DESCRIPTION
Fix the bug by disabling edge weight for lp loss when the loss function is contrastive loss.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
