### PR TITLE
[Bugfix] Fix the bug when _get_sparse_emb_range return a start larger than num-of-embs

### DIFF
--- a/python/graphstorm/model/utils.py
+++ b/python/graphstorm/model/utils.py
@@ -146,6 +146,13 @@ def _get_sparse_emb_range(num_embs, rank, world_size):
         world_size : int
             World size in a distributed environment. This tells the size of a distributed cluster
             (How many processes in a cluster).
+
+        Return
+        ------
+        Tuple of (int, int)
+            A tuple storing the start idx (inclusive) and end
+            idx (exclusive) of the target emb range regarding
+            to the rank and world_size.
     """
     assert rank < world_size, \
         "local rank {rank} shold be smaller than world size {world_size}"

--- a/python/graphstorm/model/utils.py
+++ b/python/graphstorm/model/utils.py
@@ -156,7 +156,12 @@ def _get_sparse_emb_range(num_embs, rank, world_size):
     else:
         start = rank * math.ceil(num_embs / world_size)
         end = (rank + 1) * math.ceil(num_embs / world_size)
-        end = num_embs if rank + 1 == world_size else end
+        # It is possible that start is also larger than num_embs
+        # For example, when num_embs = 11, world_size = 8
+        # and rank is 7
+        # start = 7 * 2, which is 14 > 11.
+        start = num_embs if start > num_embs else start
+        end = num_embs if end > num_embs else end
     return start, end
 
 def save_sparse_emb(model_path, sparse_emb, ntype):

--- a/tests/unit-tests/test_model_save_load.py
+++ b/tests/unit-tests/test_model_save_load.py
@@ -57,6 +57,19 @@ def test_get_sparse_emb_range():
     assert start == 12
     assert end == 15
 
+    # num_embs = 15
+    for i in range(66):
+        start, end = _get_sparse_emb_range(133, i, 80)
+        assert start == i * 2
+        assert end == i * 2 + 2
+    start, end = _get_sparse_emb_range(133, 66, 80)
+    assert start == 132
+    assert end == 133
+    for i in range(67, 80):
+        start, end = _get_sparse_emb_range(133, i, 80)
+        assert start == 133
+        assert end == 133
+
     try:
         _get_sparse_emb_range(15, 4, 4)
     except:

--- a/tests/unit-tests/test_model_save_load.py
+++ b/tests/unit-tests/test_model_save_load.py
@@ -57,7 +57,7 @@ def test_get_sparse_emb_range():
     assert start == 12
     assert end == 15
 
-    # num_embs = 15
+    # num_embs = 133
     for i in range(66):
         start, end = _get_sparse_emb_range(133, i, 80)
         assert start == i * 2
@@ -70,11 +70,8 @@ def test_get_sparse_emb_range():
         assert start == 133
         assert end == 133
 
-    try:
+    with pytest.raises(AssertionError):
         _get_sparse_emb_range(15, 4, 4)
-    except:
-        return
-    raise "_get_sparse_emb_range should handle the case when local_rank is >= world_size"
 
 @pytest.mark.parametrize("world_size", [3, 4])
 def test_sparse_embed_save(world_size):


### PR DESCRIPTION
*Issue #, if available:*
In _get_sparse_emb_range, It is possible that start is also larger than num_embs. For example, when `num_embs = 11`, `world_size = 8`, and `rank is 7`, `start = 7 * 2`, which is `14 > 11`.

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
