### PR TITLE
[Feature] Run config for using edge features

### DIFF
--- a/examples/acm_data.py
+++ b/examples/acm_data.py
@@ -152,7 +152,13 @@ def create_acm_raw_data(graph,
                 # Here we assume all others are edge features
                 # convert tensor to list of arrays for saving in parquet format
                 edge_dict[feat_name] = convert_tensor_to_list_arrays(val)
-            
+
+        # Give ('paper', 'citing', 'paper') edge type categorical features for different tasks
+        if src_ntype == 'paper' and etype == 'citing' and dst_ntype == 'paper':
+            cates = ['C_' + str(i) for i in range(1, 17, 3)]
+            num_pvp_edges = graph.num_edges((src_ntype, etype, dst_ntype))
+            edge_dict['cate_feat'] = np.random.choice(cates, num_pvp_edges)
+
         # generate the pandas DataFrame that combine ids, and, if have, features and labels
         edge_df = pd.DataFrame(edge_dict)
         # add canonical edge type name and edge dataframe as a tuple
@@ -372,11 +378,11 @@ def create_acm_dgl_graph(dowload_path='/tmp/ACM.mat',
         emb = nn.Parameter(th.Tensor(graph_acm.number_of_nodes(n_type), 256), requires_grad = False)
         nn.init.xavier_uniform_(emb)
         graph_acm.nodes[n_type].data['feat'] = emb
-        
+
     # For link prediction task, use "paper, citing, paper" edges as targe-etype and create labels.
     target_etype = ('paper', 'citing', 'paper')
     graph_acm.edges[target_etype].data['label'] = th.ones(graph_acm.num_edges(target_etype))
-    
+
     print(graph_acm)
     print(f'\n Number of classes: {labels.max() + 1}')
     print(f'\n Paper node labels: {labels.shape}')

--- a/python/graphstorm/run/gsgnn_ep/ep_infer_gnn.py
+++ b/python/graphstorm/run/gsgnn_ep/ep_infer_gnn.py
@@ -79,6 +79,7 @@ def main(config_args):
     dataloader = GSgnnEdgeDataLoader(infer_data, target_idxs, fanout=fanout,
                                      batch_size=config.eval_batch_size,
                                      node_feats=config.node_feat_name,
+                                     edge_feats=config.edge_feat_name,
                                      label_field=config.label_field,
                                      decoder_edge_feats=config.decoder_edge_feat,
                                      train_task=False,

--- a/python/graphstorm/run/gsgnn_ep/ep_infer_lm.py
+++ b/python/graphstorm/run/gsgnn_ep/ep_infer_lm.py
@@ -72,6 +72,7 @@ def main(config_args):
     dataloader = GSgnnEdgeDataLoader(infer_data, target_idxs, fanout=[],
                                      batch_size=config.eval_batch_size,
                                      node_feats=config.node_feat_name,
+                                     edge_feats=config.edge_feat_name,
                                      label_field=config.label_field,
                                      decoder_edge_feats=config.decoder_edge_feat,
                                      train_task=False,

--- a/python/graphstorm/run/gsgnn_ep/gsgnn_ep.py
+++ b/python/graphstorm/run/gsgnn_ep/gsgnn_ep.py
@@ -158,7 +158,7 @@ def main(config_args):
             'uses full-graph inference by default to generate node embeddings at the end of ' + \
             'training. But the full-graph inference method does not support edge features ' + \
             'in the current version. Please set the \"save_embed_path\" to none ' + \
-            'set this argument if you want to use edge features in training command.'
+            ' if you want to use edge features in training command.'
         model = gs.create_builtin_edge_gnn_model(train_data.g, config, train_task=False)
         best_model_path = trainer.get_best_model_path()
         # TODO(zhengda) the model path has to be in a shared filesystem.

--- a/python/graphstorm/run/gsgnn_ep/gsgnn_ep.py
+++ b/python/graphstorm/run/gsgnn_ep/gsgnn_ep.py
@@ -92,6 +92,7 @@ def main(config_args):
     dataloader = GSgnnEdgeDataLoader(train_data, train_idxs, fanout=config.fanout,
                                      batch_size=config.batch_size,
                                      node_feats=config.node_feat_name,
+                                     edge_feats=config.edge_feat_name,
                                      label_field=config.label_field,
                                      decoder_edge_feats=config.decoder_edge_feat,
                                      train_task=True,
@@ -110,6 +111,7 @@ def main(config_args):
         val_dataloader = GSgnnEdgeDataLoader(train_data, val_idxs, fanout=fanout,
             batch_size=config.eval_batch_size,
             node_feats=config.node_feat_name,
+            edge_feats=config.edge_feat_name,
             label_field=config.label_field,
             decoder_edge_feats=config.decoder_edge_feat,
             train_task=False,
@@ -121,6 +123,7 @@ def main(config_args):
         test_dataloader = GSgnnEdgeDataLoader(train_data, test_idxs, fanout=fanout,
             batch_size=config.eval_batch_size,
             node_feats=config.node_feat_name,
+            edge_feats=config.edge_feat_name,
             label_field=config.label_field,
             decoder_edge_feats=config.decoder_edge_feat,
             train_task=False,
@@ -151,6 +154,11 @@ def main(config_args):
                 grad_norm_type=config.grad_norm_type)
 
     if config.save_embed_path is not None:
+        assert config.edge_feat_name is None, 'GraphStorm edge prediction training command ' + \
+            'uses full-graph inference by default to generate node embeddings at the end of ' + \
+            'training. But the full-graph inference method does not support edge features ' + \
+            'in this version. Please set the \"save_embed_path\" to be empty or does not ' + \
+            'set this argument if you want to use edge features in training command.'
         model = gs.create_builtin_edge_gnn_model(train_data.g, config, train_task=False)
         best_model_path = trainer.get_best_model_path()
         # TODO(zhengda) the model path has to be in a shared filesystem.

--- a/python/graphstorm/run/gsgnn_ep/gsgnn_ep.py
+++ b/python/graphstorm/run/gsgnn_ep/gsgnn_ep.py
@@ -157,7 +157,7 @@ def main(config_args):
         assert config.edge_feat_name is None, 'GraphStorm edge prediction training command ' + \
             'uses full-graph inference by default to generate node embeddings at the end of ' + \
             'training. But the full-graph inference method does not support edge features ' + \
-            'in this version. Please set the \"save_embed_path\" to be empty or does not ' + \
+            'in the current version. Please set the \"save_embed_path\" to none ' + \
             'set this argument if you want to use edge features in training command.'
         model = gs.create_builtin_edge_gnn_model(train_data.g, config, train_task=False)
         best_model_path = trainer.get_best_model_path()

--- a/python/graphstorm/run/gsgnn_ep/gsgnn_lm_ep.py
+++ b/python/graphstorm/run/gsgnn_ep/gsgnn_lm_ep.py
@@ -87,6 +87,7 @@ def main(config_args):
     dataloader = GSgnnEdgeDataLoader(train_data, train_idxs, fanout=[],
                                      batch_size=config.batch_size,
                                      node_feats=config.node_feat_name,
+                                     edge_feats=config.edge_feat_name,
                                      label_field=config.label_field,
                                      decoder_edge_feats=config.decoder_edge_feat,
                                      train_task=True,
@@ -101,6 +102,7 @@ def main(config_args):
         val_dataloader = GSgnnEdgeDataLoader(train_data, val_idxs, fanout=fanout,
             batch_size=config.eval_batch_size,
             node_feats=config.node_feat_name,
+            edge_feats=config.edge_feat_name,
             label_field=config.label_field,
             decoder_edge_feats=config.decoder_edge_feat,
             train_task=False,
@@ -109,6 +111,7 @@ def main(config_args):
         test_dataloader = GSgnnEdgeDataLoader(train_data, test_idxs, fanout=fanout,
             batch_size=config.eval_batch_size,
             node_feats=config.node_feat_name,
+            edge_feats=config.edge_feat_name,
             label_field=config.label_field,
             decoder_edge_feats=config.decoder_edge_feat,
             train_task=False,
@@ -135,6 +138,11 @@ def main(config_args):
                 grad_norm_type=config.grad_norm_type)
 
     if config.save_embed_path is not None:
+        assert config.edge_feat_name is None, 'GraphStorm edge prediction training command ' + \
+            'uses full-graph inference by default to generate node embeddings at the end of ' + \
+            'training. But the full-graph inference method does not support edge features ' + \
+            'in this version. Please set the \"save_embed_path\" to be empty or does not ' + \
+            'set this argument if you want to use edge features in training command.'
         model = gs.create_builtin_edge_model(train_data.g, config, train_task=False)
         best_model_path = trainer.get_best_model_path()
         # TODO(zhengda) the model path has to be in a shared filesystem.

--- a/python/graphstorm/run/gsgnn_ep/gsgnn_lm_ep.py
+++ b/python/graphstorm/run/gsgnn_ep/gsgnn_lm_ep.py
@@ -141,8 +141,8 @@ def main(config_args):
         assert config.edge_feat_name is None, 'GraphStorm edge prediction training command ' + \
             'uses full-graph inference by default to generate node embeddings at the end of ' + \
             'training. But the full-graph inference method does not support edge features ' + \
-            'in this version. Please set the \"save_embed_path\" to be empty or does not ' + \
-            'set this argument if you want to use edge features in training command.'
+            'in the current version. Please set the \"save_embed_path\" to none ' + \
+            ' if you want to use edge features in training command.'
         model = gs.create_builtin_edge_model(train_data.g, config, train_task=False)
         best_model_path = trainer.get_best_model_path()
         # TODO(zhengda) the model path has to be in a shared filesystem.

--- a/python/graphstorm/run/gsgnn_lp/gsgnn_lm_lp.py
+++ b/python/graphstorm/run/gsgnn_lp/gsgnn_lm_lp.py
@@ -136,8 +136,8 @@ def main(config_args):
         assert config.edge_feat_name is None, 'GraphStorm node prediction training command ' + \
             'uses full-graph inference by default to generate node embeddings at the end of ' + \
             'training. But the full-graph inference method does not support edge features ' + \
-            'in this version. Please set the \"save_embed_path\" to be empty or does not ' + \
-            'set this argument if you want to use edge features in training command.'
+            'in the current version. Please set the \"save_embed_path\" to none ' + \
+            ' if you want to use edge features in training command.'
         model = gs.create_builtin_lp_model(train_data.g, config, train_task=False)
         best_model_path = trainer.get_best_model_path()
         # TODO(zhengda) the model path has to be in a shared filesystem.

--- a/python/graphstorm/run/gsgnn_lp/gsgnn_lm_lp.py
+++ b/python/graphstorm/run/gsgnn_lp/gsgnn_lm_lp.py
@@ -67,6 +67,7 @@ def main(config_args):
                                 train_idxs, [],
                                 config.batch_size, config.num_negative_edges,
                                 node_feats=config.node_feat_name,
+                                edge_feats=config.edge_feat_name,
                                 pos_graph_edge_feats=config.lp_edge_weight_for_loss,
                                 train_task=True,
                                 edge_dst_negative_field=config.train_etypes_negative_dstnode,
@@ -84,12 +85,14 @@ def main(config_args):
                 config.eval_batch_size,
                 config.eval_etypes_negative_dstnode,
                 node_feats=config.node_feat_name,
+                edge_feats=config.edge_feat_name,
                 pos_graph_edge_feats=config.lp_edge_weight_for_loss)
         else:
             val_dataloader = test_dataloader_cls(train_data, val_idxs,
                 config.eval_batch_size,
                 config.num_negative_edges_eval,
                 node_feats=config.node_feat_name,
+                edge_feats=config.edge_feat_name,
                 pos_graph_edge_feats=config.lp_edge_weight_for_loss)
 
     test_idxs = train_data.get_edge_test_set(config.eval_etype)
@@ -99,12 +102,14 @@ def main(config_args):
                 config.eval_batch_size,
                 config.eval_etypes_negative_dstnode,
                 node_feats=config.node_feat_name,
+                edge_feats=config.edge_feat_name,
                 pos_graph_edge_feats=config.lp_edge_weight_for_loss)
         else:
             test_dataloader = test_dataloader_cls(train_data, test_idxs,
                 config.eval_batch_size,
                 config.num_negative_edges_eval,
                 node_feats=config.node_feat_name,
+                edge_feats=config.edge_feat_name,
                 pos_graph_edge_feats=config.lp_edge_weight_for_loss)
 
     # Preparing input layer for training or inference.
@@ -128,6 +133,11 @@ def main(config_args):
                 grad_norm_type=config.grad_norm_type)
 
     if config.save_embed_path is not None:
+        assert config.edge_feat_name is None, 'GraphStorm node prediction training command ' + \
+            'uses full-graph inference by default to generate node embeddings at the end of ' + \
+            'training. But the full-graph inference method does not support edge features ' + \
+            'in this version. Please set the \"save_embed_path\" to be empty or does not ' + \
+            'set this argument if you want to use edge features in training command.'
         model = gs.create_builtin_lp_model(train_data.g, config, train_task=False)
         best_model_path = trainer.get_best_model_path()
         # TODO(zhengda) the model path has to be in a shared filesystem.

--- a/python/graphstorm/run/gsgnn_lp/gsgnn_lp.py
+++ b/python/graphstorm/run/gsgnn_lp/gsgnn_lp.py
@@ -76,6 +76,7 @@ def main(config_args):
     dataloader = dataloader_cls(train_data, train_idxs, config.fanout,
                                 config.batch_size, config.num_negative_edges,
                                 node_feats=config.node_feat_name,
+                                edge_feats=config.edge_feat_name,
                                 pos_graph_edge_feats=config.lp_edge_weight_for_loss,
                                 train_task=True,
                                 reverse_edge_types_map=config.reverse_edge_types_map,
@@ -98,6 +99,7 @@ def main(config_args):
                 fanout=config.eval_fanout,
                 fixed_test_size=config.fixed_test_size,
                 node_feats=config.node_feat_name,
+                edge_feats=config.edge_feat_name,
                 pos_graph_edge_feats=config.lp_edge_weight_for_loss)
         else:
             val_dataloader = test_dataloader_cls(train_data, val_idxs,
@@ -105,6 +107,7 @@ def main(config_args):
                 config.num_negative_edges_eval, config.eval_fanout,
                 fixed_test_size=config.fixed_test_size,
                 node_feats=config.node_feat_name,
+                edge_feats=config.edge_feat_name,
                 pos_graph_edge_feats=config.lp_edge_weight_for_loss)
 
     test_idxs = train_data.get_edge_test_set(config.eval_etype)
@@ -116,12 +119,14 @@ def main(config_args):
                 fanout=config.eval_fanout,
                 fixed_test_size=config.fixed_test_size,
                 node_feats=config.node_feat_name,
+                edge_feats=config.edge_feat_name,
                 pos_graph_edge_feats=config.lp_edge_weight_for_loss)
         else:
             test_dataloader = test_dataloader_cls(train_data, test_idxs,
                 config.eval_batch_size, config.num_negative_edges_eval, config.eval_fanout,
                 fixed_test_size=config.fixed_test_size,
                 node_feats=config.node_feat_name,
+                edge_feats=config.edge_feat_name,
                 pos_graph_edge_feats=config.lp_edge_weight_for_loss)
 
     # Preparing input layer for training or inference.
@@ -146,6 +151,11 @@ def main(config_args):
                 grad_norm_type=config.grad_norm_type)
 
     if config.save_embed_path is not None:
+        assert config.edge_feat_name is None, 'GraphStorm node prediction training command ' + \
+            'uses full-graph inference by default to generate node embeddings at the end of ' + \
+            'training. But the full-graph inference method does not support edge features ' + \
+            'in this version. Please set the \"save_embed_path\" to be empty or does not ' + \
+            'set this argument if you want to use edge features in training command.'
         model = gs.create_builtin_lp_gnn_model(train_data.g, config, train_task=False)
         best_model_path = trainer.get_best_model_path()
         # TODO(zhengda) the model path has to be in a shared filesystem.

--- a/python/graphstorm/run/gsgnn_lp/gsgnn_lp.py
+++ b/python/graphstorm/run/gsgnn_lp/gsgnn_lp.py
@@ -154,8 +154,8 @@ def main(config_args):
         assert config.edge_feat_name is None, 'GraphStorm node prediction training command ' + \
             'uses full-graph inference by default to generate node embeddings at the end of ' + \
             'training. But the full-graph inference method does not support edge features ' + \
-            'in this version. Please set the \"save_embed_path\" to be empty or does not ' + \
-            'set this argument if you want to use edge features in training command.'
+            'in the current version. Please set the \"save_embed_path\" to none ' + \
+            ' if you want to use edge features in training command.'
         model = gs.create_builtin_lp_gnn_model(train_data.g, config, train_task=False)
         best_model_path = trainer.get_best_model_path()
         # TODO(zhengda) the model path has to be in a shared filesystem.

--- a/python/graphstorm/run/gsgnn_lp/lp_infer_gnn.py
+++ b/python/graphstorm/run/gsgnn_lp/lp_infer_gnn.py
@@ -77,7 +77,8 @@ def main(config_args):
             batch_size=config.eval_batch_size,
             fixed_edge_dst_negative_field=config.eval_etypes_negative_dstnode,
             fanout=config.eval_fanout,
-            node_feats=config.node_feat_name)
+            node_feats=config.node_feat_name,
+            edge_feats=config.edge_feat_name)
     else:
         if config.eval_negative_sampler == BUILTIN_LP_UNIFORM_NEG_SAMPLER:
             test_dataloader_cls = GSgnnLinkPredictionTestDataLoader
@@ -92,7 +93,8 @@ def main(config_args):
             batch_size=config.eval_batch_size,
             num_negative_edges=config.num_negative_edges_eval,
             fanout=config.eval_fanout,
-            node_feats=config.node_feat_name)
+            node_feats=config.node_feat_name,
+            edge_feats=config.edge_feat_name)
     infer.infer(infer_data, dataloader,
                 save_embed_path=config.save_embed_path,
                 edge_mask_for_gnn_embeddings=None if config.no_validation else \

--- a/python/graphstorm/run/gsgnn_lp/lp_infer_lm.py
+++ b/python/graphstorm/run/gsgnn_lp/lp_infer_lm.py
@@ -71,7 +71,8 @@ def main(config_args):
             infer_data, infer_idxs,
             batch_size=config.eval_batch_size,
             fixed_edge_dst_negative_field=config.eval_etypes_negative_dstnode,
-            node_feats=config.node_feat_name)
+            node_feats=config.node_feat_name,
+            edge_feats=config.edge_feat_name)
     else:
         if config.eval_negative_sampler == BUILTIN_LP_UNIFORM_NEG_SAMPLER:
             test_dataloader_cls = GSgnnLinkPredictionTestDataLoader
