### PR TITLE
Add Adjusted Mean Ranking Index metric for Link Prediction

### DIFF
--- a/.github/workflow_scripts/pytest_check.sh
+++ b/.github/workflow_scripts/pytest_check.sh
@@ -7,4 +7,3 @@ FORCE_CUDA=1 python3 -m pip install -e '.[test]'  --no-build-isolation
 python3 -m pip install pytest
 sh ./tests/unit-tests/prepare_test_data.sh
 export NCCL_IB_DISABLE=1; export NCCL_SHM_DISABLE=1; NCCL_NET=Socket NCCL_DEBUG=INFO python3 -m pytest -x ./tests/unit-tests -s
-

--- a/inference_scripts/mt_infer/ml_nc_ec_er_lp_only_infer.yaml
+++ b/inference_scripts/mt_infer/ml_nc_ec_er_lp_only_infer.yaml
@@ -71,6 +71,9 @@ gsf:
         reverse_edge_types_map:
           - user,rating,rating-rev,movie
         batch_size: 128 # will overwrite the global batch_size
+        eval_metric:
+          - "mrr"
+          - "amri"
     - reconstruct_node_feat:
         reconstruct_nfeat_name: "title"
         target_ntype: "movie"

--- a/inference_scripts/mt_infer/ml_nc_ec_er_lp_with_mask_infer.yaml
+++ b/inference_scripts/mt_infer/ml_nc_ec_er_lp_with_mask_infer.yaml
@@ -91,6 +91,9 @@ gsf:
           - "train_mask_field_lp"
           - null # empty means there is no validation mask
           - "test_mask_field_lp"
+        eval_metric:
+          - "mrr"
+          - "amri"
     - reconstruct_node_feat:
         reconstruct_nfeat_name: "title"
         target_ntype: "movie"

--- a/python/graphstorm/eval/eval_func.py
+++ b/python/graphstorm/eval/eval_func.py
@@ -701,7 +701,7 @@ def compute_mae(pred, labels):
     diff = th.abs(pred.cpu() - labels.cpu())
     return th.mean(diff).cpu().item()
 
-def compute_mrr(ranking):
+def compute_mrr(ranking: th.Tensor) -> th.Tensor:
     """ Get link prediction Mean Reciprocal Rank (MRR) metrics
 
     Parameters

--- a/python/graphstorm/eval/eval_func.py
+++ b/python/graphstorm/eval/eval_func.py
@@ -729,7 +729,16 @@ def compute_amri(ranking: th.Tensor, candidate_sizes: th.Tensor) -> th.Tensor:
         AMRI = 1 - \\frac{\\text{MR}-1}{\\mathbb{E}[\\text{MR}-1]}
 
     where MR is the mean rank, and `E[MR]` is the expected mean rank, which is used
-    to adjust for chance. Its values will be in the [-1, 1] range, where 1 corresponds
+    to adjust for chance. E[MR] is defined as:
+
+    .. math::
+        \\mathbb{E}[\\text{MR}] = \\mathbb{E} \\left[ \\frac{1}{n} \\sum^n_{i=1}{r_i} \\right]
+
+    Where :math:`r_i` is the rank the model assigns to the positive edge,
+    compared to the negative edges in the candidate list, and :math:`n` is the number of
+    candidate lists, one per positive edge.
+
+    AMRI values will be in the :math:`[-1, 1]` range, where 1 corresponds
     to optimal performance where each individual rank is 1. A value of 0 indicates
     model performance similar to a model assigning random scores, or equal score
     to every candidate. The value is negative if the model performs worse than the

--- a/python/graphstorm/eval/eval_func.py
+++ b/python/graphstorm/eval/eval_func.py
@@ -741,7 +741,7 @@ def compute_amri(ranking: th.Tensor, candidate_sizes: th.Tensor) -> th.Tensor:
     ranking : torch.Tensor
         ranking of each positive edge
     candidate_sizes : th.Tensor
-        The size of each candidate list. If all lists have
+        The size of each candidate list. If all candidate lists have
         the same size this will be a single-value tensor.
 
     Returns

--- a/python/graphstorm/eval/eval_func.py
+++ b/python/graphstorm/eval/eval_func.py
@@ -753,7 +753,8 @@ def compute_amri(ranking: th.Tensor, candidate_sizes: th.Tensor) -> th.Tensor:
     """
     if candidate_sizes.shape[0] > 1:
         assert ranking.shape[0] == candidate_sizes.shape[0], \
-            "ranking and candidate_sizes must have the same length"
+            ("ranking and candidate_sizes must have the same length, "
+             f"got {ranking.shape=} {candidate_sizes.shape=}" )
         assert th.all(ranking <= candidate_sizes).item(), \
             "all ranks must be <= candidate_sizes"
 

--- a/python/graphstorm/eval/eval_func.py
+++ b/python/graphstorm/eval/eval_func.py
@@ -722,7 +722,7 @@ def compute_amri(ranking: th.Tensor, candidate_sizes: th.Tensor) -> th.Tensor:
     """Computes the Adjusted Mean Rank Index (AMRI) for the given ranking and candidate sizes.
 
     AMRI is a metric that evaluates the performance of link prediction models by considering both
-    the rank of the correct candidate and the number of candidates considered. It is calculated as:
+    the rank of the correct candidate and the number of candidates. It is calculated as:
 
     .. math::
         AMRI = 1 - \\frac{\\text{MR}-1}{\\mathbb{E}[\\text{MR}-1]}

--- a/python/graphstorm/eval/evaluator.py
+++ b/python/graphstorm/eval/evaluator.py
@@ -19,7 +19,7 @@
 import abc
 import warnings
 from statistics import mean
-from typing import Optional, Tuple
+from typing import Dict, Optional, Tuple
 
 import torch as th
 
@@ -196,7 +196,7 @@ class GSgnnLPRankingEvalInterface():
         test_rankings,
         total_iters,
         **kwargs,
-    ) -> Tuple[dict[str, th.Tensor], dict[str, th.Tensor]]:
+    ) -> Tuple[Dict[str, th.Tensor], Dict[str, th.Tensor]]:
         """Evaluate Link Prediction results on validation and test sets.
 
         **Link Prediction** evaluators should provide the ranking of validation and test sets as
@@ -979,7 +979,7 @@ class GSgnnLPEvaluator(GSgnnBaseEvaluator, GSgnnLPRankingEvalInterface):
             self,
             rankings,
             train=True,
