### PR TITLE
[SageMaker] [GraphBolt] Add support for launching GraphBolt jobs on SageMaker

### DIFF
--- a/.github/workflow_scripts/pytest_check.sh
+++ b/.github/workflow_scripts/pytest_check.sh
@@ -1,9 +1,20 @@
-# Move to parent directory
-cd ../../
-
+#!/bin/env bash
+# Move to repository root
 set -ex
 
-FORCE_CUDA=1 python3 -m pip install -e '.[test]'  --no-build-isolation
+cd ../../
+
+
+GS_HOME=$(pwd)
+# Add SageMaker launch scripts to make the scripts testable
+export PYTHONPATH="${PYTHONPATH}:${GS_HOME}/sagemaker/launch/"
+
 python3 -m pip install pytest
+FORCE_CUDA=1 python3 -m pip install -e '.[test]'  --no-build-isolation
+
+# Run SageMaker tests
+python3 -m pytest -x ./tests/sagemaker-tests -s
+
+# Run main library unit tests (Requires multi-gpu instance)
 sh ./tests/unit-tests/prepare_test_data.sh
 export NCCL_IB_DISABLE=1; export NCCL_SHM_DISABLE=1; NCCL_NET=Socket NCCL_DEBUG=INFO python3 -m pytest -x ./tests/unit-tests -s

--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,9 @@ __pycache__/
 *.py[cod]
 *$py.class
 *.egg-info/
+.pytest_cache
+.mypy_cache
+.ipynb_checkpoints
 
 # used by the container build
 /code
@@ -20,3 +23,8 @@ __pycache__/
 docs/build/
 docs/source/_build
 docs/source/generated
+
+# IDEs and Python venv
+.idea
+.venv
+.vscode

--- a/docker/push_gsf_container.sh
+++ b/docker/push_gsf_container.sh
@@ -5,7 +5,7 @@ set -euox pipefail
 if [ -b "${1-}" ] && [ "$1" == "--help" ] || [ -b "${1-}" ] && [ "$1" == "-h" ]; then
     echo "Usage: docker/push_gsf_container.sh <image-name> <tag> <region> <account>"
     echo "Optionally provide the image name, tag, region and account number for the ecr repository"
-    echo "For example: docker/push_gsf_container.sh graphstorm sm us-west-2 1234567890"
+    echo "For example: docker/push_gsf_container.sh graphstorm sm-gpu us-west-2 1234567890"
     exit 1
 fi
 

--- a/docker/sagemaker/Dockerfile.sm
+++ b/docker/sagemaker/Dockerfile.sm
@@ -20,15 +20,16 @@ FROM branch-${DEVICE} AS final
 
 LABEL maintainer="Amazon AI Graph ML team"
 
-# Install related Python packages
+# Install required Python packages,
+# we set the versions to match those of the base conda environment when possible
 RUN pip3 install \
-        boto3 \
-        numba==0.58.1 \
+        boto3==1.34.112 \
+        numba==0.59.1 \
         numpy==1.26.4 \
         ogb==1.3.6 \
-        pyarrow==18.0.0 \
-        scikit-learn \
-        scipy \
+        pyarrow==16.1.0 \
+        scikit-learn==1.5.0 \
+        scipy==1.13.1 \
         transformers==4.28.1 \
     && rm -rf /root/.cache
 
@@ -56,5 +57,5 @@ ENV PYTHONPATH="/root/dgl/tools/:${PYTHONPATH}"
 
 WORKDIR /opt/ml/code
 
-ENTRYPOINT ["bash", "-m", "start_with_right_hostname.sh"]
+ENTRYPOINT ["bash", "-m", "/usr/local/bin/start_with_right_hostname.sh"]
 CMD ["/bin/bash"]

--- a/docker/sagemaker/Dockerfile.sm
+++ b/docker/sagemaker/Dockerfile.sm
@@ -24,9 +24,9 @@ LABEL maintainer="Amazon AI Graph ML team"
 RUN pip3 install \
         boto3 \
         numba==0.58.1 \
-        numpy==1.26.1 \
+        numpy==1.26.4 \
         ogb==1.3.6 \
-        pyarrow \
+        pyarrow==18.0.0 \
         scikit-learn \
         scipy \
         transformers==4.28.1 \

