### PR TITLE
[GSProcessing] Replace colons in edge feature paths with underscores to ensure EFS compatibility.

### DIFF
--- a/graphstorm-processing/graphstorm_processing/graph_loaders/dist_heterogeneous_loader.py
+++ b/graphstorm-processing/graphstorm_processing/graph_loaders/dist_heterogeneous_loader.py
@@ -1685,7 +1685,7 @@ class DistHeterogeneousGraphLoader(object):
                         single_feature_df = transformed_feature_df.select(bert_feat_name)
                         feature_output_path = os.path.join(
                             self.output_prefix,
-                            f"edge_data/{edge_type}-{bert_feat_name}",
+                            f"edge_data/{edge_type.replace(':', '_')}-{bert_feat_name}",
                         )
                         feat_meta, feat_size = self._write_processed_feature(
                             bert_feat_name,
@@ -1699,7 +1699,7 @@ class DistHeterogeneousGraphLoader(object):
                         feat_col, feat_name
                     )
                     feature_output_path = os.path.join(
-                        self.output_prefix, f"edge_data/{edge_type}-{feat_name}"
+                        self.output_prefix, f"edge_data/{edge_type.replace(':', '_')}-{feat_name}"
                     )
                     feat_meta, feat_size = self._write_processed_feature(
                         feat_name,


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

* When copying data from S3 to HDFS or EFS we can't use paths that contain colons `:`. We have already fixed this for edge structures and labels, this fixes it for features as well.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