@@ -85,7 +86,8 @@ def main(config_args):
         dataloader = test_dataloader_cls(infer_data, infer_idxs,
             batch_size=config.eval_batch_size,
             num_negative_edges=config.num_negative_edges_eval,
-            node_feats=config.node_feat_name)
+            node_feats=config.node_feat_name,
+            edge_feats=config.edge_feat_name)
     # Preparing input layer for training or inference.
     # The input layer can pre-compute node features in the preparing step if needed.
     # For example pre-compute all BERT embeddings

--- a/python/graphstorm/run/gsgnn_np/gsgnn_np.py
+++ b/python/graphstorm/run/gsgnn_np/gsgnn_np.py
@@ -173,8 +173,8 @@ def main(config_args):
         assert config.edge_feat_name is None, 'GraphStorm node prediction training command ' + \
             'uses full-graph inference by default to generate node embeddings at the end of ' + \
             'training. But the full-graph inference method does not support edge features ' + \
-            'in this version. Please set the \"save_embed_path\" to be empty or does not ' + \
-            'set this argument if you want to use edge features in training command.'
+            'in the current version. Please set the \"save_embed_path\" to none ' + \
+            ' if you want to use edge features in training command.'
         model = gs.create_builtin_node_gnn_model(train_data.g, config, train_task=False)
         best_model_path = trainer.get_best_model_path()
         # TODO(zhengda) the model path has to be in a shared filesystem.