-            candidate_sizes: Optional[dict[str, th.Tensor]] = None,
+            candidate_sizes: Optional[Dict[str, th.Tensor]] = None,
         ):
         """ Compute evaluation score.
 
@@ -1010,7 +1010,7 @@ class GSgnnLPEvaluator(GSgnnBaseEvaluator, GSgnnLPRankingEvalInterface):
         sizes_list = []
 
         # compute ranking value for each metric
-        metrics: dict[str, th.Tensor] = {}
+        metrics: Dict[str, th.Tensor] = {}
         for metric in self.metric_list:
             if metric == "amri":
                 assert candidate_sizes
@@ -1036,7 +1036,7 @@ class GSgnnLPEvaluator(GSgnnBaseEvaluator, GSgnnLPRankingEvalInterface):
             for _, metric_val in metrics.items():
                 th.distributed.all_reduce(metric_val)
 
-        return_metrics: dict[str, float] = {}
+        return_metrics: Dict[str, float] = {}
         for metric, metric_val in metrics.items():
             return_metric = metric_val / get_world_size()
             return_metrics[metric] = return_metric.item()

--- a/python/graphstorm/eval/evaluator.py
+++ b/python/graphstorm/eval/evaluator.py
@@ -921,7 +921,7 @@ class GSgnnLPEvaluator(GSgnnBaseEvaluator, GSgnnLPRankingEvalInterface):
             Currently we support:
 
             val_candidate_sizes : torch.Tensor
-                The size of each candidate list in the test set.
+                The size of each candidate list (positive + negative pairs) for each testing edges in the validation set.
                 If the tensor has a single element we use that as the size of all lists.
             test_candidate_sizes : torch.Tensor
                 The size of each candidate list in the test set.

--- a/python/graphstorm/eval/evaluator.py
+++ b/python/graphstorm/eval/evaluator.py
@@ -1021,7 +1021,8 @@ class GSgnnLPEvaluator(GSgnnBaseEvaluator, GSgnnLPRankingEvalInterface):
         metrics: Dict[str, th.Tensor] = {}
         for metric in self.metric_list:
             if metric == "amri":
-                assert candidate_sizes
+                assert candidate_sizes, \
+                    f"candidate_sizes needs to have a value for AMRI, got {candidate_sizes=}."
                 for _, size in candidate_sizes.items():
                     sizes_list.append(size)
                 candidate_sizes_tensor = th.cat(sizes_list, dim=0)
@@ -2027,8 +2028,7 @@ class GSgnnMultiTaskEvalInterface(abc.ABC):
         self,
         val_results: Dict[str, Any],
         test_results: Dict[str, Any],
-        total_iters: int,
-        **kwargs
+        total_iters: int
     ):
         """Evaluate multi-task training results, using task-specific evaluators for each task.
 
@@ -2189,7 +2189,6 @@ class GSgnnMultiTaskEvaluator(GSgnnBaseEvaluator, GSgnnMultiTaskEvalInterface):
         val_results: Dict[str, Any],
         test_results: Dict[str, Any],
         total_iters: int,
-        **kwargs
     ):
         eval_tasks = {}
         val_scores = {}

--- a/python/graphstorm/eval/evaluator.py
+++ b/python/graphstorm/eval/evaluator.py
@@ -1223,7 +1223,7 @@ class GSgnnPerEtypeLPEvaluator(GSgnnBaseEvaluator, GSgnnLPRankingEvalInterface):
             metrics = {}
             etype_candidate_sizes = candidate_sizes[etype] if candidate_sizes is not None else None
             for metric in self.metric_list:
-                arg_tuple = (ranking, etype_candidate_sizes) if metric == "amri" else (ranking)
+                arg_tuple = (ranking, etype_candidate_sizes) if metric == "amri" else (ranking, )
                 if train:
                     # training expects always a single number to be
                     # returned and has a different (potentially) evaluation function

--- a/python/graphstorm/eval/evaluator.py
+++ b/python/graphstorm/eval/evaluator.py
@@ -240,7 +240,7 @@ class GSgnnLPRankingEvalInterface():
             Currently we support:
 
             candidate_sizes : dict of tensors
-                A mapping from edge type to the the size of each candidate list
+                A mapping from edge type to the size of each candidate list
                 (positive + negative pairs).
                 If the tensor has a single element we use that as the size of all lists.
 

--- a/python/graphstorm/eval/evaluator.py
+++ b/python/graphstorm/eval/evaluator.py
@@ -982,7 +982,7 @@ class GSgnnLPEvaluator(GSgnnBaseEvaluator, GSgnnLPRankingEvalInterface):
 
     def compute_score(
             self,
-            rankings,
+            rankings: Dict[str, th.Tensor],
             train=True,
             **kwargs
         ):
@@ -1023,8 +1023,8 @@ class GSgnnLPEvaluator(GSgnnBaseEvaluator, GSgnnLPRankingEvalInterface):
             if metric == "amri":
                 assert candidate_sizes, \
                     f"candidate_sizes needs to have a value for AMRI, got {candidate_sizes=}."
-                for _, size in candidate_sizes.items():
-                    sizes_list.append(size)
+                for etype, _ in rankings.items():
+                    sizes_list.append(candidate_sizes[etype])
                 candidate_sizes_tensor = th.cat(sizes_list, dim=0)
                 arg_tuple = (ranking, candidate_sizes_tensor)
             else:

--- a/python/graphstorm/eval/evaluator.py
+++ b/python/graphstorm/eval/evaluator.py
@@ -235,8 +235,9 @@ class GSgnnLPRankingEvalInterface():
         train: boolean
             If in model training.
         candidate_sizes : torch.Tensor, optional
-            The size of each candidate list. If all lists have the
-            same size this will be an int, otherwise a list of ints.
+            The size of each candidate list (positive + negative pairs)
+            for every edge in the testing set. If the tensor has a
+            single element we use that as the size of all lists.
 
         Returns
         -------
@@ -921,10 +922,12 @@ class GSgnnLPEvaluator(GSgnnBaseEvaluator, GSgnnLPRankingEvalInterface):
             Currently we support:
 
             val_candidate_sizes : torch.Tensor
-                The size of each candidate list (positive + negative pairs) for each testing edges in the validation set.
+                A tensor containing the size of each candidate list (positive + negative pairs)
+                for each testing edge in the validation set.
                 If the tensor has a single element we use that as the size of all lists.
             test_candidate_sizes : torch.Tensor
-                The size of each candidate list in the test set.
+                A tensor containing the size of each candidate list (positive + negative pairs)
+                for every edge in the test set.
                 If the tensor has a single element we use that as the size of all lists.
 
             ..versionadded:: 0.4.0
@@ -1122,14 +1125,16 @@ class GSgnnPerEtypeLPEvaluator(GSgnnBaseEvaluator, GSgnnLPRankingEvalInterface):
             Currently we support:
 
             val_candidate_sizes : dict of tensors
