### PR TITLE
Reduce sensitive for test_fp_min_max_transform to avoid flaky test

### DIFF
--- a/tests/unit-tests/gconstruct/test_transform.py
+++ b/tests/unit-tests/gconstruct/test_transform.py
@@ -307,7 +307,7 @@ def test_fp_min_max_transform(input_dtype, out_dtype):
     feats[feats < min_val] = min_val
     feats = (feats-min_val)/(max_val-min_val)
     feats = feats if out_dtype is None else feats.astype(out_dtype)
-    assert_almost_equal(norm_feats, feats, decimal=6)
+    assert_almost_equal(norm_feats, feats, decimal=5)
 
     transform = NumericalMinMaxTransform("test", "test", out_dtype=out_dtype)
     max_val = np.array([2., 3., 0.])


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Got this error in a un-related PR. We fixed the previous check in another PR, now doing the second one:


```
[2024-11-07T18:45:49.137Z] ________________ test_fp_min_max_transform[float16-complex128] _________________
[2024-11-07T18:45:49.137Z] input_dtype = <class 'numpy.complex128'>, out_dtype = <class 'numpy.float16'>
[2024-11-07T18:45:49.137Z]     @pytest.mark.parametrize("input_dtype", [np.cfloat, np.float32])
[2024-11-07T18:45:49.137Z]     @pytest.mark.parametrize("out_dtype", [None, np.float16])
[2024-11-07T18:45:49.137Z]     def test_fp_min_max_transform(input_dtype, out_dtype):
[2024-11-07T18:45:49.137Z]         transform = NumericalMinMaxTransform("test", "test", out_dtype=out_dtype)
[2024-11-07T18:45:49.137Z]         max_val = np.array([2.])
[2024-11-07T18:45:49.137Z]         min_val = np.array([-1.])
[2024-11-07T18:45:49.137Z]         transform._max_val = max_val
[2024-11-07T18:45:49.137Z]         transform._min_val = min_val
[2024-11-07T18:45:49.137Z]         feats = np.random.randn(100).astype(input_dtype)
[2024-11-07T18:45:49.137Z]         norm_feats = transform(feats)["test"]
[2024-11-07T18:45:49.137Z]         if out_dtype is not None:
[2024-11-07T18:45:49.137Z]             assert norm_feats.dtype == np.float16
[2024-11-07T18:45:49.137Z]         else:
[2024-11-07T18:45:49.137Z]             assert norm_feats.dtype != np.float16
[2024-11-07T18:45:49.137Z]         feats[feats > max_val] = max_val
[2024-11-07T18:45:49.137Z]         feats[feats < min_val] = min_val
[2024-11-07T18:45:49.137Z]         feats = (feats-min_val)/(max_val-min_val)
[2024-11-07T18:45:49.137Z]         feats = feats if out_dtype is None else feats.astype(out_dtype)
[2024-11-07T18:45:49.137Z]         assert_almost_equal(norm_feats, feats, decimal=5)
[2024-11-07T18:45:49.137Z]     
[2024-11-07T18:45:49.137Z]         feats = np.random.randn(100, 1).astype(input_dtype)
[2024-11-07T18:45:49.137Z]         norm_feats = transform(feats)["test"]
[2024-11-07T18:45:49.137Z]         if out_dtype is not None:
[2024-11-07T18:45:49.137Z]             assert norm_feats.dtype == np.float16
[2024-11-07T18:45:49.137Z]         else:
[2024-11-07T18:45:49.137Z]             assert norm_feats.dtype != np.float16
[2024-11-07T18:45:49.137Z]         feats[feats > max_val] = max_val
[2024-11-07T18:45:49.137Z]         feats[feats < min_val] = min_val
[2024-11-07T18:45:49.137Z]         feats = (feats-min_val)/(max_val-min_val)
[2024-11-07T18:45:49.137Z]         feats = feats if out_dtype is None else feats.astype(out_dtype)
[2024-11-07T18:45:49.137Z] >       assert_almost_equal(norm_feats, feats, decimal=6)
[2024-11-07T18:45:49.137Z] tests/unit-tests/gconstruct/test_transform.py:310: 
[2024-11-07T18:45:49.137Z] _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
[2024-11-07T18:45:49.137Z] /usr/lib/python3.10/contextlib.py:79: in inner
[2024-11-07T18:45:49.137Z]     return func(*args, **kwds)
[2024-11-07T18:45:49.137Z] /usr/lib/python3.10/contextlib.py:79: in inner
[2024-11-07T18:45:49.137Z]     return func(*args, **kwds)
[2024-11-07T18:45:49.137Z] _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
[2024-11-07T18:45:49.137Z] args = (<function assert_array_almost_equal.<locals>.compare at 0x7f51a8107880>, array([[0.372   ],
[2024-11-07T18:45:49.137Z]        [0.      ],
[2024-11-07T18:45:49.137Z]       ...26   ],
[2024-11-07T18:45:49.137Z]        [1.      ],
[2024-11-07T18:45:49.137Z]        [0.3762  ],
[2024-11-07T18:45:49.137Z]        [0.3076  ],
[2024-11-07T18:45:49.137Z]        [0.6826  ],
[2024-11-07T18:45:49.137Z]        [0.119   ]], dtype=float16))
[2024-11-07T18:45:49.137Z] kwds = {'err_msg': '', 'header': 'Arrays are not almost equal to 6 decimals', 'precision': 6, 'verbose': True}
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