--- a/docker/sagemaker/Dockerfile.sm
+++ b/docker/sagemaker/Dockerfile.sm
@@ -49,7 +49,7 @@ ENV PYTHONPATH="/opt/ml/code/graphstorm/python/:${PYTHONPATH}"
 RUN cp /opt/ml/code/graphstorm/sagemaker/run/* /opt/ml/code/
 
 # Download DGL source code
-RUN cd /root; git clone --branch v${DGL_VERSION} https://github.com/dmlc/dgl.git
+RUN cd /root; git clone --branch v${DGL_VERSION} --single-branch https://github.com/dmlc/dgl.git
 # Un-comment if we prefer a local DGL distribution
 # COPY dgl /root/dgl
 ENV PYTHONPATH="/root/dgl/tools/:${PYTHONPATH}"

--- a/docker/sagemaker/build_artifacts/start_with_right_hostname.sh
+++ b/docker/sagemaker/build_artifacts/start_with_right_hostname.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -x
 
 if [[ "$1" = "train" ]]; then
      CURRENT_HOST=$(jq .current_host  /opt/ml/input/config/resourceconfig.json)

--- a/docker/sagemaker/build_artifacts/start_with_right_hostname.sh
+++ b/docker/sagemaker/build_artifacts/start_with_right_hostname.sh
@@ -1,12 +1,12 @@
 #!/usr/bin/env bash
-set -x
 
 if [[ "$1" = "train" ]]; then
      CURRENT_HOST=$(jq .current_host  /opt/ml/input/config/resourceconfig.json)
      sed -ie "s/PLACEHOLDER_HOSTNAME/$CURRENT_HOST/g" changehostname.c
      gcc -o changehostname.o -c -fPIC -Wall changehostname.c
      gcc -o libchangehostname.so -shared -export-dynamic changehostname.o -ldl
-     LD_PRELOAD=/libchangehostname.so train
+     CWD=$(pwd)
+     LD_PRELOAD=$CWD/libchangehostname.so train
 else
-     eval "$@"
+     "$@"
 fi

--- a/docs/source/advanced/using-graphbolt.rst
+++ b/docs/source/advanced/using-graphbolt.rst
@@ -186,7 +186,7 @@ the partitioned DGL graph files have been created on S3.
 After running your distributed partition SageMaker job as normal using
 ``sagemaker/launch_partition.py``, you next need to launch the
 ``sagemaker/launch_graphbolt_convert.py`` script, passing as input
-the S3 URI where the DistDGL partition data is stored by ``launch_partition.py``,
+the S3 URI, where the DistDGL partition data is stored by ``launch_partition.py``,
 **plus the suffix `dist_graph`** as that's where GSPartition creates the partition files.
 
 For example, if you used ``--output-data-s3 s3://my-bucket/my-part-graph`` for

--- a/docs/source/advanced/using-graphbolt.rst
+++ b/docs/source/advanced/using-graphbolt.rst
@@ -170,7 +170,15 @@ data using our GraphBolt conversion entry point:
 Using GraphBolt on SageMaker
 ----------------------------
 
-To prepare data to use with GraphBolt on SageMaker
+Before being able to train on SageMaker
+we need to ensure our data on S3 have been
+converted to the GraphBolt format.
+When using GConstruct to process our data
+we can include the GraphBolt data conversion in the GConstruct
+step as we'll show below.
+
+When using distributed graph construction with GSProcessing and GSPartition,
+to prepare data to use with GraphBolt on SageMaker
 we need to launch the GraphBolt data conversion step
 as a separate SageMaker job, after
 the partitioned DGL graph files have been created on S3.
@@ -227,6 +235,7 @@ one you used with GConstruct as shown below:
 
 .. code-block:: bash
 
+    # NOTE: we provide 'my-graph' as the graph name
     sagemaker/launch_gconstruct.py \
         --graph-name my-graph \
         --graph-data-s3 "s3-uri-where-raw-data-exist" \
@@ -234,6 +243,7 @@ one you used with GConstruct as shown below:
         --graph-config-file "gconstruct-config.json" # We don't add --use-graphbolt true
 
     # Once the above job succeeds we run the below to convert the data to GraphBolt
+    # NOTE: Our metadata file name will be named 'my-graph.json'
     sagemaker/launch_graphbolt_convert.py \
         --graph-data-s3 "s3-uri-where-gspartition-data-will-be"
         --metadata-filename "my-graph.json" # Should be <graph-name>.json
@@ -253,7 +263,6 @@ to indicate that we want to use GraphBolt during training/inference:
         --use-graphbolt true
 
 
-Internally we use the unknown arguments mechanism of Python's
-``argparse`` module to forward
-the ``--use-graphbolt`` argument to the downstream job, along
-with other GraphStorm arguments.
+If you want to test steps locally you can use SageMaker's
+[local mode](https://sagemaker.readthedocs.io/en/stable/overview.html#local-mode)
+by providing `local` as the instance type in the launch scripts.

--- a/docs/source/advanced/using-graphbolt.rst
+++ b/docs/source/advanced/using-graphbolt.rst
@@ -178,15 +178,15 @@ the partitioned DGL graph files have been created on S3.
 After running your distributed partition SageMaker job as normal using
 ``sagemaker/launch_partition.py``, you next need to launch the
 ``sagemaker/launch_graphbolt_convert.py`` script, passing as input
-the S3 URI where you created the DistDGL partition data,
-**plus the suffix dist_graph** as that's where GSPartition creates the partition files.
+the S3 URI where the DistDGL partition data is stored by ``launch_partition.py``,
+**plus the suffix `dist_graph`** as that's where GSPartition creates the partition files.
 
 For example, if you used ``--output-data-s3 s3://my-bucket/my-part-graph`` for
 ``sagemaker/launch_partition.py`` you need to use ``--graph-data-s3 s3://my-bucket/my-part-graph/dist_graph``
 for ``sagemaker/launch_graphbolt_convert.py``.
 
-So where before the SageMaker job sequence for distributed processing and training
-was ``GSProcessing -> GSPartition -> GSTraining`` to use GraphBolt we need to add
+Without using GraphBolt a SageMaker job sequence for distributed processing and training
+is ``GSProcessing -> GSPartition -> GSTraining``. To use GraphBolt we need to add
 a step after partitioning and before training:
 ``GSProcessing -> GSPartition -> GraphBoltConvert -> GSTraining``.
 
@@ -198,7 +198,7 @@ a step after partitioning and before training:
         --output-data-s3 "s3-uri-where-gspartition-data-will-be"
         # Add other required parameters like --partition-algorithm, --num-instances etc.
 
-    # Once the above job succeeds we run the below to convert the data to GraphBolt.
+    # Once the above job succeeds we run the following command to convert the data to GraphBolt format.
     # Note the /dist_graph suffix!
     sagemaker/launch_graphbolt_convert.py \
         --graph-data-s3 "s3-uri-where-gspartition-data-will-be/dist_graph" \
@@ -222,7 +222,7 @@ So the job sequence there remains ``GConstruct -> GSTraining``.
 If you initially used GConstruct to create the non-GraphBolt DistDGL files,
 you'll need to pass in the additional argument ``--metadata-filename``
 to ``launch_graphbolt_convert.py``.
-Use ``<graph-name>.json`` where the graph name should correspond to the
+Use ``<graph-name>.json`` where the graph name should be the
 one you used with GConstruct as shown below:
 
 .. code-block:: bash

--- a/python/graphstorm/gpartition/convert_to_graphbolt.py
+++ b/python/graphstorm/gpartition/convert_to_graphbolt.py
@@ -67,6 +67,11 @@ def run_gb_conversion(part_config: str, njobs=1):
     """
     dgl_version = importlib.metadata.version("dgl")
     if version.parse(dgl_version) < version.parse("2.4.0"):
+        if njobs > 1:
+            logging.warning(
+                "GB conversion njobs > 1 is only supported for DGL >= 2.4.0. "
+                "njobs will be set to 1."
+            )
         dgl_distributed.dgl_partition_to_graphbolt(
             part_config,
             store_eids=True,

--- a/python/graphstorm/gpartition/convert_to_graphbolt.py
+++ b/python/graphstorm/gpartition/convert_to_graphbolt.py
@@ -27,24 +27,67 @@ from packaging import version
 
 def parse_gbconv_args() -> argparse.Namespace:
     """Parses GraphBolt conversion arguments"""
-    parser = argparse.ArgumentParser("Convert partitioned DGL graph to GraphBolt format.")
-    parser.add_argument("--metadata-filepath", type=str, required=True,
-                           help="File path to the partitioned DGL metadata file.")
-    parser.add_argument("--logging-level", type=str, default="info",
-                           help="The logging level. The possible values: debug, info, warning, \
-                                   error. The default value is info.")
+    parser = argparse.ArgumentParser(
+        "Convert partitioned DGL graph to GraphBolt format."
+    )
+    parser.add_argument(
+        "--metadata-filepath",
+        type=str,
+        required=True,
+        help="File path to the partitioned DGL metadata file.",
+    )
+    parser.add_argument(
+        "--logging-level",
+        type=str,
+        default="info",
+        help="The logging level. The possible values: debug, info, warning, "
+        "error. The default value is info.",
+    )
+    parser.add_argument(
+        "--njobs",
+        type=int,
+        default=1,
+        help="Number of parallel processes to use for GraphBolt partition conversion. "
+        "Only applies for DGL >= v2.4.0.",
+    )
 
     return parser.parse_args()
 
 
-def main():
-    """ Entry point
+def run_gb_conversion(part_config: str, njobs=1):
+    """Converts the DistGraph data under the given part_config to GraphBolt
+
+    Parameters
+    ----------
+    part_config : str
+        File path to the partitioned data metadata JSON file
+    njobs : int, optional
+        Number of partitions to convert in parallel, by default 1.
+        Only applies if DGL >= 2.4.0.
     """
-    dgl_version = importlib.metadata.version('dgl')
+    dgl_version = importlib.metadata.version("dgl")
+    if version.parse(dgl_version) < version.parse("2.4.0"):
+        dgl_distributed.dgl_partition_to_graphbolt(
+            part_config,
+            store_eids=True,
+            graph_formats="coo",
+        )
+    else:
+        dgl_distributed.dgl_partition_to_graphbolt(  # pylint: disable=unexpected-keyword-arg
+            part_config,
+            store_eids=True,
+            graph_formats="coo",
+            njobs=njobs,
+        )
+
+
+def main():
+    """Entry point"""
+    dgl_version = importlib.metadata.version("dgl")
     if version.parse(dgl_version) < version.parse("2.1.0"):
         raise ValueError(
-                "GraphBolt conversion requires DGL version >= 2.1.0, "
-                f"but DGL version was {dgl_version}. "
+            "GraphBolt conversion requires DGL version >= 2.1.0, "
+            f"but DGL version was {dgl_version}. "
         )
 
     gb_conv_args = parse_gbconv_args()
@@ -59,14 +102,10 @@ def main():
     gb_start = time.time()
     logging.info("Converting partitions to GraphBolt format")
 
-    dgl_distributed.dgl_partition_to_graphbolt(
-            part_config,
-            store_eids=True,
-            graph_formats="coo",
-        )
+    run_gb_conversion(part_config, njobs=gb_conv_args.njobs)
 
-    logging.info("GraphBolt conversion took %f sec.",
-                    time.time() - gb_start)
+    logging.info("GraphBolt conversion took %f sec.", time.time() - gb_start)
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     main()

--- a/python/graphstorm/sagemaker/utils.py
+++ b/python/graphstorm/sagemaker/utils.py
@@ -280,6 +280,9 @@ def download_graph(graph_data_s3, graph_name, part_id, world_size,
                 # Something else has gone wrong.
                 raise err
 
+    assert graph_config, \
+        (f"Could not find a graph config file named {graph_name}.json or metadata.json "
+         f"under {graph_data_s3}")
     S3Downloader.download(os.path.join(graph_data_s3, graph_config),
             graph_path, sagemaker_session=sagemaker_session)
     try:

--- a/sagemaker/launch/common_parser.py
+++ b/sagemaker/launch/common_parser.py
@@ -95,7 +95,7 @@ def parse_unknown_gs_args(unknown_args: List[str]) -> Dict[str, str]:
 
     The input is a list of arguments, the second element of the tuple
     returned by ``argparse.ArgumentParser.parse_known_args()``, which
-    can be a single string depending on how the arguments were passed.
+    can be a single string depending on how the arguments are passed.
 
     We must handle cases like
         ``--target-etype query,clicks,asin query,search,asin``

--- a/sagemaker/launch/common_parser.py
+++ b/sagemaker/launch/common_parser.py
@@ -91,8 +91,8 @@ def parse_estimator_kwargs(arg_string: str) -> Dict[str, Any]:
     return typed_args_dict
 
 def parse_unknown_gs_args(unknown_args: List[str]) -> Dict[str, str]:
-    """
-    Parses unknown arguments for GraphStorm tasks.
+    """Parses unknown arguments for GraphStorm tasks.
+
     The input is a list of arguments, the second element of the tuple
     returned by ``argparse.ArgumentParser.parse_known_args()``.
 
@@ -100,9 +100,15 @@ def parse_unknown_gs_args(unknown_args: List[str]) -> Dict[str, str]:
         ``--target-etype query,clicks,asin query,search,asin``
         ``--feat-name ntype0:feat0 ntype1:feat1``
 
+    Parameters
+    ----------
+    unknown_args : List[str]
+        List of unknown arguments.
 
-    :param unknown_args: List of unknown arguments.
-    :return: Dictionary of parsed arguments.
+    Returns
+    -------
+    Dict[str, str]
+        Dictionary of parsed arguments {'arg_name': 'arg_value'}
     """
     unknown_args_dict = {}
     current_arg_name = None

--- a/sagemaker/launch/common_parser.py
+++ b/sagemaker/launch/common_parser.py
@@ -94,11 +94,13 @@ def parse_unknown_gs_args(unknown_args: List[str]) -> Dict[str, str]:
     """Parses unknown arguments for GraphStorm tasks.
 
     The input is a list of arguments, the second element of the tuple
-    returned by ``argparse.ArgumentParser.parse_known_args()``.
+    returned by ``argparse.ArgumentParser.parse_known_args()``, which
+    can be a single string depending on how the arguments were passed.
 
     We must handle cases like
         ``--target-etype query,clicks,asin query,search,asin``
         ``--feat-name ntype0:feat0 ntype1:feat1``
+        ``'--feat-name ntype0:feat0 --num-epochs 2'`` (note the quotes)
 
     Parameters
     ----------
@@ -112,6 +114,10 @@ def parse_unknown_gs_args(unknown_args: List[str]) -> Dict[str, str]:
     """
     unknown_args_dict = {}
     current_arg_name = None
+
+    # Handle case where all args were parsed as a single string
+    if len(unknown_args) == 1 and unknown_args[0].count("--") > 1:
+        unknown_args = unknown_args[0].split()
 
     for arg in unknown_args:
         # We have the name of the argument

--- a/sagemaker/launch/common_parser.py
+++ b/sagemaker/launch/common_parser.py
@@ -1,7 +1,7 @@
 """
 Common parsers for all launcher scripts.
 """
-from typing import Any, Dict
+from typing import Any, Dict, List
 from ast import literal_eval
 import argparse
 
@@ -89,3 +89,35 @@ def parse_estimator_kwargs(arg_string: str) -> Dict[str, Any]:
         typed_args_dict[k] = literal_eval(v)
 
     return typed_args_dict
+
+def parse_unknown_gs_args(unknown_args: List[str]) -> Dict[str, str]:
+    """
+    Parses unknown arguments for GraphStorm tasks.
+    The input is a list of arguments, the second element of the tuple
+    returned by ``argparse.ArgumentParser.parse_known_args()``.
+
+    We must handle cases like
+        ``--target-etype query,clicks,asin query,search,asin``
+        ``--feat-name ntype0:feat0 ntype1:feat1``
+
+
+    :param unknown_args: List of unknown arguments.
+    :return: Dictionary of parsed arguments.
+    """
+    unknown_args_dict = {}
+    current_arg_name = None
+
+    for arg in unknown_args:
+        # We have the name of the argument
+        if arg.startswith("--"):
+            current_arg_name = arg[2:]
+            # The default value of the dict will be the empty string
+            unknown_args_dict[current_arg_name] = ""
+        # We are parsing the values for the current arg
+        elif current_arg_name is not None:
+            # If we already started parsing current arg's values,
+            # append the new value to the existing, otherwise initialize it
+            arg_value = f" {arg}" if unknown_args_dict[current_arg_name] else arg
+            unknown_args_dict[current_arg_name] += arg_value
+
+    return unknown_args_dict

--- a/sagemaker/launch/common_parser.py
+++ b/sagemaker/launch/common_parser.py
@@ -38,7 +38,7 @@ def get_common_parser() -> argparse.ArgumentParser:
 
     common_args = parser.add_argument_group("Common arguments")
 
-    common_args.add_argument("--graph-data-s3", type=str,
+    common_args.add_argument("--graph-data-s3", "--input-graph-s3", type=str,
         help="S3 location of input graph data", required=True)
     common_args.add_argument("--image-url", type=str,
         help="GraphStorm SageMaker docker image URI",
@@ -49,7 +49,7 @@ def get_common_parser() -> argparse.ArgumentParser:
     common_args.add_argument("--instance-type", type=str,
         help="instance type for the SageMaker job")
     common_args.add_argument("--instance-count", type=int,
-        default=2,
+        default=1,
         help="number of instances")
     common_args.add_argument("--region", type=str,
         default="us-west-2",

--- a/sagemaker/launch/common_parser.py
+++ b/sagemaker/launch/common_parser.py
@@ -116,7 +116,7 @@ def parse_unknown_gs_args(unknown_args: List[str]) -> Dict[str, str]:
     current_arg_name = None
 
     # Handle case where all args were parsed as a single string
-    if len(unknown_args) == 1 and unknown_args[0].count("--") > 1:
+    if len(unknown_args) == 1 and unknown_args[0].count("--") >= 1:
         unknown_args = unknown_args[0].split()
 
     for arg in unknown_args:

--- a/sagemaker/launch/launch_gconstruct.py
+++ b/sagemaker/launch/launch_gconstruct.py
@@ -39,12 +39,11 @@ def run_job(input_args, image, unknownargs):
     unknownargs: dict
         GraphStorm graph construction parameters
     """
-    sm_task_name = input_args.task_name # SageMaker task name
     role = input_args.role # SageMaker ARN role
     instance_type = input_args.instance_type # SageMaker instance type
     region = input_args.region # AWS region
     entry_point = input_args.entry_point # GraphStorm gconstruct entry_point
-    input_graph_s3 = input_args.input_graph_s3
+    input_graph_s3 = input_args.graph_data_s3
     output_graph_s3 = input_args.output_graph_s3
     graph_name = input_args.graph_name # Inference graph name
     graph_config_file = input_args.graph_config_file # graph config file
@@ -105,9 +104,7 @@ def get_gconstruct_parser():
 
     gconstruct_arguments = parser.add_argument_group("GraphStorm Gconstruct arguments")
 
-    gconstruct_arguments.add_argument("--input-graph-s3", type=str,
-        required=True, help="S3 location of the input graph data")
-    gconstruct_arguments.add_argument("--output-graph-s3", type=str,
+    gconstruct_arguments.add_argument("--output-graph-s3", "--output-data-s3", type=str,
         required=True, help="S3 location to store the constructed graph")
     gconstruct_arguments.add_argument("--entry-point", type=str,
         default="graphstorm/sagemaker/run/gconstruct_entry.py",
@@ -124,7 +121,8 @@ def get_gconstruct_parser():
 if __name__ == "__main__":
     arg_parser = get_gconstruct_parser()
     args, unknownargs = arg_parser.parse_known_args()
-    print(args)
+    print(f"known args: {args}")
+    print(f"unknown args: {unknownargs}")
 
     gconstruct_image = args.image_url
 

--- a/sagemaker/launch/launch_graphbolt_convert.py
+++ b/sagemaker/launch/launch_graphbolt_convert.py
@@ -1,23 +1,43 @@
-""" Launch SageMaker training task
 """
+    Copyright Contributors
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+    Launch SageMaker GraphBolt conversion step
+"""
+
 import logging
 import os
+from pprint import pformat
 from time import strftime, gmtime
 
-import boto3 # pylint: disable=import-error
+import boto3  # pylint: disable=import-error
 import sagemaker
 from sagemaker.processing import ScriptProcessor
 from sagemaker.workflow.steps import ProcessingInput
 
-from common_parser import ( # pylint: disable=wrong-import-order
-    get_common_parser, parse_estimator_kwargs)
+from common_parser import (  # pylint: disable=wrong-import-order
+    get_common_parser,
+    parse_estimator_kwargs,
+)
 
 INSTANCE_TYPE = "ml.m5.12xlarge"
 
 SCRIPT_PATH = os.path.dirname(os.path.realpath(__file__))
 
+
 def run_gbconvert_job(input_args, image):
-    """ Run job using SageMaker estimator.PyTorch
+    """Run job using SageMaker estimator.PyTorch
 
         TODO: We may need to simplify the argument list. We can use a config object.
 
@@ -28,21 +48,24 @@ def run_gbconvert_job(input_args, image):
     image: str
         ECR image uri
     """
-    timestamp = strftime("%Y-%m-%d-%H-%M-%S", gmtime())
     # SageMaker base job name
-    sm_task_name = input_args.task_name if input_args.task_name else timestamp
-    role = input_args.role # SageMaker ARN role
-    instance_type = input_args.instance_type # SageMaker instance type
-    region = input_args.region # AWS region
-    graph_data_s3 = input_args.graph_data_s3 # S3 location storing input graph data (unpartitioned)
-    graph_data_s3 = graph_data_s3[:-1] if graph_data_s3[-1] == '/' \
-        else graph_data_s3 # The input will be an S3 prefix without trailing /
+    sm_task_name = input_args.task_name if input_args.task_name else "gs-gb-convert"
+    role = input_args.role  # SageMaker ARN role
+    instance_type = input_args.instance_type  # SageMaker instance type
+    region = input_args.region  # AWS region
+    graph_data_s3 = (
+        input_args.graph_data_s3
+    )  # S3 location storing input graph data (unpartitioned)
+    graph_data_s3 = (
+        graph_data_s3[:-1] if graph_data_s3[-1] == "/" else graph_data_s3
+    )  # The input will be an S3 prefix without trailing /
 
     sagemaker_session = sagemaker.Session(boto3.Session(region_name=region))
 
-    print(f"Parameters {input_args}")
+    logging.info("Parameters %s", pformat(input_args))
     if input_args.sm_estimator_parameters:
-        print(f"SageMaker Estimator parameters: '{input_args.sm_estimator_parameters}'")
+        logging.info("SageMaker Estimator parameters: '%s'",
+                     input_args.sm_estimator_parameters)
 
     estimator_kwargs = parse_estimator_kwargs(input_args.sm_estimator_parameters)
 
@@ -52,12 +75,14 @@ def run_gbconvert_job(input_args, image):
         instance_count=1,
         instance_type=instance_type,
         command=["python3"],
-        base_job_name=f"gs-gb-convert-{sm_task_name}",
+        base_job_name=sm_task_name,
         sagemaker_session=sagemaker_session,
-        tags=[{"Key":"GraphStorm", "Value":"beta"},
-            {"Key":"GraphStorm_Task", "Value":"GraphBoltConvert"}],
+        tags=[
+            {"Key": "GraphStorm", "Value": "beta"},
+            {"Key": "GraphStorm_Task", "Value": "GraphBoltConvert"},
+        ],
         env={"AWS_REGION": region},
-        **estimator_kwargs
+        **estimator_kwargs,
     )
 
     # The partition data will be download to this path on the instance
@@ -69,18 +94,23 @@ def run_gbconvert_job(input_args, image):
     # in-place and we can't write to the location where S3 files are loaded
     gb_convert_processor.run(
         code=input_args.entry_point,
-        inputs=[ProcessingInput(
-            input_name="dist_graph_s3_input",
-            destination=local_dist_part_path,
-            source=graph_data_s3,
-            s3_input_mode="File",
-        )],
+        inputs=[
+            ProcessingInput(
+                input_name="dist_graph_s3_input",
+                destination=local_dist_part_path,
+                source=graph_data_s3,
+                s3_input_mode="File",
+            )
+        ],
         arguments=[
-            "--njobs", str(input_args.gb_convert_njobs),
-            "--metadata-filename", input_args.metadata_filename,
+            "--njobs",
+            str(input_args.gb_convert_njobs),
+            "--metadata-filename",
+            input_args.metadata_filename,
         ],
         wait=not input_args.async_execution,
     )
+
 
 def get_partition_parser():
     """
@@ -90,22 +120,37 @@ def get_partition_parser():
 
     partition_args = parser.add_argument_group("GraphStorm Partition Arguments")
 
-    partition_args.add_argument("--entry-point", type=str,
+    partition_args.add_argument(
+        "--entry-point",
+        type=str,
         default="run/gb_convert_entry.py",
-        help="PATH-TO graphstorm/sagemaker/run/gb_convert_entry.py")
+        help="PATH-TO graphstorm/sagemaker/run/gb_convert_entry.py",
+    )
 
-    partition_args.add_argument("--gb-convert-njobs", type=int, default=1,
-        help="Number of parallel processes to use for GraphBolt partition conversion.")
+    partition_args.add_argument(
+        "--gb-convert-njobs",
+        type=int,
+        default=1,
+        help="Number of parallel processes to use for GraphBolt partition conversion.",
+    )
 
-    partition_args.add_argument("--metadata-filename", type=str, default="metadata.json",
+    partition_args.add_argument(
+        "--metadata-filename",
+        type=str,
+        default="metadata.json",
         help="Partition metadata file name. Default: 'metadata.json'. If GConstruct was "
-            "used should be set to <graph-name>.json")
+        "used should be set to <graph-name>.json",
+    )
 
-
-    partition_args.add_argument('--log-level', default='INFO',
-        type=str, choices=['DEBUG', 'INFO', 'WARNING', 'CRITICAL', 'FATAL'])
+    partition_args.add_argument(
+        "--log-level",
+        default="INFO",
+        type=str,
+        choices=["DEBUG", "INFO", "WARNING", "CRITICAL", "FATAL"],
+    )
 
     return parser.parse_args()
+
 
 if __name__ == "__main__":
     args = get_partition_parser()
@@ -114,8 +159,8 @@ if __name__ == "__main__":
     # NOTE: Ensure no logging has been done before setting logging configuration
     logging.basicConfig(
         level=getattr(logging, args.log_level.upper(), None),
-        format='%(asctime)s - %(levelname)s - %(message)s'
-        )
+        format="%(asctime)s - %(levelname)s - %(message)s",
+    )
 
     partition_image = args.image_url
     if not args.instance_type:

--- a/sagemaker/launch/launch_graphbolt_convert.py
+++ b/sagemaker/launch/launch_graphbolt_convert.py
@@ -92,7 +92,7 @@ def get_partition_parser():
 
     partition_args.add_argument("--entry-point", type=str,
         default="run/gb_convert_entry.py",
-        help="PATH-TO graphstorm/sagemaker/run/partition_entry.py")
+        help="PATH-TO graphstorm/sagemaker/run/gb_convert_entry.py")
 
     partition_args.add_argument("--gb-convert-njobs", type=int, default=1,
         help="Number of parallel processes to use for GraphBolt partition conversion.")

--- a/sagemaker/launch/launch_graphbolt_convert.py
+++ b/sagemaker/launch/launch_graphbolt_convert.py
@@ -1,0 +1,124 @@
+""" Launch SageMaker training task
+"""
+import logging
+import os
+from time import strftime, gmtime
+
+import boto3 # pylint: disable=import-error
+import sagemaker
+from sagemaker.processing import ScriptProcessor
+from sagemaker.workflow.steps import ProcessingInput
+
+from common_parser import ( # pylint: disable=wrong-import-order
+    get_common_parser, parse_estimator_kwargs)
+
+INSTANCE_TYPE = "ml.m5.12xlarge"
+
+SCRIPT_PATH = os.path.dirname(os.path.realpath(__file__))
+
+def run_gbconvert_job(input_args, image):
+    """ Run job using SageMaker estimator.PyTorch
+
+        TODO: We may need to simplify the argument list. We can use a config object.
+
+    Parameters
+    ----------
+    input_args:
+        Input arguments
+    image: str
+        ECR image uri
+    """
+    timestamp = strftime("%Y-%m-%d-%H-%M-%S", gmtime())
+    # SageMaker base job name
+    sm_task_name = input_args.task_name if input_args.task_name else timestamp
+    role = input_args.role # SageMaker ARN role
+    instance_type = input_args.instance_type # SageMaker instance type
+    region = input_args.region # AWS region
+    graph_data_s3 = input_args.graph_data_s3 # S3 location storing input graph data (unpartitioned)
+    graph_data_s3 = graph_data_s3[:-1] if graph_data_s3[-1] == '/' \
+        else graph_data_s3 # The input will be an S3 prefix without trailing /
+
+    sagemaker_session = sagemaker.Session(boto3.Session(region_name=region))
+
+    print(f"Parameters {input_args}")
+    if input_args.sm_estimator_parameters:
+        print(f"SageMaker Estimator parameters: '{input_args.sm_estimator_parameters}'")
+
+    estimator_kwargs = parse_estimator_kwargs(input_args.sm_estimator_parameters)
+
+    gb_convert_processor = ScriptProcessor(
+        image_uri=image,
+        role=role,
+        instance_count=1,
+        instance_type=instance_type,
+        command=["python3"],
+        base_job_name=f"gs-gb-convert-{sm_task_name}",
+        sagemaker_session=sagemaker_session,
+        tags=[{"Key":"GraphStorm", "Value":"beta"},
+            {"Key":"GraphStorm_Task", "Value":"GraphBoltConvert"}],
+        env={"AWS_REGION": region},
+        **estimator_kwargs
+    )
+
+    # The partition data will be download to this path on the instance
+    local_dist_part_path = "/opt/ml/processing/dist_graph/"
+
+    logging.info("Using source data %s", graph_data_s3)
+
+    # TODO: We'd like to use FastFile here, but DGL makes the data conversion
+    # in-place and we can't write to the location where S3 files are loaded
+    gb_convert_processor.run(
+        code=input_args.entry_point,
+        inputs=[ProcessingInput(
+            input_name="dist_graph_s3_input",
+            destination=local_dist_part_path,
+            source=graph_data_s3,
+            s3_input_mode="File",
+        )],
+        arguments=[
+            "--njobs", str(input_args.gb_convert_njobs),
+            "--metadata-filename", input_args.metadata_filename,
+        ],
+        wait=not input_args.async_execution,
+    )
+
+def get_partition_parser():
+    """
+    Get GraphStorm partition task parser.
+    """
+    parser = get_common_parser()
+
+    partition_args = parser.add_argument_group("GraphStorm Partition Arguments")
+
+    partition_args.add_argument("--entry-point", type=str,
+        default="run/gb_convert_entry.py",
+        help="PATH-TO graphstorm/sagemaker/run/partition_entry.py")
+
+    partition_args.add_argument("--gb-convert-njobs", type=int, default=1,
+        help="Number of parallel processes to use for GraphBolt partition conversion.")
+
+    partition_args.add_argument("--metadata-filename", type=str, default="metadata.json",
+        help="Partition metadata file name. Default: 'metadata.json'. If GConstruct was "
+            "used should be set to <graph-name>.json")
+
+
+    partition_args.add_argument('--log-level', default='INFO',
+        type=str, choices=['DEBUG', 'INFO', 'WARNING', 'CRITICAL', 'FATAL'])
+
+    return parser.parse_args()
+
+if __name__ == "__main__":
+    args = get_partition_parser()
+    print(args)
+
+    # NOTE: Ensure no logging has been done before setting logging configuration
+    logging.basicConfig(
+        level=getattr(logging, args.log_level.upper(), None),
+        format='%(asctime)s - %(levelname)s - %(message)s'
+        )
+
+    partition_image = args.image_url
+    if not args.instance_type:
+        args.instance_type = INSTANCE_TYPE
+
+    run_gbconvert_job(args, partition_image)

--- a/sagemaker/launch/launch_infer.py
+++ b/sagemaker/launch/launch_infer.py
@@ -77,7 +77,8 @@ def run_job(input_args, image, unknownargs):
         "output-chunk-size": output_chunk_size,
         "output-emb-s3": output_emb_s3_path,
         "task-type": task_type,
-        "log-level": log_level
+        "log-level": log_level,
+        "use-graphbolt": input_args.use_graphbolt,
     }
     # In Link Prediction, no prediction outputs
     if task_type not in ["link_prediction", "compute_emb"]:

--- a/sagemaker/launch/launch_partition.py
+++ b/sagemaker/launch/launch_partition.py
@@ -1,14 +1,11 @@
 """ Launch SageMaker training task
 """
 import logging
-import os
 from time import strftime, gmtime
 
 import boto3 # pylint: disable=import-error
 from sagemaker.processing import ScriptProcessor
-from sagemaker.workflow.pipeline import Pipeline, PipelineDefinitionConfig
-from sagemaker.workflow.pipeline_context import PipelineSession
-from sagemaker.workflow.steps import ProcessingStep, ProcessingInput
+import sagemaker
 
 from common_parser import ( # pylint: disable=wrong-import-order
     get_common_parser, parse_estimator_kwargs)
@@ -39,12 +36,12 @@ def run_job(input_args, image):
     graph_data_s3 = input_args.graph_data_s3 # S3 location storing input graph data (unpartitioned)
     graph_data_s3 = graph_data_s3[:-1] if graph_data_s3[-1] == '/' \
         else graph_data_s3 # The input will be an S3 folder
-    # S3 location storing partitioned graph data
-    output_data_s3 = input_args.output_data_s3[:-1] if input_args.output_data_s3[-1] == '/' \
-        else input_args.output_data_s3 # The output will be an S3 prefix
+    output_data_s3 = input_args.output_data_s3 # S3 location storing partitioned graph data
+    output_data_s3 = output_data_s3[:-1] if output_data_s3[-1] == '/' \
+        else output_data_s3 # The output will be an S3 folder
     metadata_filename = input_args.metadata_filename # graph metadata filename
 
-    pipeline_session = PipelineSession(boto3.Session(region_name=region))
+    sagemaker_session = sagemaker.Session(boto3.Session(region_name=region))
 
     skip_partitioning_str = "true" if input_args.skip_partitioning else "false"
     arguments = [
@@ -58,91 +55,32 @@ def run_job(input_args, image):
     ]
     arguments = [str(x) for x in arguments]
 
-    print(f"Parameters {input_args}")
+    print(f"Parameters {arguments}")
     if input_args.sm_estimator_parameters:
         print(f"SageMaker Estimator parameters: '{input_args.sm_estimator_parameters}'")
 
     estimator_kwargs = parse_estimator_kwargs(input_args.sm_estimator_parameters)
 
-    dist_part_processor = ScriptProcessor(
+    script_processor = ScriptProcessor(
         image_uri=image,
         role=role,
         instance_count=instance_count,
         instance_type=instance_type,
         command=["python3"],
         base_job_name=f"gs-partition-{sm_task_name}",
-        sagemaker_session=pipeline_session,
+        sagemaker_session=sagemaker_session,
         tags=[{"Key":"GraphStorm", "Value":"beta"},
               {"Key":"GraphStorm_Task", "Value":"Partition"}],
         **estimator_kwargs
     )
 
-    dist_part_step = ProcessingStep(
-        name=f"gs-partition-{sm_task_name}",
-        processor=dist_part_processor,
-        job_arguments=arguments,
+    script_processor.run(
         code=entry_point,
+        arguments=arguments,
+        inputs=[],
+        outputs=[],
+        wait=not input_args.async_execution
     )
-
-    pipeline_steps = [dist_part_step]
-
-    if input_args.use_graphbolt.lower() == "true":
-        gb_convert_processor = ScriptProcessor(
-            image_uri=image,
-            role=role,
-            instance_count=1,
-            instance_type=instance_type,
-            command=["python3"],
-            base_job_name=f"gs-gb-convert-{sm_task_name}",
-            sagemaker_session=pipeline_session,
-            tags=[{"Key":"GraphStorm", "Value":"beta"},
-                {"Key":"GraphStorm_Task", "Value":"GraphBoltConvert"}],
-            **estimator_kwargs
-        )
-
-        local_dist_part_path = "/opt/ml/processing/dist_graph/"
-
-        # TODO: We'd like to use FastFile here, but DGL makes the data conversion
-        # in-place and we can't write to the location where S3 files are loaded
-        gb_convert_step = ProcessingStep(
-            name=f"gs-gb-convert-{sm_task_name}",
-            processor=gb_convert_processor,
-            job_arguments=["--njobs", str(input_args.gb_convert_njobs)],
-            code="run/gb_convert_entry.py",
-            inputs=[ProcessingInput(
-                input_name="dist_graph_s3_input",
-                destination=local_dist_part_path,
-                source=os.path.join(output_data_s3, "dist_graph/"),
-                s3_input_mode="File",
-            )],
-            depends_on=[dist_part_step],
-        )
-
-        pipeline_steps.append(gb_convert_step)
-
-    pipeline_definition_config = PipelineDefinitionConfig(
-        use_custom_job_prefix=False,
-    )
-
-    pipeline = Pipeline(
-        name="MyPipeline",
-        steps=pipeline_steps,
-        sagemaker_session=pipeline_session,
-        pipeline_definition_config=pipeline_definition_config,
-    )
-
-    pipeline.create(
-        role_arn=role,
-        description="GraphStorm DistPartition"
-    )
-
-    execution = pipeline.start()
-
-    print(execution.describe())
-
-    # if not input_args.async_execution:
-    #     execution.wait()
-
 
 def get_partition_parser():
     """
@@ -172,14 +110,6 @@ def get_partition_parser():
     partition_args.add_argument("--skip-partitioning", action='store_true',
         help="When set, we skip the partitioning step. "
              "Partition assignments for all node types need to exist on S3.")
-    partition_args.add_argument("--gb-convert-njobs", type=int, default=1,
-        help="Number of parallel processes to use for GraphBolt partition conversion.")
-    partition_args.add_argument(
-        "--use-graphbolt", type=str, choices=["true", "false"],
-        default="false",
-        help=("Whether to convert the partitioned data to the GraphBolt format "
-            "after creating the DistDGL graph."))
-
 
     partition_args.add_argument('--log-level', default='INFO',
         type=str, choices=['DEBUG', 'INFO', 'WARNING', 'CRITICAL', 'FATAL'])

--- a/sagemaker/launch/launch_partition.py
+++ b/sagemaker/launch/launch_partition.py
@@ -1,11 +1,14 @@
 """ Launch SageMaker training task
 """
 import logging
+import os
 from time import strftime, gmtime
 
 import boto3 # pylint: disable=import-error
 from sagemaker.processing import ScriptProcessor
-import sagemaker
+from sagemaker.workflow.pipeline import Pipeline, PipelineDefinitionConfig
+from sagemaker.workflow.pipeline_context import PipelineSession
+from sagemaker.workflow.steps import ProcessingStep, ProcessingInput
 
 from common_parser import ( # pylint: disable=wrong-import-order
     get_common_parser, parse_estimator_kwargs)
@@ -36,12 +39,12 @@ def run_job(input_args, image):
     graph_data_s3 = input_args.graph_data_s3 # S3 location storing input graph data (unpartitioned)
     graph_data_s3 = graph_data_s3[:-1] if graph_data_s3[-1] == '/' \
         else graph_data_s3 # The input will be an S3 folder
-    output_data_s3 = input_args.output_data_s3 # S3 location storing partitioned graph data
-    output_data_s3 = output_data_s3[:-1] if output_data_s3[-1] == '/' \
-        else output_data_s3 # The output will be an S3 folder
+    # S3 location storing partitioned graph data
+    output_data_s3 = input_args.output_data_s3[:-1] if input_args.output_data_s3[-1] == '/' \
+        else input_args.output_data_s3 # The output will be an S3 prefix
     metadata_filename = input_args.metadata_filename # graph metadata filename
 
-    sagemaker_session = sagemaker.Session(boto3.Session(region_name=region))
+    pipeline_session = PipelineSession(boto3.Session(region_name=region))
 
     skip_partitioning_str = "true" if input_args.skip_partitioning else "false"
     arguments = [
@@ -55,32 +58,91 @@ def run_job(input_args, image):
     ]
     arguments = [str(x) for x in arguments]
 
-    print(f"Parameters {arguments}")
+    print(f"Parameters {input_args}")
     if input_args.sm_estimator_parameters:
         print(f"SageMaker Estimator parameters: '{input_args.sm_estimator_parameters}'")
 
     estimator_kwargs = parse_estimator_kwargs(input_args.sm_estimator_parameters)
 
-    script_processor = ScriptProcessor(
+    dist_part_processor = ScriptProcessor(
         image_uri=image,
         role=role,
         instance_count=instance_count,
         instance_type=instance_type,
         command=["python3"],
         base_job_name=f"gs-partition-{sm_task_name}",
-        sagemaker_session=sagemaker_session,
+        sagemaker_session=pipeline_session,
         tags=[{"Key":"GraphStorm", "Value":"beta"},
               {"Key":"GraphStorm_Task", "Value":"Partition"}],
         **estimator_kwargs
     )
 
-    script_processor.run(
+    dist_part_step = ProcessingStep(
+        name=f"gs-partition-{sm_task_name}",
+        processor=dist_part_processor,
+        job_arguments=arguments,
         code=entry_point,
-        arguments=arguments,
-        inputs=[],
-        outputs=[],
-        wait=not input_args.async_execution
     )
+
+    pipeline_steps = [dist_part_step]
+
+    if input_args.use_graphbolt.lower() == "true":
+        gb_convert_processor = ScriptProcessor(
+            image_uri=image,
+            role=role,
+            instance_count=1,
+            instance_type=instance_type,
+            command=["python3"],
+            base_job_name=f"gs-gb-convert-{sm_task_name}",
+            sagemaker_session=pipeline_session,
+            tags=[{"Key":"GraphStorm", "Value":"beta"},
+                {"Key":"GraphStorm_Task", "Value":"GraphBoltConvert"}],
+            **estimator_kwargs
+        )
+
+        local_dist_part_path = "/opt/ml/processing/dist_graph/"
+
+        # TODO: We'd like to use FastFile here, but DGL makes the data conversion
+        # in-place and we can't write to the location where S3 files are loaded
+        gb_convert_step = ProcessingStep(
+            name=f"gs-gb-convert-{sm_task_name}",
+            processor=gb_convert_processor,
+            job_arguments=["--njobs", str(input_args.gb_convert_njobs)],
+            code="run/gb_convert_entry.py",
+            inputs=[ProcessingInput(
+                input_name="dist_graph_s3_input",
+                destination=local_dist_part_path,
+                source=os.path.join(output_data_s3, "dist_graph/"),
+                s3_input_mode="File",
+            )],
+            depends_on=[dist_part_step],
+        )
+
+        pipeline_steps.append(gb_convert_step)
+
+    pipeline_definition_config = PipelineDefinitionConfig(
+        use_custom_job_prefix=False,
+    )
+
+    pipeline = Pipeline(
+        name="MyPipeline",
+        steps=pipeline_steps,
+        sagemaker_session=pipeline_session,
+        pipeline_definition_config=pipeline_definition_config,
+    )
+
+    pipeline.create(
+        role_arn=role,
+        description="GraphStorm DistPartition"
+    )
+
+    execution = pipeline.start()
+
+    print(execution.describe())
+
+    # if not input_args.async_execution:
+    #     execution.wait()
+
 
 def get_partition_parser():
     """
@@ -110,6 +172,14 @@ def get_partition_parser():
     partition_args.add_argument("--skip-partitioning", action='store_true',
         help="When set, we skip the partitioning step. "
              "Partition assignments for all node types need to exist on S3.")
+    partition_args.add_argument("--gb-convert-njobs", type=int, default=1,
+        help="Number of parallel processes to use for GraphBolt partition conversion.")
+    partition_args.add_argument(
+        "--use-graphbolt", type=str, choices=["true", "false"],
+        default="false",
+        help=("Whether to convert the partitioned data to the GraphBolt format "
+            "after creating the DistDGL graph."))
+
 
     partition_args.add_argument('--log-level', default='INFO',
         type=str, choices=['DEBUG', 'INFO', 'WARNING', 'CRITICAL', 'FATAL'])

--- a/sagemaker/launch/launch_train.py
+++ b/sagemaker/launch/launch_train.py
@@ -81,8 +81,7 @@ def run_job(input_args, image, unknowargs):
     if model_checkpoint_to_load is not None:
         params["model-checkpoint-to-load"] = model_checkpoint_to_load
     unknown_args_dict = parse_unknown_gs_args(unknowargs)
-    if len(unknown_args_dict) > 0:
-        params.update(unknown_args_dict)
+    params.update(unknown_args_dict)
 
     print(f"SageMaker launch parameters {params}")
     print(f"GraphStorm forwarded parameters {unknown_args_dict}")

--- a/sagemaker/launch/launch_train.py
+++ b/sagemaker/launch/launch_train.py
@@ -109,7 +109,7 @@ def run_job(input_args, image, unknowargs):
         py_version="py3",
         base_job_name=prefix,
         hyperparameters=params,
-        sagemaker_session=sess,
+        # sagemaker_session=sess,
         tags=[{"Key":"GraphStorm", "Value":"oss"},
               {"Key":"GraphStorm_Task", "Value":"Training"}],
         **estimator_kwargs

--- a/sagemaker/launch/launch_train.py
+++ b/sagemaker/launch/launch_train.py
@@ -101,7 +101,6 @@ def run_job(input_args, image, unknowargs):
         py_version="py3",
         base_job_name=prefix,
         hyperparameters=params,
-        # sagemaker_session=sess,
         tags=[{"Key":"GraphStorm", "Value":"oss"},
               {"Key":"GraphStorm_Task", "Value":"Training"}],
         **estimator_kwargs
@@ -145,8 +144,8 @@ def get_train_parser():
 if __name__ == "__main__":
     arg_parser = get_train_parser()
     args, unknownargs = arg_parser.parse_known_args()
-    print(f"Train launch Known args: {args}")
-    print(f"Train launch unknown args: {unknownargs}")
+    print(f"Train launch Known args: '{args}'")
+    print(f"Train launch unknown args:{type(unknownargs)=} '{unknownargs=}'")
 
     train_image = args.image_url
 

--- a/sagemaker/launch/launch_train.py
+++ b/sagemaker/launch/launch_train.py
@@ -21,7 +21,12 @@ import boto3 # pylint: disable=import-error
 from sagemaker.pytorch.estimator import PyTorch
 import sagemaker
 
-from common_parser import get_common_parser, parse_estimator_kwargs, SUPPORTED_TASKS
+from common_parser import (
+    get_common_parser,
+    parse_estimator_kwargs,
+    SUPPORTED_TASKS,
+    parse_unknown_gs_args,
+    )
 
 INSTANCE_TYPE = "ml.g4dn.12xlarge"
 
@@ -75,24 +80,12 @@ def run_job(input_args, image, unknowargs):
         params["custom-script"] = custom_script
     if model_checkpoint_to_load is not None:
         params["model-checkpoint-to-load"] = model_checkpoint_to_load
-    # We must handle cases like
-    # --target-etype query,clicks,asin query,search,asin
-    # --feat-name ntype0:feat0 ntype1:feat1
-    unknow_idx = 0
-    while unknow_idx < len(unknowargs):
-        assert unknowargs[unknow_idx].startswith("--")
-        sub_params = []
-        for i in range(unknow_idx+1, len(unknowargs)+1):
-            # end of loop or stand with --
-            if i == len(unknowargs) or \
-                unknowargs[i].startswith("--"):
-                break
-            sub_params.append(unknowargs[i])
-        params[unknowargs[unknow_idx][2:]] = ' '.join(sub_params)
-        unknow_idx = i
+    unknown_args_dict = parse_unknown_gs_args(unknowargs)
+    if len(unknown_args_dict) > 0:
+        params.update(unknown_args_dict)
 
-    print(f"Parameters {params}")
-    print(f"GraphStorm Parameters {unknowargs}")
+    print(f"SageMaker launch parameters {params}")
+    print(f"GraphStorm forwarded parameters {unknown_args_dict}")
     if input_args.sm_estimator_parameters:
         print(f"SageMaker Estimator parameters: '{input_args.sm_estimator_parameters}'")
 
@@ -153,7 +146,8 @@ def get_train_parser():
 if __name__ == "__main__":
     arg_parser = get_train_parser()
     args, unknownargs = arg_parser.parse_known_args()
-    print(args)
+    print(f"Train launch Known args: {args}")
+    print(f"Train launch unknown args: {unknownargs}")
 
     train_image = args.image_url
 

--- a/sagemaker/run/gb_convert_entry.py
+++ b/sagemaker/run/gb_convert_entry.py
@@ -1,5 +1,5 @@
 """
-    Copyright 2023 Contributors
+    Copyright Contributors
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -23,20 +23,28 @@ import os
 from graphstorm.sagemaker.sagemaker_gb_convert import run_gb_convert
 
 
-if __name__ =='__main__':
+if __name__ == "__main__":
     parser = argparse.ArgumentParser()
-    parser.add_argument("--njobs", type=int, default=1,
-                        help="Number of parallel jobs to run for partition conversion.")
-    parser.add_argument("--metadata-filename", type=str, default="metadata.json",
+    parser.add_argument(
+        "--njobs",
+        type=int,
+        default=1,
+        help="Number of parallel jobs to run for partition conversion.",
+    )
+    parser.add_argument(
+        "--metadata-filename",
+        type=str,
+        default="metadata.json",
         help="Partition metadata file name. Default: 'metadata.json'. If GConstruct was "
-            "used should be set to <graph-name>.json")
+        "used should be set to <graph-name>.json",
+    )
     args = parser.parse_args()
 
     # NOTE: Ensure no logging has been done before setting logging configuration
     logging.basicConfig(
         level=getattr(logging, "INFO", None),
-        format='%(asctime)s - %(levelname)s - %(message)s'
-        )
+        format="%(asctime)s - %(levelname)s - %(message)s",
+    )
 
     # Read processing config file
     with open("/opt/ml/config/processingjobconfig.json", "r", encoding="utf-8") as f:
@@ -52,14 +60,16 @@ if __name__ =='__main__':
             break
     else:
         raise ValueError(
-            "Could not find a Processing input named 'dist_graph_s3_input'")
-
+            "Could not find a Processing input named 'dist_graph_s3_input'"
+        )
 
     # Run the conversion locally
     logging.info("Running graph partition conversion...")
     print(f"{local_partition_path=}, {s3_partition_path=}")
     run_gb_convert(
         s3_partition_path,
-        local_dist_part_config=os.path.join(local_partition_path, args.metadata_filename),
-        njobs=args.njobs
+        local_dist_part_config=os.path.join(
+            local_partition_path, args.metadata_filename
+        ),
+        njobs=args.njobs,
     )

--- a/sagemaker/run/gb_convert_entry.py
+++ b/sagemaker/run/gb_convert_entry.py
@@ -1,0 +1,65 @@
+"""
+    Copyright 2023 Contributors
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+    SageMaker GraphBolt partition conversion entry point.
+"""
+import argparse
+import json
+import logging
+import os
+
+from graphstorm.sagemaker.sagemaker_gb_convert import run_gb_convert
+
+
+if __name__ =='__main__':
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--njobs", type=int, default=1,
+                        help="Number of parallel jobs to run for partition conversion.")
+    parser.add_argument("--metadata-filename", type=str, default="metadata.json",
+        help="Partition metadata file name. Default: 'metadata.json'. If GConstruct was "
+            "used should be set to <graph-name>.json")
+    args = parser.parse_args()
+
+    # NOTE: Ensure no logging has been done before setting logging configuration
+    logging.basicConfig(
+        level=getattr(logging, "INFO", None),
+        format='%(asctime)s - %(levelname)s - %(message)s'
+        )
+
+    # Read processing config file
+    with open("/opt/ml/config/processingjobconfig.json", "r", encoding="utf-8") as f:
+        processing_config = json.load(f)
+
+    processing_inputs: list[dict] = processing_config["ProcessingInputs"]
+
+    # Find the S3 input path from the job's configuration
+    for input_entry in processing_inputs:
+        if input_entry["InputName"] == "dist_graph_s3_input":
+            local_partition_path = input_entry["S3Input"]["LocalPath"]
+            s3_partition_path = input_entry["S3Input"]["S3Uri"]
+            break
+    else:
+        raise ValueError(
+            "Could not find a Processing input named 'dist_graph_s3_input'")
+
+
+    # Run the conversion locally
+    logging.info("Running graph partition conversion...")
+    print(f"{local_partition_path=}, {s3_partition_path=}")
+    run_gb_convert(
+        s3_partition_path,
+        local_dist_part_config=os.path.join(local_partition_path, args.metadata_filename),
+        njobs=args.njobs
+    )

--- a/sagemaker/run/gconstruct_entry.py
+++ b/sagemaker/run/gconstruct_entry.py
@@ -19,8 +19,8 @@ import argparse
 import sys
 import subprocess
 
-def parse_construct_args():
-    """  Add arguments for launch gconstruct using SageMaker
+def parse_construct_args() -> tuple[argparse.Namespace, list[str]]:
+    """  Parse known and unknown arguments to pass to GConstruct
     """
     parser = argparse.ArgumentParser(description='gs sagemaker graph construction pipeline')
 
@@ -32,12 +32,15 @@ def parse_construct_args():
         required=True, help="Path to store output")
     parser.add_argument("--graph-name", type=str,
         required=True, help="Graph name")
-    return parser
+
+    return parser.parse_known_args()
 
 
 if __name__ =='__main__':
-    parser = parse_construct_args()
-    args, unknownargs = parser.parse_known_args()
+    args, unknownargs = parse_construct_args()
+
+    print(f"entry point known args: {args}")
+    print(f"entry point unknown args: {unknownargs}")
 
     subprocess.check_call(['ls'], cwd=args.input_path, shell=False)
     subprocess.run(["df", "-h"], check=True)

--- a/sagemaker/run/train_entry.py
+++ b/sagemaker/run/train_entry.py
@@ -22,7 +22,7 @@ import subprocess
 from graphstorm.config import SUPPORTED_TASKS
 from graphstorm.sagemaker.sagemaker_train import run_train
 
-def parse_train_args():
+def get_train_parser():
     """  Add arguments for model training
     """
     parser = argparse.ArgumentParser(description='gs sagemaker train pipeline')
@@ -60,8 +60,10 @@ def parse_train_args():
     return parser
 
 if __name__ =='__main__':
-    parser = parse_train_args()
-    args, unknownargs = parser.parse_known_args()
+    train_parser = get_train_parser()
+    args, unknownargs = train_parser.parse_known_args()
 
     subprocess.run(["df", "-h"], check=True)
+    print(f"Train Entry Known args: {args}")
+    print(f"Train entry unknown args: {unknownargs}")
     run_train(args, unknownargs)

--- a/tests/sagemaker-tests/test_sagemaker_args.py
+++ b/tests/sagemaker-tests/test_sagemaker_args.py
@@ -47,12 +47,6 @@ def test_quoted_args():
     assert dict(parse_unknown_gs_args(args)) == expected
 
 @pytest.mark.parametrize("input_args, expected_output", [
-    (['--num', '1', '2', '3', '--str', 'a', 'b', 'c'],
-     {'num': '1 2 3', 'str': 'a b c'}),
-    (['--mixed', 'str', '123', 'true', '--flag'],
-     {'mixed': 'str 123 true', 'flag': ''}),
-    (['--empty', '', '--zero', '0', '--false', 'false'],
-     {'empty': '', 'zero': '0', 'false': 'false'}),
     (['--special-chars', '!@#$%^&*()'],
      {'special-chars': '!@#$%^&*()'}),
     (['--unicode', 'こんにちは', 'world'],

--- a/tests/sagemaker-tests/test_sagemaker_args.py
+++ b/tests/sagemaker-tests/test_sagemaker_args.py
@@ -1,0 +1,62 @@
+import pytest
+from common_parser import parse_unknown_gs_args
+
+def test_basic_parsing():
+    args = ['--num-epochs', '1', '--use-graphbolt', 'true']
+    expected = {'num-epochs': '1', 'use-graphbolt': 'true'}
+    assert dict(parse_unknown_gs_args(args)) == expected
+
+def test_multiple_values():
+    args = [
+        '--target-etype',
+        'query,clicks,asin',
+        'query,search,asin',
+        '--feat-name',
+        'ntype0:feat0',
+        'ntype1:feat1',
+    ]
+    expected = {
+        'target-etype': 'query,clicks,asin query,search,asin',
+        'feat-name': 'ntype0:feat0 ntype1:feat1'
+    }
+    assert dict(parse_unknown_gs_args(args)) == expected
+
+def test_empty_value():
+    args = ['--empty-arg', '--next-arg', 'value']
+    expected = {'empty-arg': '', 'next-arg': 'value'}
+    assert dict(parse_unknown_gs_args(args)) == expected
+
+def test_no_args():
+    args = []
+    result = parse_unknown_gs_args(args)
+    assert len(result) == 0
+
+def test_only_flags():
+    args = ['--flag1', '--flag2', '--flag3']
+    expected = {'flag1': '', 'flag2': '', 'flag3': ''}
+    assert dict(parse_unknown_gs_args(args)) == expected
+
+def test_mixed_args():
+    args = ['--arg1', 'value1', '--flag', '--arg2', 'value2a', 'value2b']
+    expected = {'arg1': 'value1', 'flag': '', 'arg2': 'value2a value2b'}
+    assert dict(parse_unknown_gs_args(args)) == expected
+
+def test_quoted_args():
+    args = ['--arg', '"quoted value"', '--another-arg', "'single quoted'"]
+    expected = {'arg': '"quoted value"', 'another-arg': "'single quoted'"}
+    assert dict(parse_unknown_gs_args(args)) == expected
+
+@pytest.mark.parametrize("input_args, expected_output", [
+    (['--num', '1', '2', '3', '--str', 'a', 'b', 'c'],
+     {'num': '1 2 3', 'str': 'a b c'}),
+    (['--mixed', 'str', '123', 'true', '--flag'],
+     {'mixed': 'str 123 true', 'flag': ''}),
+    (['--empty', '', '--zero', '0', '--false', 'false'],
+     {'empty': '', 'zero': '0', 'false': 'false'}),
+    (['--special-chars', '!@#$%^&*()'],
+     {'special-chars': '!@#$%^&*()'}),
+    (['--unicode', 'こんにちは', 'world'],
+     {'unicode': 'こんにちは world'}),
+])
+def test_parse_unknown_gs_args_parametrized(input_args, expected_output):
+    assert dict(parse_unknown_gs_args(input_args)) == expected_output

--- a/tests/sagemaker-tests/test_sagemaker_args.py
+++ b/tests/sagemaker-tests/test_sagemaker_args.py
@@ -66,11 +66,11 @@ def test_parse_unknown_gs_args_parametrized(input_args, expected_output):
 
 
 def test_parse_single_string():
-    """Happens when GS args are passed in quoted:
+    """Happens when GS args are passed in quoted in bash:
     ``python launch_*.py --launch-arg 1 '--gs-arg1 2 --gs-arg2 3'``
     """
-    args = ["--num-epochs 1 --use-graphbolt true"]
-    expected = {"num-epochs": "1", "use-graphbolt": "true"}
+    args = ["--feat-name ntype0:feat0 ntype1:feat1"]
+    expected = {"feat-name": "ntype0:feat0 ntype1:feat1"}
     assert dict(parse_unknown_gs_args(args)) == expected
 
 

--- a/tests/sagemaker-tests/test_sagemaker_args.py
+++ b/tests/sagemaker-tests/test_sagemaker_args.py
@@ -1,56 +1,88 @@
 import pytest
 from common_parser import parse_unknown_gs_args
 
+
 def test_basic_parsing():
-    args = ['--num-epochs', '1', '--use-graphbolt', 'true']
-    expected = {'num-epochs': '1', 'use-graphbolt': 'true'}
+    args = ["--num-epochs", "1", "--use-graphbolt", "true"]
+    expected = {"num-epochs": "1", "use-graphbolt": "true"}
     assert dict(parse_unknown_gs_args(args)) == expected
+
 
 def test_multiple_values():
     args = [
-        '--target-etype',
-        'query,clicks,asin',
-        'query,search,asin',
-        '--feat-name',
-        'ntype0:feat0',
-        'ntype1:feat1',
+        "--target-etype",
+        "query,clicks,asin",
+        "query,search,asin",
+        "--feat-name",
+        "ntype0:feat0",
+        "ntype1:feat1",
     ]
     expected = {
-        'target-etype': 'query,clicks,asin query,search,asin',
-        'feat-name': 'ntype0:feat0 ntype1:feat1'
+        "target-etype": "query,clicks,asin query,search,asin",
+        "feat-name": "ntype0:feat0 ntype1:feat1",
     }
     assert dict(parse_unknown_gs_args(args)) == expected
 
+
 def test_empty_value():
-    args = ['--empty-arg', '--next-arg', 'value']
-    expected = {'empty-arg': '', 'next-arg': 'value'}
+    args = ["--empty-arg", "--next-arg", "value"]
+    expected = {"empty-arg": "", "next-arg": "value"}
     assert dict(parse_unknown_gs_args(args)) == expected
+
 
 def test_no_args():
     args = []
     result = parse_unknown_gs_args(args)
     assert len(result) == 0
 
+
 def test_only_flags():
-    args = ['--flag1', '--flag2', '--flag3']
-    expected = {'flag1': '', 'flag2': '', 'flag3': ''}
+    args = ["--flag1", "--flag2", "--flag3"]
+    expected = {"flag1": "", "flag2": "", "flag3": ""}
     assert dict(parse_unknown_gs_args(args)) == expected
+
 
 def test_mixed_args():
-    args = ['--arg1', 'value1', '--flag', '--arg2', 'value2a', 'value2b']
-    expected = {'arg1': 'value1', 'flag': '', 'arg2': 'value2a value2b'}
+    args = ["--arg1", "value1", "--flag", "--arg2", "value2a", "value2b"]
+    expected = {"arg1": "value1", "flag": "", "arg2": "value2a value2b"}
     assert dict(parse_unknown_gs_args(args)) == expected
+
 
 def test_quoted_args():
-    args = ['--arg', '"quoted value"', '--another-arg', "'single quoted'"]
-    expected = {'arg': '"quoted value"', 'another-arg': "'single quoted'"}
+    args = ["--arg", '"quoted value"', "--another-arg", "'single quoted'"]
+    expected = {"arg": '"quoted value"', "another-arg": "'single quoted'"}
     assert dict(parse_unknown_gs_args(args)) == expected
 
-@pytest.mark.parametrize("input_args, expected_output", [
-    (['--special-chars', '!@#$%^&*()'],
-     {'special-chars': '!@#$%^&*()'}),
-    (['--unicode', 'こんにちは', 'world'],
-     {'unicode': 'こんにちは world'}),
-])
+
+@pytest.mark.parametrize(
+    "input_args, expected_output",
+    [
+        (["--special-chars", "!@#$%^&*()"], {"special-chars": "!@#$%^&*()"}),
+        (["--unicode", "こんにちは", "world"], {"unicode": "こんにちは world"}),
+    ],
+)
 def test_parse_unknown_gs_args_parametrized(input_args, expected_output):
     assert dict(parse_unknown_gs_args(input_args)) == expected_output
+
+
+def test_parse_single_string():
+    """Happens when GS args are passed in quoted:
+    ``python launch_*.py --launch-arg 1 '--gs-arg1 2 --gs-arg2 3'``
+    """
+    args = ["--num-epochs 1 --use-graphbolt true"]
+    expected = {"num-epochs": "1", "use-graphbolt": "true"}
+    assert dict(parse_unknown_gs_args(args)) == expected
+
+
+def test_parse_complex_string_with_quotes():
+    args = [
+        (
+            "--target-etype query,clicks,asin query,search,asin "
+            "--feat-name ntype0:feat0 ntype1:feat1"
+        )
+    ]
+    expected = {
+        "target-etype": "query,clicks,asin query,search,asin",
+        "feat-name": "ntype0:feat0 ntype1:feat1",
+    }
+    assert dict(parse_unknown_gs_args(args)) == expected


### PR DESCRIPTION
*Issue #, if available:*


*Description of changes:*

* Add a new SageMaker job to convert DistPart data to GraphBolt. This is our only option currently as there's no way to directly use S3 as a writable, shared file system in SageMaker, see https://github.com/awslabs/graphstorm/issues/1081 for details.
* The `sagemaker/launch_graphbolt_convert.py` will launch the SageMaker job, that downloads the entire partitioned graph to one instance, then runs the GB conversion, one partition at a time. Because DGL writes the new fused CSC graph representation in the same directory as the input data, we can't use one of SageMaker's FastFile modes to stream the data, as that creates read-only filesystems.
* [Optional] We also include an example of how one could use a SageMaker Pipeline to run the GSPartition and GBConvert jobs in sequence, but this can be removed (because SageMaker Pipelines are persistent once created).
* Added unit test mechanism to test sagemaker scripts, we start with testing our parsing logic. To make the scripts available to the runner's python runtime we add the `graphstorm/sagemaker/launch` directory to the runner's `PYTHONPATH`.

EDIT: One note about the PR: The changes to the partition launch that use a SageMaker Pipeline are for demonstration purposes, I think I'll remove them alltogether and just have separate partition/gbconvert jobs. But we might want to have an example of how to programmatically build an SM pipeline as an example, e.g. from gsprocessing to training (as SM jobs)







By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