--- a/python/graphstorm/run/gsgnn_np/gsgnn_np.py
+++ b/python/graphstorm/run/gsgnn_np/gsgnn_np.py
@@ -121,6 +121,7 @@ def main(config_args):
                                          batch_size=config.batch_size,
                                          train_task=True,
                                          node_feats=config.node_feat_name,
+                                         edge_feats=config.edge_feat_name,
                                          label_field=config.label_field,
                                          construct_feat_ntype=config.construct_feat_ntype,
                                          construct_feat_fanout=config.construct_feat_fanout)
@@ -133,6 +134,7 @@ def main(config_args):
                                              batch_size=config.eval_batch_size,
                                              train_task=False,
                                              node_feats=config.node_feat_name,
+                                             edge_feats=config.edge_feat_name,
                                              label_field=config.label_field,
                                              construct_feat_ntype=config.construct_feat_ntype,
                                              construct_feat_fanout=config.construct_feat_fanout)
@@ -141,6 +143,7 @@ def main(config_args):
                                               batch_size=config.eval_batch_size,
                                               train_task=False,
                                               node_feats=config.node_feat_name,
+                                              edge_feats=config.edge_feat_name,
                                               label_field=config.label_field,
                                               construct_feat_ntype=config.construct_feat_ntype,
                                               construct_feat_fanout=config.construct_feat_fanout)