-                The size of each candidate list in the validation set, in the format of
-                {etype: size}. If all lists have the same size this will be a single-value
-                tensor per etype.
+                The size of each candidate list (positive + negative pairs)
+                in the validation set, in the format of {etype: size_tensor}.
+                If all candidate lists have the same size this
+                will be a single-value tensor per etype.
 
             test_candidate_sizes : dict of tensors
-                The size of each candidate list in the test set, in the format of
-                {etype: size}. If all lists have the same size this will be a single-value
-                tensor per etype.
+                The size of each candidate list (positive + negative pairs)
+                in the test set, in the format of {etype: size_tensor}.
+                If all candidate lists have the same size this
+                will be a single-value tensor per etype.
 
 
             ..versionadded:: 0.4.0

--- a/python/graphstorm/gsf.py
+++ b/python/graphstorm/gsf.py
@@ -49,8 +49,7 @@ from .config import (BUILTIN_LP_LOSS_CROSS_ENTROPY,
                      BUILTIN_CLASS_LOSS_FOCAL)
 from .eval.eval_func import (
     SUPPORTED_HIT_AT_METRICS,
-    SUPPORTED_LINK_PREDICTION_METRICS,
-)
+    SUPPORTED_LINK_PREDICTION_METRICS)
 from .model.embed import GSNodeEncoderInputLayer
 from .model.lm_embed import GSLMNodeEncoderInputLayer, GSPureLMNodeInputLayer
 from .model.rgcn_encoder import RelationalGCNEncoder, RelGraphConvLayer