@@ -167,6 +170,11 @@ def main(config_args):
                 grad_norm_type=config.grad_norm_type)
 
     if config.save_embed_path is not None:
+        assert config.edge_feat_name is None, 'GraphStorm node prediction training command ' + \
+            'uses full-graph inference by default to generate node embeddings at the end of ' + \
+            'training. But the full-graph inference method does not support edge features ' + \
+            'in this version. Please set the \"save_embed_path\" to be empty or does not ' + \
+            'set this argument if you want to use edge features in training command.'
         model = gs.create_builtin_node_gnn_model(train_data.g, config, train_task=False)
         best_model_path = trainer.get_best_model_path()
         # TODO(zhengda) the model path has to be in a shared filesystem.

--- a/python/graphstorm/run/gsgnn_np/np_infer_gnn.py
+++ b/python/graphstorm/run/gsgnn_np/np_infer_gnn.py
@@ -80,6 +80,7 @@ def main(config_args):
                                      batch_size=config.eval_batch_size,
                                      train_task=False,
                                      node_feats=config.node_feat_name,
+                                     edge_feats=config.edge_feat_name,
                                      label_field=config.label_field,
                                      construct_feat_ntype=config.construct_feat_ntype,
                                      construct_feat_fanout=config.construct_feat_fanout)

--- a/tests/end2end-tests/create_data.sh
+++ b/tests/end2end-tests/create_data.sh
@@ -183,6 +183,30 @@ python3 -m graphstorm.gconstruct.construct_graph \
 	--graph-name movie-lens-100k \
 	--add-reverse-edges
 
+# movielens with edge feature for node classification and edge classification in cpu and mgpu
+python3 -m graphstorm.gconstruct.construct_graph \
+	--conf-file $GS_HOME/tests/end2end-tests/data_gen/movielens_ef_nc_ec.json \
+	--num-processes 1 \
+	--output-dir movielen_100k_ef_nc_ec_train_val_1p_4t \
+	--graph-name movie-lens-100k \
+	--add-reverse-edges
+
+# movielens with edge feature for edge regression in cpu and mgpu
+python3 -m graphstorm.gconstruct.construct_graph \
+	--conf-file $GS_HOME/tests/end2end-tests/data_gen/movielens_ef_er.json \
+	--num-processes 1 \
+	--output-dir movielen_100k_ef_er_train_val_1p_4t \
+	--graph-name movie-lens-100k \
+	--add-reverse-edges
+
+# movielens with edge feature for link prediction in cpu and mgpu
+python3 -m graphstorm.gconstruct.construct_graph \
+	--conf-file $GS_HOME/tests/end2end-tests/data_gen/movielens_ef_lp.json \
+	--num-processes 1 \
+	--output-dir movielen_100k_ef_lp_train_val_1p_4t \
+	--graph-name movie-lens-100k \
+	--add-reverse-edges
+
 date
 
 echo 'Done'

--- a/tests/end2end-tests/data_gen/movielens_ef_er.json
+++ b/tests/end2end-tests/data_gen/movielens_ef_er.json
@@ -1,0 +1,54 @@
+{
+    "version": "gconstruct-v0.1",
+    "nodes": [
+            {
+                    "node_id_col":  "id",
+                    "node_type":    "user",
+                    "format":       {"name": "hdf5"},
+                    "files":        "/data/ml-100k/user.hdf5",
+                    "features":     [
+                           {
+                                   "feature_col":  "feat"
+                           }
+                    ]
+            },
+            {
+                    "node_id_col":  "id",
+                    "node_type":    "movie",
+                    "format":       {"name": "parquet"},
+                    "files":        "/data/ml-100k/movie.parquet",
+                    "features":     [
+                        {
+                                "feature_col":  "title",
+                                "transform":    {
+                                        "name": "bert_hf",
+                                        "bert_model": "bert-base-uncased",
+                                        "max_seq_length": 128
+                                }
+                        }
+                 ]
+            }
+    ],
+    "edges": [
+            {
+                    "source_id_col":    "src_id",
+                    "dest_id_col":      "dst_id",
+                    "relation":         ["user", "rating", "movie"],
+                    "format":           {"name": "parquet"},
+                    "files":        "/data/ml-100k/edges.parquet",
+                    "features":     [
+                           {
+                                   "feature_col":  "feat",
+                                   "feature_name": "feat"
+                           }
+                    ],
+                    "labels":	[
+                        {
+                            "label_col":	"rate",
+                            "task_type":	"regression",
+                            "split_pct":	[0.1, 0.1, 0.1]
+                        }
+                    ]
+            }
+    ]
+}

--- a/tests/end2end-tests/data_gen/movielens_ef_lp.json
+++ b/tests/end2end-tests/data_gen/movielens_ef_lp.json
@@ -1,0 +1,57 @@
+{
+    "version": "gconstruct-v0.1",
+    "nodes": [
+            {
+                    "node_id_col":  "id",
+                    "node_type":    "user",
+                    "format":       {"name": "hdf5"},
+                    "files":        "/data/ml-100k/user.hdf5",
+                    "features":     [
+                           {
+                                   "feature_col":  "feat"
+                           }
+                    ]
+            },
+            {
+                    "node_id_col":  "id",
+                    "node_type":    "movie",
+                    "format":       {"name": "parquet"},
+                    "files":        "/data/ml-100k/movie.parquet",
+                    "features":     [
+                        {
+                                "feature_col":  "title",
+                                "transform":    {
+                                        "name": "bert_hf",
+                                        "bert_model": "bert-base-uncased",
+                                        "max_seq_length": 16
+                                }
+                        }
+                 ]
+            }
+    ],
+    "edges": [
+            {
+                    "source_id_col":    "src_id",
+                    "dest_id_col":      "dst_id",
+                    "relation":         ["user", "rating", "movie"],
+                    "format":           {"name": "parquet"},
+                    "files":        "/data/ml-100k/edges.parquet",
+                    "labels":	[
+                        {
+                            "task_type":	"link_prediction",
+                            "split_pct":	[0.1, 0.1, 0.1]
+                        }
+                    ],
+                    "features":[
+                        {
+                                "feature_col": "rate",
+                                "feature_name": "rate"
+                        },
+                        {
+                                "feature_col":  "feat",
+                                "feature_name": "feat"
+                        }
+                    ]
+            }
+    ]
+}

--- a/tests/end2end-tests/data_gen/movielens_ef_nc_ec.json
+++ b/tests/end2end-tests/data_gen/movielens_ef_nc_ec.json
@@ -1,0 +1,61 @@
+{
+    "version": "gconstruct-v0.1",
+    "nodes": [
+            {
+                    "node_id_col":  "id",
+                    "node_type":    "user",
+                    "format":       {"name": "hdf5"},
+                    "files":        "/data/ml-100k/user.hdf5",
+                    "features":     [
+                           {
+                                   "feature_col":  "feat"
+                           }
+                    ]
+            },
+            {
+                    "node_id_col":  "id",
+                    "node_type":    "movie",
+                    "format":       {"name": "parquet"},
+                    "files":        "/data/ml-100k/movie.parquet",
+                    "features":     [
+                        {
+                                "feature_col":  "title",
+                                "transform":    {
+                                        "name": "bert_hf",
+                                        "bert_model": "bert-base-uncased",
+                                        "max_seq_length": 16
+                                }
+                        }
+                 ],
+                    "labels":	[
+                        {
+                            "label_col":	"label",
+                            "task_type":	"classification",
+                            "split_pct":	[0.8, 0.1, 0.1]
+                        }
+                    ]
+            }
+    ],
+    "edges": [
+            {
+                    "source_id_col":    "src_id",
+                    "dest_id_col":      "dst_id",
+                    "relation":         ["user", "rating", "movie"],
+                    "format":           {"name": "parquet"},
+                    "files":        "/data/ml-100k/edges.parquet",
+                    "features":     [
+                           {
+                                   "feature_col":  "feat",
+                                   "feature_name": "feat"
+                           }
+                    ],
+                    "labels":	[
+                        {
+                            "label_col":	"rate",
+                            "task_type":	"classification",
+                            "split_pct":	[0.1, 0.1, 0.1]
+                        }
+                    ]
+            }
+    ]
+}