@@ -1209,9 +1208,9 @@ def create_lp_evaluator(config):
     assert all(
         (x.startswith(SUPPORTED_HIT_AT_METRICS) or x in SUPPORTED_LINK_PREDICTION_METRICS)
             for x in config.eval_metric), (
-            "Invalid LP evaluation metrics. "
-            "GraphStorm only supports MRR and Hit@K metrics for link prediction."
-        )
+        "Invalid LP evaluation metrics. "
+        f"GraphStorm only supports {SUPPORTED_LINK_PREDICTION_METRICS} as metrics "
+        f"for link prediction, got {config.eval_metric}")
 
     if config.report_eval_per_type:
         return GSgnnPerEtypeLPEvaluator(eval_frequency=config.eval_frequency,

--- a/python/graphstorm/inference/graphstorm_infer.py
+++ b/python/graphstorm/inference/graphstorm_infer.py
@@ -17,6 +17,7 @@
 """
 from ..tracker import GSSageMakerTaskTracker
 
+
 class GSInferrer():
     """ Generic GSgnn Inferrer.
 
@@ -25,7 +26,7 @@ class GSInferrer():
     model : GSgnnModel
         This model could be one of the internal GraphStorm GNN models, i.e.,
         ``GSgnnNodeModel``, ``GSgnnEdgeModel``, ``GSgnnLinkPredictionModel``, or a model
-        class that inherit them.  
+        class that inherit them.
         For customized GNN models, they should be the concrete implementation that inherits
         one of the ``GSgnnNodeModelBase``, ``GSgnnEdgeModelBase``, and
         ``GSgnnLinkPredictionModelBase`` classes.

--- a/python/graphstorm/inference/mt_infer.py
+++ b/python/graphstorm/inference/mt_infer.py
@@ -319,7 +319,7 @@ class GSgnnMultiTaskLearningInferrer(GSInferrer):
             test_start = time.time()
             assert isinstance(self.evaluator, GSgnnLPRankingEvalInterface)
             val_score, test_score = self.evaluator.evaluate(
-                None,
+                pre_results,
                 pre_results,
                 0,
                 val_candidate_sizes=None,

--- a/python/graphstorm/inference/mt_infer.py
+++ b/python/graphstorm/inference/mt_infer.py
@@ -317,13 +317,19 @@ class GSgnnMultiTaskLearningInferrer(GSInferrer):
 
         if do_eval:
             test_start = time.time()
-            assert isinstance(self.evaluator, GSgnnLPRankingEvalInterface)
-            val_score, test_score = self.evaluator.evaluate(
-                pre_results,
-                pre_results,
-                0,
-                val_candidate_sizes=None,
-                test_candidate_sizes=test_lengths,
+            if isinstance(self.evaluator, GSgnnLPRankingEvalInterface):
+                val_score, test_score = self.evaluator.evaluate(
+                    pre_results,
+                    pre_results,
+                    0,
+                    val_candidate_sizes=test_lengths,
+                    test_candidate_sizes=test_lengths,
+                )
+            else:
+                val_score, test_score = self.evaluator.evaluate(
+                    pre_results,
+                    pre_results,
+                    0
                 )
             sys_tracker.check('run evaluation')
             if get_rank() == 0:

--- a/python/graphstorm/inference/mt_infer.py
+++ b/python/graphstorm/inference/mt_infer.py
@@ -18,12 +18,15 @@
 import os
 import time
 import logging
+from typing import Any, Dict, Optional
+
 import torch as th
 
 from ..config import (BUILTIN_TASK_NODE_CLASSIFICATION,
                       BUILTIN_TASK_NODE_REGRESSION,
                       BUILTIN_TASK_EDGE_CLASSIFICATION,
                       BUILTIN_TASK_EDGE_REGRESSION)
+from ..dataloading import GSgnnMultiTaskDataLoader
 from ..eval.evaluator import GSgnnMultiTaskEvaluator
 from .graphstorm_infer import GSInferrer
 from ..model.utils import save_full_node_embeddings as save_gsgnn_embeddings
@@ -55,10 +58,10 @@ class GSgnnMultiTaskLearningInferrer(GSInferrer):
 
     # pylint: disable=unused-argument
     def infer(self, data,
-              predict_test_loader=None,
-              lp_test_loader=None,
-              recon_nfeat_test_loader=None,
-              recon_efeat_test_loader=None,
+              predict_test_loader: Optional[GSgnnMultiTaskDataLoader] = None,
+              lp_test_loader: Optional[GSgnnMultiTaskDataLoader] = None,
+              recon_nfeat_test_loader: Optional[GSgnnMultiTaskDataLoader] = None,
+              recon_efeat_test_loader: Optional[GSgnnMultiTaskDataLoader] = None,
               save_embed_path=None,
               save_prediction_path=None,
               use_mini_batch_infer=False,
@@ -210,7 +213,7 @@ class GSgnnMultiTaskLearningInferrer(GSInferrer):
         # 2. node feature reconstruction (as it has the chance
         #    to reuse the node embeddings generated at the beginning)
         # 3. link prediction.
-        pre_results = {}
+        pre_results: Dict[str, Any] = {}
         test_lengths = None
         if predict_test_loader is not None:
             # compute prediction results for node classification,
@@ -323,8 +326,6 @@ class GSgnnMultiTaskLearningInferrer(GSInferrer):
                 pre_results,
                 pre_results,
                 0,
-                val_candidate_sizes=test_lengths,
-                test_candidate_sizes=test_lengths,
             )
 
             sys_tracker.check('run evaluation')

--- a/python/graphstorm/model/edge_decoder.py
+++ b/python/graphstorm/model/edge_decoder.py
@@ -17,6 +17,8 @@
 """
 import abc
 import logging
+from typing import Dict
+
 import numpy as np
 import torch as th
 from torch import nn
@@ -916,11 +918,11 @@ class LinkPredictionTestScoreInterface(abc.ABC):
     @abc.abstractmethod
     def calc_test_scores(
         self,
-        emb: dict[str, th.Tensor],
-        pos_neg_tuple: dict[tuple[str, str, str], th.Tensor],
+        emb: Dict[str, th.Tensor],
+        pos_neg_tuple: Dict[tuple[str, str, str], th.Tensor],
         neg_sample_type: str,
         device: th.device,
-    ) -> dict[tuple[str, str, str], tuple[th.Tensor, th.Tensor]]:
+    ) -> Dict[tuple[str, str, str], tuple[th.Tensor, th.Tensor]]:
         """ Compute scores for positive edges and negative edges.
 
         Parameters

--- a/python/graphstorm/model/edge_decoder.py
+++ b/python/graphstorm/model/edge_decoder.py
@@ -17,7 +17,7 @@
 """
 import abc
 import logging
-from typing import Dict
+from typing import Dict, Union
 
 import numpy as np
 import torch as th
@@ -921,7 +921,7 @@ class LinkPredictionTestScoreInterface(abc.ABC):
         emb: Dict[str, th.Tensor],
         pos_neg_tuple: Dict[tuple[str, str, str], th.Tensor],
         neg_sample_type: str,
-        device: th.device,
+        device: Union[int, th.device],
     ) -> Dict[tuple[str, str, str], tuple[th.Tensor, th.Tensor]]:
         """ Compute scores for positive edges and negative edges.
 

--- a/python/graphstorm/model/edge_decoder.py
+++ b/python/graphstorm/model/edge_decoder.py
@@ -909,7 +909,7 @@ class MLPEFeatEdgeDecoder(MLPEdgeDecoder):
         return out
 
 ##################### Link Prediction Decoders #######################
-class LinkPredictionTestScoreMixin(abc.ABC):
+class LinkPredictionTestScoreInterface(abc.ABC):
     """ Mixin class for link prediction test score computation
     """
 
@@ -960,7 +960,7 @@ class LinkPredictionTestScoreMixin(abc.ABC):
             of {(src_ntype, etype, dst_ntype): (pos_scores, neg_scores)}
         """
 
-class LinkPredictNoParamDecoder(GSLayerNoParam, LinkPredictionTestScoreMixin):
+class LinkPredictNoParamDecoder(GSLayerNoParam, LinkPredictionTestScoreInterface):
     """ Abstract class for Link prediction decoder without trainable parameters
     """
 
@@ -987,7 +987,7 @@ class LinkPredictNoParamDecoder(GSLayerNoParam, LinkPredictionTestScoreMixin):
             in the input graph.
         """
 
-class LinkPredictLearnableDecoder(GSLayer, LinkPredictionTestScoreMixin):
+class LinkPredictLearnableDecoder(GSLayer, LinkPredictionTestScoreInterface):
     """ Abstract class for Link prediction decoder with trainable parameters
     """
 

--- a/python/graphstorm/model/edge_decoder.py
+++ b/python/graphstorm/model/edge_decoder.py
@@ -17,7 +17,7 @@
 """
 import abc
 import logging
-from typing import Dict, Union
+from typing import Dict, Tuple, Union
 
 import numpy as np
 import torch as th
@@ -919,10 +919,10 @@ class LinkPredictionTestScoreInterface(abc.ABC):
     def calc_test_scores(
         self,
         emb: Dict[str, th.Tensor],
-        pos_neg_tuple: Dict[tuple[str, str, str], th.Tensor],
+        pos_neg_tuple: Dict[Tuple[str, str, str], th.Tensor],
         neg_sample_type: str,
         device: Union[int, th.device],
-    ) -> Dict[tuple[str, str, str], tuple[th.Tensor, th.Tensor]]:
+    ) -> Dict[Tuple[str, str, str], Tuple[th.Tensor, th.Tensor]]:
         """ Compute scores for positive edges and negative edges.
 
         Parameters

--- a/python/graphstorm/model/edge_decoder.py
+++ b/python/graphstorm/model/edge_decoder.py
@@ -909,7 +909,58 @@ class MLPEFeatEdgeDecoder(MLPEdgeDecoder):
         return out
 
 ##################### Link Prediction Decoders #######################
-class LinkPredictNoParamDecoder(GSLayerNoParam):
+class LinkPredictionTestScoreMixin(abc.ABC):
+    """ Mixin class for link prediction test score computation
+    """
+
+    @abc.abstractmethod
+    def calc_test_scores(
+        self,
+        emb: dict[str, th.Tensor],
+        pos_neg_tuple: dict[tuple[str, str, str], th.Tensor],
+        neg_sample_type: str,
+        device: th.device,
+    ) -> dict[tuple[str, str, str], tuple[th.Tensor, th.Tensor]]:
+        """ Compute scores for positive edges and negative edges.
+
+        Parameters
+        ----------
+        emb: dict of Tensor
+            Node embeddings in the format of {ntype: emb}.
+        pos_neg_tuple: dict of tuple
+            Positive and negative edges stored in a dict of tuple in the format of
+            {("src_ntype1", "etype1", "dst_ntype1" ): (pos_src_idx, neg_src_idx,
+            pos_dst_idx, neg_dst_idx)}.
+
+            The `pos_src_idx` represents the postive source node indexes in the format
+            of Torch.Tensor. The `neg_src_idx` represents the negative source node indexes
+            in the format of Torch.Tensor. The `pos_dst_idx` represents the postive destination
+            node indexes in the format of Torch.Tensor. The `neg_dst_idx` represents the
+            negative destination node indexes in the format of Torch.Tensor.
+
+            We define positive and negative edges as:
+
+            * The positive edges: (pos_src_idx, pos_dst_idx)
+            * The negative edges: (pos_src_idx, neg_dst_idx) and
+              (neg_src_idx, pos_dst_idx)
+
+        neg_sample_type: str
+            Describe how negative samples are sampled. There are two options:
+
+            * ``Uniform``: For each positive edge, we sample K negative edges.
+            * ``Joint``: For one batch of positive edges, we sample K negative edges.
+
+        device: th.device
+            Device used to compute scores.
+
+        Returns
+        --------
+        scores: dict of tuple
+            Return a dictionary of edge type's positive scores and negative scores in the format
+            of {(src_ntype, etype, dst_ntype): (pos_scores, neg_scores)}
+        """
+
+class LinkPredictNoParamDecoder(GSLayerNoParam, LinkPredictionTestScoreMixin):
     """ Abstract class for Link prediction decoder without trainable parameters
     """
 
@@ -936,7 +987,7 @@ class LinkPredictNoParamDecoder(GSLayerNoParam):
             in the input graph.
         """
 
-class LinkPredictLearnableDecoder(GSLayer):
+class LinkPredictLearnableDecoder(GSLayer, LinkPredictionTestScoreMixin):
     """ Abstract class for Link prediction decoder with trainable parameters
     """
 

--- a/python/graphstorm/model/lp_gnn.py
+++ b/python/graphstorm/model/lp_gnn.py
@@ -17,7 +17,7 @@
 """
 import abc
 from collections import defaultdict
-from typing import Union
+from typing import Dict, Union
 
 import torch as th
 
@@ -184,7 +184,7 @@ def lp_mini_batch_predict(model, emb, loader, device, return_batch_lengths=False
 
 def run_lp_mini_batch_predict(
         decoder,
-        emb: dict[str, th.Tensor],
+        emb: Dict[str, th.Tensor],
         loader: GSgnnEdgeDataLoader,
         device: Union[th.device, int],
         return_batch_lengths=False,
@@ -220,8 +220,8 @@ def run_lp_mini_batch_predict(
             and the corresponding batch lengths for each ranking value.
     """
     with th.no_grad():
-        ranking: dict[tuple, list[th.Tensor]] = defaultdict(list)
-        batch_lengths: dict[tuple, list[th.Tensor]] = defaultdict(list)
+        ranking: Dict[tuple, list[th.Tensor]] = defaultdict(list)
+        batch_lengths: Dict[tuple, list[th.Tensor]] = defaultdict(list)
         assert isinstance(decoder, LinkPredictionTestScoreInterface)
         for pos_neg_tuple, neg_sample_type in loader:
             score = \
@@ -238,8 +238,8 @@ def run_lp_mini_batch_predict(
                     th.tensor([neg_score.shape[1]+1])
                 )
 
-        rankings: dict[tuple, th.Tensor] = {}
-        batch_length_tensors: dict[tuple, th.Tensor] = {}
+        rankings: Dict[tuple, th.Tensor] = {}
+        batch_length_tensors: Dict[tuple, th.Tensor] = {}
         for canonical_etype, rank in ranking.items():
             rankings[canonical_etype] = th.cat(rank, dim=0)
             etype_lengths = batch_lengths[canonical_etype]

--- a/python/graphstorm/model/lp_gnn.py
+++ b/python/graphstorm/model/lp_gnn.py
@@ -22,7 +22,7 @@ import torch as th
 
 from ..dataloading.dataloading import GSgnnEdgeDataLoader
 from .gnn import GSgnnModel, GSgnnModelBase
-from ..model.edge_decoder import LinkPredictionTestScoreMixin
+from ..model.edge_decoder import LinkPredictionTestScoreInterface
 from .utils import normalize_node_embs
 from ..eval.utils import calc_ranking
 
@@ -221,12 +221,11 @@ def run_lp_mini_batch_predict(
     with th.no_grad():
         ranking: dict[tuple, list[th.Tensor]] = defaultdict(list)
         batch_lengths: dict[tuple, list[th.Tensor]] = defaultdict(list)
-        assert isinstance(decoder, LinkPredictionTestScoreMixin)
+        assert isinstance(decoder, LinkPredictionTestScoreInterface)
         for pos_neg_tuple, neg_sample_type in loader:
-            score: dict[tuple, tuple[th.Tensor, th.Tensor]] = \
+            score = \
                 decoder.calc_test_scores(
                     emb, pos_neg_tuple, neg_sample_type, device)
-            print(f"{score=}")
             for canonical_etype, s in score.items():
                 # We do not concatenate rankings into a single
                 # ranking tensor to avoid unnecessary data copy.

--- a/python/graphstorm/model/lp_gnn.py
+++ b/python/graphstorm/model/lp_gnn.py
@@ -222,7 +222,8 @@ def run_lp_mini_batch_predict(
     with th.no_grad():
         ranking: Dict[Tuple, List[th.Tensor]] = defaultdict(list)
         batch_lengths: Dict[Tuple, List[th.Tensor]] = defaultdict(list)
-        assert isinstance(decoder, LinkPredictionTestScoreInterface)
+        assert isinstance(decoder, LinkPredictionTestScoreInterface), \
+            f"The decoder must implement LinkPredictionTestScoreInterface, got {decoder=}"
         for pos_neg_tuple, neg_sample_type in loader:
             score = \
                 decoder.calc_test_scores(

--- a/python/graphstorm/model/lp_gnn.py
+++ b/python/graphstorm/model/lp_gnn.py
@@ -233,13 +233,17 @@ def run_lp_mini_batch_predict(
                 pos_score, neg_score = s
                 assert pos_score.shape[0] == neg_score.shape[0], \
                     "There should be as many negative lists as there are positive examples"
-                ranking[canonical_etype].append(calc_ranking(pos_score, neg_score))
-                # Set the number of candidates for each positive example (neg_score.shape[0])
-                # which will be the number of negatives (neg_score.shape[1])
+                score_ranking = calc_ranking(pos_score, neg_score)
+                ranking[canonical_etype].append(score_ranking)
+                # Set the number of candidates for each positive example
+                # (equal to neg_score.shape[0])
+                # which will be the number of negatives (equal to neg_score.shape[1])
                 # plus one for the positive example
-                batch_lengths[canonical_etype].append(
-                    th.tensor(neg_score.shape[0] * [neg_score.shape[1] + 1])
-                )
+                lengths_tensor = th.tensor(neg_score.shape[0] * [neg_score.shape[1] + 1])
+                # Ensure rankings and lengths are on the same device
+                lengths_tensor = lengths_tensor.to(score_ranking.device)
+
+                batch_lengths[canonical_etype].append(lengths_tensor)
 
         rankings: Dict[Tuple, th.Tensor] = {}
         batch_length_tensors: Dict[Tuple, th.Tensor] = {}

--- a/python/graphstorm/model/lp_gnn.py
+++ b/python/graphstorm/model/lp_gnn.py
@@ -17,6 +17,7 @@
 """
 import abc
 from collections import defaultdict
+from typing import Union
 
 import torch as th
 
@@ -185,7 +186,7 @@ def run_lp_mini_batch_predict(
         decoder,
         emb: dict[str, th.Tensor],
         loader: GSgnnEdgeDataLoader,
-        device: th.device,
+        device: Union[th.device, int],
         return_batch_lengths=False,
     ):
     """ Perform mini-batch link prediction with the given decoder.
@@ -205,7 +206,7 @@ def run_lp_mini_batch_predict(
             The GNN embeddings
         loader : GSgnnEdgeDataLoader
             The GraphStorm dataloader
-        device: th.device
+        device: th.device or int
             Device used to compute test scores
         return_batch_lengths: bool, default False
             Whether to return the candidate list sizes of each ranking value.

--- a/python/graphstorm/run/gsgnn_lp/gsgnn_lp.py
+++ b/python/graphstorm/run/gsgnn_lp/gsgnn_lp.py
@@ -58,8 +58,6 @@ def main(config_args):
                               model_layer_to_load=config.restore_model_layers)
     trainer.setup_device(device=get_device())
     if not config.no_validation:
-        # TODO(zhengda) we need to refactor the evaluator.
-        # Currently, we only support mrr
         evaluator = gs.create_lp_evaluator(config)
         trainer.setup_evaluator(evaluator)
         val_idxs = train_data.get_edge_val_set(config.eval_etype)

--- a/python/graphstorm/trainer/gsgnn_trainer.py
+++ b/python/graphstorm/trainer/gsgnn_trainer.py
@@ -17,7 +17,9 @@
 """
 import os
 import logging
+from typing import Optional
 
+from ..eval.evaluator import GSgnnBaseEvaluator
 from ..model import GSOptimizer
 from ..model import GSgnnModel, GSgnnModelBase
 from ..model.utils import TopKList
@@ -344,7 +346,7 @@ class GSgnnTrainer():
             return True
 
     @property
-    def evaluator(self):
+    def evaluator(self) -> Optional[GSgnnBaseEvaluator]:
         """ The evaluator associated with the trainer.
         """
         return self._evaluator

--- a/python/graphstorm/trainer/lp_trainer.py
+++ b/python/graphstorm/trainer/lp_trainer.py
@@ -374,8 +374,10 @@ class GSgnnLinkPredictionTrainer(GSgnnTrainer):
         else:
             test_rankings, test_lengths = None, None
         sys_tracker.check('after_test_score')
-        assert self.evaluator is not None
-        assert isinstance(self.evaluator, GSgnnLPRankingEvalInterface)
+        assert self.evaluator is not None, \
+            "Evaluator needs to be setup, use trainer.setup_evaluator(evaluator)"
+        assert isinstance(self.evaluator, GSgnnLPRankingEvalInterface), \
+            f"Evaluator needs to implement GSgnnLPRankingEvalInterface, got {type(self.evaluator)}"
         val_score, test_score = self.evaluator.evaluate(
             val_rankings,
             test_rankings,

--- a/python/graphstorm/trainer/lp_trainer.py
+++ b/python/graphstorm/trainer/lp_trainer.py
@@ -22,6 +22,7 @@ import torch as th
 from torch.nn.parallel import DistributedDataParallel
 import dgl
 
+from ..eval.evaluator import GSgnnLPRankingEvalInterface
 from ..model.lp_gnn import GSgnnLinkPredictionModelInterface
 from ..model.lp_gnn import lp_mini_batch_predict
 from ..model.gnn_with_reconstruct import GNNEncoderWithReconstructedEmbed
@@ -96,7 +97,7 @@ class GSgnnLinkPredictionTrainer(GSgnnTrainer):
         This function performs the training for the given link prediction model.
         It iterates over the training batches provided by the ``train_loader``
         to compute the loss, and then performs the backward steps using trainer's
-        own optimizer. 
+        own optimizer.
 
         If an evaluator and a validation dataloader are added to this trainer, during
         training, the trainer will perform model evaluation in three cases:
@@ -122,7 +123,7 @@ class GSgnnLinkPredictionTrainer(GSgnnTrainer):
             save model checkpoints.
             Default: None.
         save_model_frequency: int
-            The number of iterations to train the model before saving a model checkpoint. 
+            The number of iterations to train the model before saving a model checkpoint.
             Default: -1, meaning only save model after each epoch.
         save_perf_results_path: str
             The path of the file where the performance results are saved. Default: None.
@@ -346,7 +347,7 @@ class GSgnnLinkPredictionTrainer(GSgnnTrainer):
         Returns
         -------
         val_score: dict
-            Validation scores of differnet metrics in the format of {metric: val_score}.
+            Validation scores of different metrics in the format of {metric: val_score}.
         """
         test_start = time.time()
         sys_tracker.check('before prediction')
@@ -361,16 +362,27 @@ class GSgnnLinkPredictionTrainer(GSgnnTrainer):
                                           edge_mask=edge_mask_for_gnn_embeddings,
                                           task_tracker=self.task_tracker)
         sys_tracker.check('compute embeddings')
-        val_scores = lp_mini_batch_predict(model, emb, val_loader, self.device) \
-            if val_loader is not None else None
+        if val_loader is not None:
+            val_rankings, val_lengths = lp_mini_batch_predict(
+                model, emb, val_loader, self.device, return_batch_lengths=True)
+        else:
+            val_rankings, val_lengths = None, None
         sys_tracker.check('after_val_score')
         if test_loader is not None:
-            test_scores = lp_mini_batch_predict(model, emb, test_loader, self.device)
+            test_rankings, test_lengths = lp_mini_batch_predict(
+                model, emb, test_loader, self.device, return_batch_lengths=True)
         else:
-            test_scores = None
+            test_rankings, test_lengths = None, None
         sys_tracker.check('after_test_score')
+        assert self.evaluator is not None
+        assert isinstance(self.evaluator, GSgnnLPRankingEvalInterface)
         val_score, test_score = self.evaluator.evaluate(
-            val_scores, test_scores, total_steps)
+            val_rankings,
+            test_rankings,
+            total_steps,
+            val_candidate_sizes=val_lengths,
+            test_candidate_sizes=test_lengths,
+        )
         sys_tracker.check('evaluate validation/test')
         model.train()
 

--- a/tests/end2end-tests/graphstorm-lp/mgpu_test.sh
+++ b/tests/end2end-tests/graphstorm-lp/mgpu_test.sh
@@ -132,8 +132,8 @@ fi
 
 rm /tmp/train_log.txt
 
-echo "**************dataset: Movielens, RGCN layer 2, node feat: fixed HF BERT & sparse embed, BERT nodes: movie, inference: full-graph, negative_sampler: joint, exclude_training_targets: true, save model, eval_metric [hit_at_1 mrr hit_at_10]"
-python3 -m graphstorm.run.gs_link_prediction --workspace $GS_HOME/training_scripts/gsgnn_lp --num-trainers $NUM_TRAINERS --num-servers 1 --num-samplers 0 --part-config /data/movielen_100k_lp_train_val_1p_4t/movie-lens-100k.json --ip-config ip_list.txt --ssh-port 2222 --cf ml_lp.yaml --fanout '10,15' --num-layers 2 --use-mini-batch-infer false  --use-node-embeddings true --eval-batch-size 1024 --exclude-training-targets True --reverse-edge-types-map user,rating,rating-rev,movie  --save-model-path /data/gsgnn_lp_ml_dot/ --topk-model-to-save 1 --save-model-frequency 1000 --save-embed-path /data/gsgnn_lp_ml_dot/emb/ --logging-file /tmp/train_log.txt --logging-level debug --preserve-input True --eval-metric hit_at_1 mrr hit_at_10
+echo "**************dataset: Movielens, RGCN layer 2, node feat: fixed HF BERT & sparse embed, BERT nodes: movie, inference: full-graph, negative_sampler: joint, exclude_training_targets: true, save model, eval_metric [hit_at_1 mrr amri hit_at_10]"
+python3 -m graphstorm.run.gs_link_prediction --workspace $GS_HOME/training_scripts/gsgnn_lp --num-trainers $NUM_TRAINERS --num-servers 1 --num-samplers 0 --part-config /data/movielen_100k_lp_train_val_1p_4t/movie-lens-100k.json --ip-config ip_list.txt --ssh-port 2222 --cf ml_lp.yaml --fanout '10,15' --num-layers 2 --use-mini-batch-infer false  --use-node-embeddings true --eval-batch-size 1024 --exclude-training-targets True --reverse-edge-types-map user,rating,rating-rev,movie  --save-model-path /data/gsgnn_lp_ml_dot/ --topk-model-to-save 1 --save-model-frequency 1000 --save-embed-path /data/gsgnn_lp_ml_dot/emb/ --logging-file /tmp/train_log.txt --logging-level debug --preserve-input True --eval-metric hit_at_1 mrr amri hit_at_10
 
 error_and_exit $?
 
@@ -199,6 +199,20 @@ if test $bst_cnt -lt 1
 then
     echo "We use SageMaker task tracker, we should have Best Validation mrr"
     exit -1
+fi
+
+cnt=$(grep -c "| Test amri" /tmp/train_log.txt)
+if test $cnt -lt 1
+then
+    echo "We use SageMaker task tracker, we should have Test amri"
+    exit 1
+fi
+
+bst_cnt=$(grep -c "Best Validation amri" /tmp/train_log.txt)
+if test $bst_cnt -lt 1
+then
+    echo "We use SageMaker task tracker, we should have Best Validation amri"
+    exit 1
 fi
 
 cnt=$(grep "Validation mrr" /tmp/train_log.txt | wc -l)

--- a/tests/end2end-tests/graphstorm-mt/mgpu_test.sh
+++ b/tests/end2end-tests/graphstorm-mt/mgpu_test.sh
@@ -5,7 +5,6 @@ service ssh restart
 DGL_HOME=/root/dgl
 GS_HOME=$(pwd)
 NUM_TRAINERS=4
-NUM_INFO_TRAINERS=2
 NUM_INFERs=2
 export PYTHONPATH=$GS_HOME/python/
 cd $GS_HOME/training_scripts/gsgnn_mt
@@ -417,11 +416,12 @@ then
     exit -1
 fi
 
-cnt=$(ls -l /data/gsgnn_mt/emb/ | wc -l)
-cnt=$[cnt - 1]
+cnt=$(find /data/gsgnn_mt/emb/ -maxdepth 1 -type d | wc -l)
+cnt=$(($cnt - 1))
 if test $cnt != 2
 then
     echo "The number of saved embs $cnt is not equal to 2 (for movie and user)."
+    exit 1
 fi
 
 echo "**************[Multi-task] dataset: Movielens, RGCN layer 1, node feat: fixed HF BERT, BERT nodes: movie, inference: mini-batch load from saved model and train"

--- a/tests/unit-tests/test_eval_func.py
+++ b/tests/unit-tests/test_eval_func.py
@@ -587,7 +587,7 @@ def test_compute_amri():
     assert_almost_equal(
         actual_amri,
         expected_amri,
-        decimal=4
+        decimal=6
     )
 
     # Compute amri when all lists have the same size

--- a/tests/unit-tests/test_inferrer.py
+++ b/tests/unit-tests/test_inferrer.py
@@ -224,12 +224,13 @@ def test_mtask_infer():
             "n2": None,
         }
 
+    lp_res = np.arange(5)
+    lp_length = np.array([5])
     def mock_func_run_lp_mini_batch_predict(*args, **kwargs):
-        return lp_res
+        return lp_res, lp_length
 
     ntask_res = (np.arange(10), np.arange(10))
     etask_res = (np.arange(20), np.arange(20))
-    lp_res = np.arange(5)
     def mock_func_multi_task_mini_batch_predict(model, emb, dataloaders, task_infos, device, return_proba, return_label):
         assert len(emb) == 2
         res = {}

--- a/tests/unit-tests/test_trainer.py
+++ b/tests/unit-tests/test_trainer.py
@@ -520,9 +520,15 @@ class MTaskCheckerEvaluator(GSgnnMultiTaskEvaluator):
                     assert_equal(tr_2, cr_2)
                 else:
                     # In case LP results also returned candidate list
-                    # lengths, we only keep the rankings
+                    # lengths, we check the lengths and values
                     if isinstance(check_r, tuple):
-                        check_r, _ = check_r
+                        check_r, candidate_sizes = check_r
+                        if candidate_sizes.shape[0] > 1:
+                            assert check_r.shape[0] == candidate_sizes.shape[0], \
+                                ("ranking and candidate_sizes must have the same length, "
+                                f"got {check_r.shape=} {candidate_sizes.shape=}" )
+                            assert th.all(check_r <= candidate_sizes).item(), \
+                                "all ranks must be <= candidate_sizes"
                     assert_equal(target_r, check_r)
 
         if self._val_results is not None:

--- a/tests/unit-tests/test_trainer.py
+++ b/tests/unit-tests/test_trainer.py
@@ -33,7 +33,7 @@ from graphstorm.config import (BUILTIN_TASK_NODE_CLASSIFICATION,
                                 BUILTIN_TASK_RECONSTRUCT_NODE_FEAT,
                                 BUILTIN_TASK_RECONSTRUCT_EDGE_FEAT)
 from graphstorm.dataloading import GSgnnData, GSgnnMultiTaskDataLoader
-from graphstorm.eval.evaluator import GSgnnMultiTaskEvaluator
+from graphstorm.eval.evaluator import GSgnnLPRankingEvalInterface, GSgnnMultiTaskEvaluator
 from graphstorm.tracker import GSSageMakerTaskTracker
 from graphstorm import create_builtin_node_gnn_model
 from graphstorm.trainer import GSgnnTrainer
@@ -48,7 +48,7 @@ from graphstorm.trainer.mt_trainer import (GSgnnMultiTaskLearningTrainer,
 from graphstorm.dataloading import (GSgnnNodeDataLoader,
                                     GSgnnEdgeDataLoader,
                                     GSgnnLinkPredictionDataLoader)
-from graphstorm.model import GSgnnMultiTaskModelInterface, GSgnnModel, GSgnnModelBase
+from graphstorm.model import GSgnnMultiTaskModelInterface, GSgnnModel
 from numpy.testing import assert_equal
 
 from util import (DummyGSgnnEncoderModel,
@@ -499,7 +499,7 @@ def test_mtask_prepare_lp_mini_batch():
     assert_equal(input_nodes["n0"].numpy(), input_node_idx["n0"].numpy())
     assert_equal(input_nodes["n1"].numpy(), input_node_idx["n1"].numpy())
 
-class MTaskCheckerEvaluator(GSgnnMultiTaskEvaluator):
+class MTaskCheckerEvaluator(GSgnnMultiTaskEvaluator, GSgnnLPRankingEvalInterface):
     def __init__(self, val_rankings, test_rankings, total_iters):
         self._val_results = val_rankings
         self._test_results = test_rankings

--- a/tests/unit-tests/test_trainer.py
+++ b/tests/unit-tests/test_trainer.py
@@ -499,13 +499,13 @@ def test_mtask_prepare_lp_mini_batch():
     assert_equal(input_nodes["n0"].numpy(), input_node_idx["n0"].numpy())
     assert_equal(input_nodes["n1"].numpy(), input_node_idx["n1"].numpy())
 
-class MTaskCheckerEvaluator(GSgnnMultiTaskEvaluator, GSgnnLPRankingEvalInterface):
+class MTaskCheckerEvaluator(GSgnnMultiTaskEvaluator):
     def __init__(self, val_rankings, test_rankings, total_iters):
         self._val_results = val_rankings
         self._test_results = test_rankings
         self._steps = total_iters
 
-    def evaluate(self, val_rankings, test_rankings, total_iters, **kwargs):
+    def evaluate(self, val_results, test_results, total_iters, **kwargs):
         assert self._steps == total_iters
         def compare_results(target_res, check_res):
             assert len(target_res) == len(check_res)
@@ -526,14 +526,10 @@ class MTaskCheckerEvaluator(GSgnnMultiTaskEvaluator, GSgnnLPRankingEvalInterface
                     assert_equal(target_r, check_r)
 
         if self._val_results is not None:
-            compare_results(self._val_results, val_rankings)
+            compare_results(self._val_results, val_results)
         if self._test_results is not None:
-            compare_results(self._test_results, test_rankings)
+            compare_results(self._test_results, test_results)
         return None, None
-
-    def compute_score(self, rankings, train=True, candidate_sizes=None):
-        """Dummy implementation to conform to interface"""
-        raise NotImplementedError()
 
     @property
     def task_tracker(self):

--- a/tests/unit-tests/test_trainer.py
+++ b/tests/unit-tests/test_trainer.py
@@ -33,7 +33,7 @@ from graphstorm.config import (BUILTIN_TASK_NODE_CLASSIFICATION,
                                 BUILTIN_TASK_RECONSTRUCT_NODE_FEAT,
                                 BUILTIN_TASK_RECONSTRUCT_EDGE_FEAT)
 from graphstorm.dataloading import GSgnnData, GSgnnMultiTaskDataLoader
-from graphstorm.eval.evaluator import GSgnnLPRankingEvalInterface
+from graphstorm.eval.evaluator import GSgnnMultiTaskEvaluator
 from graphstorm.tracker import GSSageMakerTaskTracker
 from graphstorm import create_builtin_node_gnn_model
 from graphstorm.trainer import GSgnnTrainer
@@ -499,7 +499,7 @@ def test_mtask_prepare_lp_mini_batch():
     assert_equal(input_nodes["n0"].numpy(), input_node_idx["n0"].numpy())
     assert_equal(input_nodes["n1"].numpy(), input_node_idx["n1"].numpy())
 
-class MTaskCheckerEvaluator(GSgnnLPRankingEvalInterface):
+class MTaskCheckerEvaluator(GSgnnMultiTaskEvaluator):
     def __init__(self, val_rankings, test_rankings, total_iters):
         self._val_results = val_rankings
         self._test_results = test_rankings

--- a/tests/unit-tests/test_trainer.py
+++ b/tests/unit-tests/test_trainer.py
@@ -519,6 +519,10 @@ class MTaskCheckerEvaluator(GSgnnMultiTaskEvaluator, GSgnnLPRankingEvalInterface
                     assert_equal(tr_1, cr_1)
                     assert_equal(tr_2, cr_2)
                 else:
+                    # In case LP results also returned candidate list
+                    # lengths, we only keep the rankings
+                    if isinstance(check_r, tuple):
+                        check_r, _ = check_r
                     assert_equal(target_r, check_r)
 
         if self._val_results is not None:


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

* Add Adjust Mean Rank Index LP metric. This metric is normalized by the candidate list size, allowing for easier comparison between datasets/models and negative edge sample counts.
* To get the list sizes we modify `run_lp_mini_batch_predict` and `lp_mini_batch_predict` to _conditionally_ return a tuple of `rankings, lengths` that allows us to calculate AMRI in the cases where it's needed. The return type is determined by a new argument added, with a default value, so the changes are backwards compatible, existing calls to the two functions will function as before.
* Add `LinkPredictionTestScoreInterface` as a common ancestor to `LinkPredictNoParamDecoder` and `LinkPredictLearnableDecoder`, this way we can ensure at runtime that the decoder should implement the `calc_test_scores` function that is used by the LP evaluator.
* Modify the `GSgnnLPRankingEvalInterface` `evaluate` function to add optional `**kwargs`. In cases where we want to calculate a metric that needs the candidate list lengths we use these kwargs to pass the information.
* Modify the `def compute_score(self, rankings, train=True, candidate_sizes=None):` to add the optional `candidate_sizes` argument, this is only used during AMRI calculation.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