--- a/tests/end2end-tests/graphstorm-ec/mgpu_test.sh
+++ b/tests/end2end-tests/graphstorm-ec/mgpu_test.sh
@@ -346,10 +346,16 @@ rm -fr /tmp/*
 echo "**************dataset: MovieLens: EC, RGCN layer: 1, node feat: fixed HF BERT, BERT nodes: movie, edge feat in message passing: user,rating,movie:feat inference: mini-batch"
 python3 -m graphstorm.run.gs_edge_classification --workspace $GS_HOME/training_scripts/gsgnn_ep/ --num-trainers $NUM_TRAINERS --num-servers 1 --num-samplers 0 --part-config /data/movielen_100k_ef_nc_ec_train_val_1p_4t/movie-lens-100k.json --ip-config ip_list.txt --ssh-port 2222 --cf ml_ec.yaml --num-classes 5 --node-feat-name movie:title user:feat --edge-feat-name user,rating,movie:feat --batch-size 64 --save-model-path /data/gsgnn_ec_ml_ef/model/ --save-model-frequency 5 --eval-frequency 3  --num-epochs 1 --logging-file /tmp/train_log.txt  --backend nccl
 
+error_and_exit $?
+
 python3 -m graphstorm.run.gs_edge_classification --inference --workspace $GS_HOME/inference_scripts/ep_infer/ --num-trainers $NUM_INFO_TRAINERS --num-servers 1 --num-samplers 0 --part-config /data/movielen_100k_ef_nc_ec_train_val_1p_4t/movie-lens-100k.json --ip-config ip_list.txt --ssh-port 2222 --cf ml_ec_infer.yaml --num-classes 5 --use-mini-batch-infer true --restore-model-path /data/gsgnn_ec_ml_ef/model/epoch-0/ --save-prediction-path /data/gsgnn_ec_ml_ef/prediction/ --logging-file /tmp/log.txt --preserve-input True --node-feat-name movie:title user:feat --edge-feat-name user,rating,movie:feat  --backend nccl
+
+error_and_exit $?
 
 ## Emb Gen
 python3 -m graphstorm.run.gs_gen_node_embedding --workspace $GS_HOME/training_scripts/gsgnn_ep/ --num-trainers $NUM_INFO_TRAINERS --num-servers 1 --num-samplers 0 --part-config /data/movielen_100k_ef_nc_ec_train_val_1p_4t/movie-lens-100k.json --ip-config ip_list.txt --ssh-port 2222 --cf ml_ec.yaml --num-classes 5 --node-feat-name movie:title user:feat --edge-feat-name user,rating,movie:feat --use-mini-batch-infer true --restore-model-path /data/gsgnn_ec_ml_ef/model/epoch-0/ --save-embed-path /data/gsgnn_ec_ml_ef/save-emb/ --logging-file /tmp/log.txt --logging-level debug  --backend nccl
+
+error_and_exit $?
 
 cnt=$(ls -l /data/gsgnn_ec_ml_ef/ | wc -l)
 if test $cnt != 4

--- a/tests/end2end-tests/graphstorm-ec/mgpu_test.sh
+++ b/tests/end2end-tests/graphstorm-ec/mgpu_test.sh
@@ -342,3 +342,22 @@ python3 -m graphstorm.run.gs_edge_classification --workspace $GS_HOME/training_s
 error_and_exit $?
 
 rm -fr /tmp/*
+
+echo "**************dataset: MovieLens: EC, RGCN layer: 1, node feat: fixed HF BERT, BERT nodes: movie, edge feat: user,rating,movie:feat inference: mini-batch"
+python3 -m graphstorm.run.gs_edge_classification --workspace $GS_HOME/training_scripts/gsgnn_ep/ --num-trainers $NUM_TRAINERS --num-servers 1 --num-samplers 0 --part-config /data/movielen_100k_ef_nc_ec_train_val_1p_4t/movie-lens-100k.json --ip-config ip_list.txt --ssh-port 2222 --cf ml_ec.yaml --num-classes 5 --node-feat-name movie:title user:feat --edge-feat-name user,rating,movie:feat --batch-size 64 --save-model-path /data/gsgnn_ec_ml_ef/model/ --save-model-frequency 5 --eval-frequency 3  --num-epochs 1 --logging-file /tmp/train_log.txt  --backend nccl
+
+python3 -m graphstorm.run.gs_edge_classification --inference --workspace $GS_HOME/inference_scripts/ep_infer/ --num-trainers $NUM_INFO_TRAINERS --num-servers 1 --num-samplers 0 --part-config /data/movielen_100k_ef_nc_ec_train_val_1p_4t/movie-lens-100k.json --ip-config ip_list.txt --ssh-port 2222 --cf ml_ec_infer.yaml --num-classes 5 --use-mini-batch-infer true --restore-model-path /data/gsgnn_ec_ml_ef/model/epoch-0/ --save-prediction-path /data/gsgnn_ec_ml_ef/prediction/ --logging-file /tmp/log.txt --preserve-input True --node-feat-name movie:title user:feat --edge-feat-name user,rating,movie:feat  --backend nccl
+
+## Emb Gen
+python3 -m graphstorm.run.gs_gen_node_embedding --workspace $GS_HOME/training_scripts/gsgnn_ep/ --num-trainers $NUM_INFO_TRAINERS --num-servers 1 --num-samplers 0 --part-config /data/movielen_100k_ef_nc_ec_train_val_1p_4t/movie-lens-100k.json --ip-config ip_list.txt --ssh-port 2222 --cf ml_ec.yaml --num-classes 5 --node-feat-name movie:title user:feat --edge-feat-name user,rating,movie:feat --use-mini-batch-infer true --restore-model-path /data/gsgnn_ec_ml_ef/model/epoch-0/ --save-embed-path /data/gsgnn_ec_ml_ef/save-emb/ --logging-file /tmp/log.txt --logging-level debug  --backend nccl
+
+cnt=$(ls -l /data/gsgnn_ec_ml_ef/ | wc -l)
+if test $cnt != 4
+then
+    echo "We save models, predictions, and embeddings."
+    exit -1
+fi
+
+rm -R /data/gsgnn_ec_ml_ef/
+
+rm -fr /tmp/*

--- a/tests/end2end-tests/graphstorm-ec/mgpu_test.sh
+++ b/tests/end2end-tests/graphstorm-ec/mgpu_test.sh
@@ -343,7 +343,7 @@ error_and_exit $?
 
 rm -fr /tmp/*
 
-echo "**************dataset: MovieLens: EC, RGCN layer: 1, node feat: fixed HF BERT, BERT nodes: movie, edge feat: user,rating,movie:feat inference: mini-batch"
+echo "**************dataset: MovieLens: EC, RGCN layer: 1, node feat: fixed HF BERT, BERT nodes: movie, edge feat in message passing: user,rating,movie:feat inference: mini-batch"
 python3 -m graphstorm.run.gs_edge_classification --workspace $GS_HOME/training_scripts/gsgnn_ep/ --num-trainers $NUM_TRAINERS --num-servers 1 --num-samplers 0 --part-config /data/movielen_100k_ef_nc_ec_train_val_1p_4t/movie-lens-100k.json --ip-config ip_list.txt --ssh-port 2222 --cf ml_ec.yaml --num-classes 5 --node-feat-name movie:title user:feat --edge-feat-name user,rating,movie:feat --batch-size 64 --save-model-path /data/gsgnn_ec_ml_ef/model/ --save-model-frequency 5 --eval-frequency 3  --num-epochs 1 --logging-file /tmp/train_log.txt  --backend nccl
 
 python3 -m graphstorm.run.gs_edge_classification --inference --workspace $GS_HOME/inference_scripts/ep_infer/ --num-trainers $NUM_INFO_TRAINERS --num-servers 1 --num-samplers 0 --part-config /data/movielen_100k_ef_nc_ec_train_val_1p_4t/movie-lens-100k.json --ip-config ip_list.txt --ssh-port 2222 --cf ml_ec_infer.yaml --num-classes 5 --use-mini-batch-infer true --restore-model-path /data/gsgnn_ec_ml_ef/model/epoch-0/ --save-prediction-path /data/gsgnn_ec_ml_ef/prediction/ --logging-file /tmp/log.txt --preserve-input True --node-feat-name movie:title user:feat --edge-feat-name user,rating,movie:feat  --backend nccl

--- a/tests/end2end-tests/graphstorm-er/test.sh
+++ b/tests/end2end-tests/graphstorm-er/test.sh
@@ -71,6 +71,25 @@ python3 -m graphstorm.run.gs_edge_regression --workspace $GS_HOME/training_scrip
 
 error_and_exit $?
 
+echo "**************dataset: MovieLens: ER, RGCN layer: 1, node feat: fixed HF BERT, BERT nodes: movie, edge feat: user,rating,movie:feat inference: mini-batch"
+python3 -m graphstorm.run.gs_edge_regression --workspace $GS_HOME/training_scripts/gsgnn_ep/ --num-trainers $NUM_TRAINERS --num-servers 1 --num-samplers 0 --part-config /data/movielen_100k_ef_er_train_val_1p_4t/movie-lens-100k.json --ip-config ip_list.txt --ssh-port 2222 --cf ml_er.yaml --node-feat-name movie:title user:feat --edge-feat-name user,rating,movie:feat --batch-size 64 --save-model-path /data/gsgnn_er_ml_ef/model/ --save-model-frequency 5 --eval-frequency 3  --num-epochs 1 --logging-file /tmp/train_log.txt
+
+python3 -m graphstorm.run.gs_edge_regression --inference --workspace $GS_HOME/inference_scripts/ep_infer/ --num-trainers $NUM_TRAINERS --num-servers 1 --num-samplers 0 --part-config /data/movielen_100k_ef_er_train_val_1p_4t/movie-lens-100k.json --ip-config ip_list.txt --ssh-port 2222 --cf ml_er_infer.yaml --use-mini-batch-infer true --restore-model-path /data/gsgnn_er_ml_ef/model/epoch-0/ --save-prediction-path /data/gsgnn_er_ml_ef/prediction/ --logging-file /tmp/log.txt --preserve-input True --node-feat-name movie:title user:feat --edge-feat-name user,rating,movie:feat
+
+## Emb Gen
+python3 -m graphstorm.run.gs_gen_node_embedding --workspace $GS_HOME/training_scripts/gsgnn_ep/ --num-trainers $NUM_TRAINERS --num-servers 1 --num-samplers 0 --part-config /data/movielen_100k_ef_er_train_val_1p_4t/movie-lens-100k.json --ip-config ip_list.txt --ssh-port 2222 --cf ml_er.yaml --node-feat-name movie:title user:feat --edge-feat-name user,rating,movie:feat --use-mini-batch-infer true --restore-model-path /data/gsgnn_er_ml_ef/model/epoch-0/ --save-embed-path /data/gsgnn_er_ml_ef/save-emb/ --logging-file /tmp/log.txt --logging-level debug
+
+cnt=$(ls -l /data/gsgnn_er_ml_ef/ | wc -l)
+if test $cnt != 4
+then
+    echo "We save models, predictions, and embeddings."
+    exit -1
+fi
+
+rm -R /data/gsgnn_er_ml_ef/
+
+rm -fr /tmp/*
+
 date
 
 echo 'Done'

--- a/tests/end2end-tests/graphstorm-er/test.sh
+++ b/tests/end2end-tests/graphstorm-er/test.sh
@@ -7,7 +7,8 @@ GS_HOME=$(pwd)
 NUM_TRAINERS=1
 export PYTHONPATH=$GS_HOME/python/
 cd $GS_HOME/training_scripts/gsgnn_ep
-
+echo "127.0.0.1" > ip_list.txt
+cd $GS_HOME/inference_scripts/ep_infer
 echo "127.0.0.1" > ip_list.txt
 
 cat ip_list.txt

--- a/tests/end2end-tests/graphstorm-er/test.sh
+++ b/tests/end2end-tests/graphstorm-er/test.sh
@@ -7,7 +7,6 @@ GS_HOME=$(pwd)
 NUM_TRAINERS=1
 export PYTHONPATH=$GS_HOME/python/
 cd $GS_HOME/training_scripts/gsgnn_ep
-echo "127.0.0.1" > ip_list.txt
 cd $GS_HOME/inference_scripts/ep_infer
 echo "127.0.0.1" > ip_list.txt
 

--- a/tests/end2end-tests/graphstorm-er/test.sh
+++ b/tests/end2end-tests/graphstorm-er/test.sh
@@ -7,6 +7,8 @@ GS_HOME=$(pwd)
 NUM_TRAINERS=1
 export PYTHONPATH=$GS_HOME/python/
 cd $GS_HOME/training_scripts/gsgnn_ep
+echo "127.0.0.1" > ip_list.txt
+
 cd $GS_HOME/inference_scripts/ep_infer
 echo "127.0.0.1" > ip_list.txt
 
@@ -74,10 +76,16 @@ error_and_exit $?
 echo "**************dataset: MovieLens: ER, RGCN layer: 1, node feat: fixed HF BERT, BERT nodes: movie, edge feat: user,rating,movie:feat inference: mini-batch"
 python3 -m graphstorm.run.gs_edge_regression --workspace $GS_HOME/training_scripts/gsgnn_ep/ --num-trainers $NUM_TRAINERS --num-servers 1 --num-samplers 0 --part-config /data/movielen_100k_ef_er_train_val_1p_4t/movie-lens-100k.json --ip-config ip_list.txt --ssh-port 2222 --cf ml_er.yaml --node-feat-name movie:title user:feat --edge-feat-name user,rating,movie:feat --batch-size 64 --save-model-path /data/gsgnn_er_ml_ef/model/ --save-model-frequency 5 --eval-frequency 3  --num-epochs 1 --logging-file /tmp/train_log.txt
 
+error_and_exit $?
+
 python3 -m graphstorm.run.gs_edge_regression --inference --workspace $GS_HOME/inference_scripts/ep_infer/ --num-trainers $NUM_TRAINERS --num-servers 1 --num-samplers 0 --part-config /data/movielen_100k_ef_er_train_val_1p_4t/movie-lens-100k.json --ip-config ip_list.txt --ssh-port 2222 --cf ml_er_infer.yaml --use-mini-batch-infer true --restore-model-path /data/gsgnn_er_ml_ef/model/epoch-0/ --save-prediction-path /data/gsgnn_er_ml_ef/prediction/ --logging-file /tmp/log.txt --preserve-input True --node-feat-name movie:title user:feat --edge-feat-name user,rating,movie:feat
+
+error_and_exit $?
 
 ## Emb Gen
 python3 -m graphstorm.run.gs_gen_node_embedding --workspace $GS_HOME/training_scripts/gsgnn_ep/ --num-trainers $NUM_TRAINERS --num-servers 1 --num-samplers 0 --part-config /data/movielen_100k_ef_er_train_val_1p_4t/movie-lens-100k.json --ip-config ip_list.txt --ssh-port 2222 --cf ml_er.yaml --node-feat-name movie:title user:feat --edge-feat-name user,rating,movie:feat --use-mini-batch-infer true --restore-model-path /data/gsgnn_er_ml_ef/model/epoch-0/ --save-embed-path /data/gsgnn_er_ml_ef/save-emb/ --logging-file /tmp/log.txt --logging-level debug
+
+error_and_exit $?
 
 cnt=$(ls -l /data/gsgnn_er_ml_ef/ | wc -l)
 if test $cnt != 4

--- a/tests/end2end-tests/graphstorm-lp/mgpu_test.sh
+++ b/tests/end2end-tests/graphstorm-lp/mgpu_test.sh
@@ -1052,3 +1052,21 @@ error_and_exit $?
 rm -fr /data/gsgnn_lp_ml_transe_l2/*
 
 rm -fr /tmp/*
+
+echo "**************dataset: MovieLens: LP, RGCN layer: 1, node feat: fixed HF BERT, BERT nodes: movie, edge feat: user,rating,movie:feat inference: mini-batch"
+python3 -m graphstorm.run.gs_link_prediction --workspace $GS_HOME/training_scripts/gsgnn_lp --num-trainers $NUM_TRAINERS --num-servers 1 --num-samplers 0 --part-config /data/movielen_100k_ef_lp_train_val_1p_4t/movie-lens-100k.json --ip-config ip_list.txt --ssh-port 2222 --cf ml_lp.yaml --num-epochs 1 --eval-frequency 30 --logging-file /tmp/train_log.txt --save-model-path /data/gsgnn_lp_ml_ef/model/  --save-model-frequency 50 --node-feat-name movie:title user:feat --edge-feat-name user,rating,movie:feat  --backend nccl
+
+
+## Emb Gen
+python3 -m graphstorm.run.gs_gen_node_embedding --workspace $GS_HOME/training_scripts/gsgnn_lp --num-trainers $NUM_INFO_TRAINERS --num-servers 1 --num-samplers 0 --part-config /data/movielen_100k_ef_lp_train_val_1p_4t/movie-lens-100k.json --ip-config ip_list.txt --ssh-port 2222  --cf ml_lp.yaml --node-feat-name movie:title user:feat --edge-feat-name user,rating,movie:feat --restore-model-path /data/gsgnn_lp_ml_ef/model/epoch-0/ --save-embed-path /data/gsgnn_lp_ml_ef/save-emb/ --logging-file /tmp/log.txt --logging-level debug  --backend nccl
+
+cnt=$(ls -l /data/gsgnn_lp_ml_ef/ | wc -l)
+if test $cnt != 3
+then
+    echo "We save both models and embeddings."
+    exit -1
+fi
+
+rm -R /data/gsgnn_lp_ml_ef/
+
+rm -fr /tmp/*

--- a/tests/end2end-tests/graphstorm-lp/mgpu_test.sh
+++ b/tests/end2end-tests/graphstorm-lp/mgpu_test.sh
@@ -1056,9 +1056,12 @@ rm -fr /tmp/*
 echo "**************dataset: MovieLens: LP, RGCN layer: 1, node feat: fixed HF BERT, BERT nodes: movie, edge feat: user,rating,movie:feat inference: mini-batch"
 python3 -m graphstorm.run.gs_link_prediction --workspace $GS_HOME/training_scripts/gsgnn_lp --num-trainers $NUM_TRAINERS --num-servers 1 --num-samplers 0 --part-config /data/movielen_100k_ef_lp_train_val_1p_4t/movie-lens-100k.json --ip-config ip_list.txt --ssh-port 2222 --cf ml_lp.yaml --num-epochs 1 --eval-frequency 30 --logging-file /tmp/train_log.txt --save-model-path /data/gsgnn_lp_ml_ef/model/  --save-model-frequency 50 --node-feat-name movie:title user:feat --edge-feat-name user,rating,movie:feat  --backend nccl
 
+error_and_exit $?
 
 ## Emb Gen
 python3 -m graphstorm.run.gs_gen_node_embedding --workspace $GS_HOME/training_scripts/gsgnn_lp --num-trainers $NUM_INFO_TRAINERS --num-servers 1 --num-samplers 0 --part-config /data/movielen_100k_ef_lp_train_val_1p_4t/movie-lens-100k.json --ip-config ip_list.txt --ssh-port 2222  --cf ml_lp.yaml --node-feat-name movie:title user:feat --edge-feat-name user,rating,movie:feat --restore-model-path /data/gsgnn_lp_ml_ef/model/epoch-0/ --save-embed-path /data/gsgnn_lp_ml_ef/save-emb/ --logging-file /tmp/log.txt --logging-level debug  --backend nccl
+
+error_and_exit $?
 
 cnt=$(ls -l /data/gsgnn_lp_ml_ef/ | wc -l)
 if test $cnt != 3

--- a/tests/end2end-tests/graphstorm-nc/mgpu_test.sh
+++ b/tests/end2end-tests/graphstorm-nc/mgpu_test.sh
@@ -624,3 +624,28 @@ python3 -m graphstorm.run.gs_node_classification --workspace $GS_HOME/training_s
 error_and_exit $?
 
 rm -fr /tmp/*
+
+echo "**************dataset: MovieLens: NC, RGCN layer: 1, node feat: fixed HF BERT, BERT nodes: movie, edge feat: user,rating,movie:feat inference: mini-batch"
+python3 -m graphstorm.run.gs_node_classification --workspace $GS_HOME/training_scripts/gsgnn_np/ --num-trainers $NUM_TRAINERS --num-servers 1 --num-samplers 0 --part-config /data/movielen_100k_ef_nc_ec_train_val_1p_4t/movie-lens-100k.json --ip-config ip_list.txt --ssh-port 2222 --cf ml_nc.yaml --node-feat-name movie:title user:feat --edge-feat-name user,rating,movie:feat --batch-size 64 --save-model-path /data/gsgnn_nc_ml_ef/model/ --save-model-frequency 5 --eval-frequency 3  --num-epochs 1 --logging-file /tmp/train_log.txt --backend nccl 
+
+error_and_exit $?
+
+python3 -m graphstorm.run.gs_node_classification --inference --workspace $GS_HOME/inference_scripts/np_infer/ --num-trainers $NUM_INFERs --num-servers 1 --num-samplers 0 --part-config /data/movielen_100k_ef_nc_ec_train_val_1p_4t/movie-lens-100k.json --ip-config ip_list.txt --ssh-port 2222 --cf ml_nc_infer.yaml --use-mini-batch-infer true --restore-model-path /data/gsgnn_nc_ml_ef/model/epoch-0/ --save-prediction-path /data/gsgnn_nc_ml_ef/prediction/ --logging-file /tmp/log.txt --preserve-input True --node-feat-name movie:title user:feat --edge-feat-name user,rating,movie:feat --backend nccl 
+
+error_and_exit $?
+
+## Emb Gen
+python3 -m graphstorm.run.gs_gen_node_embedding --workspace $GS_HOME/training_scripts/gsgnn_np/ --num-trainers $NUM_INFERs --num-servers 1 --num-samplers 0 --part-config /data/movielen_100k_ef_nc_ec_train_val_1p_4t/movie-lens-100k.json --ip-config ip_list.txt --ssh-port 2222 --cf ml_nc.yaml --use-mini-batch-infer true --restore-model-path /data/gsgnn_nc_ml_ef/model/epoch-0/ --save-embed-path /data/gsgnn_nc_ml_ef/save-emb/ --logging-file /tmp/log.txt --logging-level debug --preserve-input True --node-feat-name movie:title user:feat --edge-feat-name user,rating,movie:feat --backend nccl 
+
+error_and_exit $?
+
+cnt=$(ls -l /data/gsgnn_nc_ml_ef/ | wc -l)
+if test $cnt != 4
+then
+    echo "We save models, predictions, and embeddings."
+    exit -1
+fi
+
+rm -R /data/gsgnn_nc_ml_ef/
+
+rm -fr /tmp/*


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This PR is the last one to configure run main function in NP, EP, and LP. The major contents include:
1. Add `edge_feat_name` argument to Node, Edge, and LinkPrediction Dataloaders in NP, EP, and LP main() funcitons.
2. Add end-to-end test cases for NC, EC, ER, and LP.
3. Modify the `acm_data.py` example data generation code to demo using edge features.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
