### PR TITLE
Add build scripts for single-command build and push for local and sagemaker GS images

### DIFF
--- a/docker/build_graphstorm_image.sh
+++ b/docker/build_graphstorm_image.sh
@@ -109,7 +109,7 @@ fi
 # Print build parameters
 msg "Execution parameters:"
 msg "- EXECUTION ENVIRONMENT: ${EXEC_ENV}"
-msg "- DEVICE_TYPE: ${EXEC_ENV}"
+msg "- DEVICE_TYPE: ${DEVICE_TYPE}"
 msg "- GSF_HOME: ${GSF_HOME}"
 msg "- IMAGE_NAME: ${IMAGE_NAME}"
 msg "- SUFFIX: ${SUFFIX}"

--- a/docker/build_graphstorm_image.sh
+++ b/docker/build_graphstorm_image.sh
@@ -47,7 +47,6 @@ parse_params() {
     DEVICE_TYPE="gpu"
     GSF_HOME="${SCRIPT_DIR}/../"
     IMAGE_NAME='graphstorm'
-    USE_PARMETIS=false
     BUILD_DIR='/tmp/graphstorm-build/docker'
     SUFFIX=""
 
@@ -114,7 +113,6 @@ msg "- DEVICE_TYPE: ${EXEC_ENV}"
 msg "- GSF_HOME: ${GSF_HOME}"
 msg "- IMAGE_NAME: ${IMAGE_NAME}"
 msg "- SUFFIX: ${SUFFIX}"
-msg "- USE_PARMETIS: ${USE_PARMETIS}"
 
 # Prepare Docker build directory
 if [[ -d ${BUILD_DIR} ]]; then

--- a/docker/build_graphstorm_image.sh
+++ b/docker/build_graphstorm_image.sh
@@ -164,7 +164,8 @@ if [[ $EXEC_ENV = "local" ]]; then
 
 elif [[ $EXEC_ENV = "sagemaker" ]]; then
     DOCKERFILE="${GSF_HOME}/docker/sagemaker/Dockerfile.sm"
-    cp -r "${GSF_HOME}/python" "$CODE_DIR/graphstorm/"
+    rsync -a --exclude="*.pyc" --exclude="*.pyo" --exclude="*.pyd" \
+        "${GSF_HOME}/python" "$CODE_DIR/graphstorm/"
     cp -r "${GSF_HOME}/sagemaker" "$CODE_DIR/graphstorm/sagemaker"
     cp -r "${GSF_HOME}/docker/sagemaker/build_artifacts" "$BUILD_DIR"
 

--- a/docker/build_graphstorm_image.sh
+++ b/docker/build_graphstorm_image.sh
@@ -1,0 +1,178 @@
+#!/usr/bin/env bash
+
+set -Eeuo pipefail
+trap cleanup SIGINT SIGTERM ERR EXIT
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd -P)
+
+usage() {
+    cat <<EOF
+Usage: $(basename "${BASH_SOURCE[0]}") [-h] [-x] -e sagemaker
+
+Builds the GraphStorm training/inference Docker images.
+
+Available options:
+
+-h, --help          Print this help and exit
+-x, --verbose       Print script debug info (set -x)
+-e, --environment   Image execution environment. Must be one of 'local' or 'sagemaker'. Required.
+-p, --path          Path to graphstorm root directory, default is one level above this script's location.
+-i, --image         Docker image name, default is 'graphstorm-\${environment}'.
+-v, --version       Docker version tag, default is the library's current version
+-s, --suffix        Suffix for the image tag, can be used to push custom image tags. Default is "".
+-b, --build         Docker build directory prefix, default is '/tmp/'.
+--use-parmetis      Include dependencies to be able to run ParMETIS distributed partitioning.
+
+Example:
+
+    bash $(basename "${BASH_SOURCE[0]}") -e sagemaker -v 0.4.0 --device cpu
+    # Will build an image tagged as 'graphstorm-sagemaker:0.4.0-cpu'
+
+EOF
+    exit
+}
+
+msg() {
+    echo >&2 -e "${1-}"
+}
+
+die() {
+    local msg=$1
+    local code=${2-1} # default exit status 1
+    msg "$msg"
+    exit "$code"
+}
+
+parse_params() {
+    # default values of variables set from params
+    GSF_HOME="${SCRIPT_DIR}/../"
+    IMAGE_NAME='graphstorm'
+    VERSION=$(grep "$GSF_HOME/python/graphstorm/__init__.py" __version__ | cut -d " " -f 3)
+    USE_PARMETIS=false
+    BUILD_DIR='/tmp/graphstorm-build'
+    SUFFIX=""
+
+    while :; do
+        case "${1-}" in
+        -h | --help) usage ;;
+        -x | --verbose) set -x ;;
+        -e | --environment)
+            EXEC_ENV="${2-}"
+            shift
+            ;;
+        -p | --path)
+            GSF_HOME="${2-}"
+            shift
+            ;;
+        -b | --build)
+            BUILD_DIR="${2-}"
+            shift
+            ;;
+        -i | --image)
+            IMAGE_NAME="${2-}"
+            shift
+            ;;
+        -v | --version)
+            VERSION="${2-}"
+            shift
+            ;;
+        -s | --suffix)
+            SUFFIX="${2-}"
+            shift
+            ;;
+        --use-parmetis)
+            USE_PARMETIS=true
+            shift
+            ;;
+        -?*) die "Unknown option: $1" ;;
+        *) break ;;
+        esac
+        shift
+    done
+
+    # check required params and arguments
+    [[ -z "${EXEC_ENV-}" ]] && die "Missing required parameter: -e/--environment [local|sagemaker]"
+
+    return 0
+}
+
+cleanup() {
+    trap - SIGINT SIGTERM ERR EXIT
+    # script cleanup here
+    if [[ ${BUILD_DIR} ]]; then
+        rm -rf "${BUILD_DIR}/docker/code"
+    fi
+}
+
+parse_params "$@"
+
+if [[ ${EXEC_ENV} == "local" || ${EXEC_ENV} == "sagemaker" ]]; then
+    : # Do nothing
+else
+    die "--environment parameter needs to be one of 'local', '' or 'sagemaker', got ${EXEC_ENV}"
+fi
+
+# Print build parameters
+msg "Execution parameters:"
+msg "- EXECUTION ENVIRONMENT: ${EXEC_ENV}"
+msg "- GSF_HOME: ${GSF_HOME}"
+msg "- IMAGE_NAME: ${IMAGE_NAME}"
+msg "- VERSION: ${VERSION}"
+msg "- SUFFIX: ${SUFFIX}"
+msg "- USE_PARMETIS: ${USE_PARMETIS}"
+
+# Prepare Docker build directory
+rm -rf "${BUILD_DIR}/docker/code"
+mkdir -p "${BUILD_DIR}/docker/code"
+
+# Set image name
+DOCKER_FULLNAME="${IMAGE_NAME}-${EXEC_ENV}:${VERSION}-${ARCH}${SUFFIX}"
+
+# Login to ECR to be able to pull source SageMaker or public.ecr.aws image
+msg "Authenticating to public ECR registry"
+if [[ ${EXEC_ENV} == "sagemaker" ]]; then
+    aws ecr get-login-password --region us-east-1 \
+        | docker login --username AWS --password-stdin 763104351884.dkr.ecr.us-east-1.amazonaws.com
+else
+    # Using local image, login to public ECR
+    aws ecr-public get-login-password --region us-east-1 |
+        docker login --username AWS --password-stdin public.ecr.aws
+fi
+
+# Copy scripts and tools codes to the docker folder
+mkdir -p $GSF_HOME"/docker/code"
+
+cp -r $GSF_HOME"/python" $GSF_HOME"/docker/code/python"
+cp -r $GSF_HOME"/examples" $GSF_HOME"/docker/code/examples"
+cp -r $GSF_HOME"/inference_scripts" $GSF_HOME"/docker/code/inference_scripts"
+cp -r $GSF_HOME"/tools" $GSF_HOME"/docker/code/tools"
+cp -r $GSF_HOME"/training_scripts" $GSF_HOME"/docker/code/training_scripts"
+
+DOCKER_FULLNAME="${IMAGE_NAME}:${TAG}-${DEVICE_TYPE}"
+
+
+if [[ $EXEC_ENV = "local" ]]; then
+    cp $SCRIPT_DIR"/local/fetch_and_run.sh" $GSF_HOME"/docker/code/"
+    DOCKERFILE="${GSF_HOME}/docker/local/Dockerfile.local"
+
+    if [[ $DEVICE_TYPE = "gpu" ]]; then
+        SOURCE_IMAGE="nvidia/cuda:12.1.1-runtime-ubuntu22.04"
+    else
+        SOURCE_IMAGE="public.ecr.aws/ubuntu/ubuntu:22.04_stable"
+    fi
+elif [[ $EXEC_ENV = "sagemaker" ]]; then
+    DOCKERFILE="${GSF_HOME}/docker/sagemaker/Dockerfile.sm"
+    if [[ $DEVICE_TYPE = "gpu" ]]; then
+        SOURCE_IMAGE="763104351884.dkr.ecr.us-east-1.amazonaws.com/pytorch-training:2.3.0-gpu-py311-cu121-ubuntu20.04-sagemaker"
+    elif [[ $DEVICE_TYPE = "cpu" ]]; then
+        SOURCE_IMAGE="763104351884.dkr.ecr.us-east-1.amazonaws.com/pytorch-training:2.3.0-cpu-py311-ubuntu20.04-sagemaker"
+    fi
+fi
+
+# Use Buildkit to avoid pulling both CPU and GPU images
+echo "Building Docker image: ${DOCKER_FULLNAME}"
+DOCKER_BUILDKIT=1 docker build \
+    --build-arg DEVICE=$DEVICE_TYPE \
+    --build-arg SOURCE=${SOURCE_IMAGE} \
+    --build-arg USE_PARMETIS=${USE_PARMETIS} \
+    -f "$DOCKERFILE" . -t "$DOCKER_FULLNAME"

--- a/docker/parmetis/Dockerfile.parmetis
+++ b/docker/parmetis/Dockerfile.parmetis
@@ -108,4 +108,16 @@ RUN mkdir -p ${SSHDIR} \
 
 EXPOSE ${SSH_PORT}
 
+COPY code/fetch_and_run.sh /graphstorm/fetch_and_run.sh
+
+RUN apt update && apt install -y --no-install-recommends \
+    curl \
+    unzip
+
+# Install aws-cli
+RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip" \
+    && unzip awscliv2.zip \
+    && ./aws/install
+
+
 CMD ["/usr/sbin/sshd", "-D"]

--- a/docker/push_graphstorm_image.sh
+++ b/docker/push_graphstorm_image.sh
@@ -2,6 +2,8 @@
 set -Eeuo pipefail
 trap cleanup SIGINT SIGTERM ERR EXIT
 
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd -P)
+
 usage() {
     cat <<EOF
 Usage: $(basename "${BASH_SOURCE[0]}") [-h] [-x] -e/--environment [sagemaker|local] [--region ...] [--account ...]
@@ -104,7 +106,7 @@ else
 fi
 
 TAG="${EXEC_ENV}-${DEVICE_TYPE}${SUFFIX}"
-LATEST_TAG="${EXEC_ENV}-${DEVICE}-latest"
+LATEST_TAG="${EXEC_ENV}-${DEVICE_TYPE}-latest"
 IMAGE="${IMAGE_NAME}"
 
 msg "Execution parameters: "
@@ -116,7 +118,6 @@ msg "- REGION: ${REGION}"
 msg "- ACCOUNT: ${ACCOUNT}"
 
 FULLNAME="${ACCOUNT}.dkr.ecr.${REGION}.amazonaws.com/${IMAGE}:${TAG}"
-LATEST_FULLNAME="${ACCOUNT}.dkr.ecr.${REGION}.amazonaws.com/${IMAGE}:${LATEST_TAG}"
 
 # If the repository doesn't exist in ECR, create it.
 echo "Getting or creating container repository: ${IMAGE}"
@@ -146,8 +147,3 @@ msg "Pushing image to ${FULLNAME}"
 docker tag "${IMAGE}:${TAG}" "${FULLNAME}"
 
 docker push "${FULLNAME}"
-
-if [ "${VERSION}" = "${LATEST_VERSION}" ]; then
-    docker tag "${IMAGE}:${TAG}" "${LATEST_FULLNAME}"
-    docker push "${LATEST_FULLNAME}"
-fi

--- a/docker/push_graphstorm_image.sh
+++ b/docker/push_graphstorm_image.sh
@@ -2,8 +2,6 @@
 set -Eeuo pipefail
 trap cleanup SIGINT SIGTERM ERR EXIT
 
-SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd -P)
-
 usage() {
     cat <<EOF
 Usage: $(basename "${BASH_SOURCE[0]}") [-h] [-x] -e/--environment [sagemaker|local] [--region ...] [--account ...]
@@ -44,7 +42,6 @@ die() {
 parse_params() {
     # default values of variables set from params
     DEVICE_TYPE="gpu"
-    GSF_HOME="${SCRIPT_DIR}/../"
     IMAGE_NAME='graphstorm'
     SUFFIX=""
     REGION=$(aws configure get region) || REGION=""
@@ -55,7 +52,6 @@ parse_params() {
         case "${1-}" in
         -h | --help) usage ;;
         -x | --verbose) set -x ;;
-        --no-color) NO_COLOR=1 ;;
         -e | --environment)
             EXEC_ENV="${2-}"
             shift
@@ -106,7 +102,6 @@ else
 fi
 
 TAG="${EXEC_ENV}-${DEVICE_TYPE}${SUFFIX}"
-LATEST_TAG="${EXEC_ENV}-${DEVICE_TYPE}-latest"
 IMAGE="${IMAGE_NAME}"
 
 msg "Execution parameters: "

--- a/docker/push_graphstorm_image.sh
+++ b/docker/push_graphstorm_image.sh
@@ -1,0 +1,134 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+trap cleanup SIGINT SIGTERM ERR EXIT
+
+usage() {
+    cat <<EOF
+Usage: $(basename "${BASH_SOURCE[0]}") [-h] [-x] [--image ...] [--version ...] [--region ...] [--account ...]
+
+Pushes GSProcessing image to ECR.
+
+Available options:
+
+-h, --help          Print this help and exit
+-x, --verbose       Print script debug info (set -x)
+-e, --environment   Image execution environment. Must be one of 'local' or 'sagemaker'. Required.
+-i, --image         Docker image name, default is 'graphstorm-\${environment}'.
+-v, --version       Docker version tag, default is the library's current version
+-s, --suffix        Suffix for the image tag, can be used to push custom image tags. Default is "".
+-r, --region        AWS Region to which we'll push the image. By default will get from aws-cli configuration.
+-a, --account       AWS Account ID. By default will get from aws-cli configuration.
+EOF
+    exit
+}
+
+msg() {
+    echo >&2 -e "${1-}"
+}
+
+die() {
+    local msg=$1
+    local code=${2-1} # default exit status 1
+    msg "$msg"
+    exit "$code"
+}
+
+parse_params() {
+    # default values of variables set from params
+    GSF_HOME="${SCRIPT_DIR}/../"
+    IMAGE='graphstorm'
+    VERSION=$(grep "$GSF_HOME/python/graphstorm/__init__.py" __version__ | cut -d " " -f 3)
+    SUFFIX=""
+    LATEST_VERSION=${VERSION}
+    REGION=$(aws configure get region) || REGION=""
+    REGION=${REGION:-us-east=1}
+    ACCOUNT=$(aws sts get-caller-identity --query Account --output text)
+
+    while :; do
+        case "${1-}" in
+        -h | --help) usage ;;
+        -x | --verbose) set -x ;;
+        --no-color) NO_COLOR=1 ;;
+        -e | --environment)
+            EXEC_ENV="${2-}"
+            shift
+            ;;
+        -i | --image)
+            IMAGE="${2-}"
+            shift
+            ;;
+        -v | --version)
+            VERSION="${2-}"
+            shift
+            ;;
+        -s | --suffix)
+            SUFFIX="${2-}"
+            shift
+            ;;
+        -r | --region)
+            REGION="${2-}"
+            shift
+            ;;
+        -a | --account)
+            ACCOUNT="${2-}"
+            shift
+            ;;
+        -?*) die "Unknown option: $1" ;;
+        *) break ;;
+        esac
+        shift
+    done
+
+    [[ -z "${EXEC_ENV-}" ]] && die "Missing required parameter: -e/--environment [local|sagemaker]"
+
+    return 0
+}
+
+cleanup() {
+    trap - SIGINT SIGTERM ERR EXIT
+    # script cleanup here
+}
+
+parse_params "${@}"
+
+if [[ ${EXEC_ENV} == "sagemaker" || ${EXEC_ENV} == "local" ]]; then
+    : # Do nothing
+else
+    die "--environment parameter needs to be one of 'sagemaker', or 'local' got ${EXEC_ENV}"
+fi
+
+TAG="${VERSION}-${ARCH}${SUFFIX}"
+LATEST_TAG="latest-${ARCH}${SUFFIX}"
+IMAGE_WITH_ENV="${IMAGE}-${EXEC_ENV}"
+
+msg "Execution parameters: "
+msg "- ENVIRONMENT: ${EXEC_ENV}"
+msg "- IMAGE: ${IMAGE}"
+msg "- TAG: ${TAG}"
+msg "- REGION: ${REGION}"
+msg "- ACCOUNT: ${ACCOUNT}"
+
+FULLNAME="${ACCOUNT}.dkr.ecr.${REGION}.amazonaws.com/${IMAGE_WITH_ENV}:${TAG}"
+LATEST_FULLNAME="${ACCOUNT}.dkr.ecr.${REGION}.amazonaws.com/${IMAGE_WITH_ENV}:${LATEST_TAG}"
+
+# If the repository doesn't exist in ECR, create it.
+echo "Getting or creating container repository: ${IMAGE_WITH_ENV}"
+if ! eval aws ecr describe-repositories --repository-names "${IMAGE_WITH_ENV}" --region ${REGION} >/dev/null 2>&1; then
+    echo >&2 "WARNING: ECR repository ${IMAGE_WITH_ENV} does not exist in region ${REGION}. Creating..."
+    aws ecr create-repository --repository-name "${IMAGE_WITH_ENV}" --region ${REGION} >/dev/null
+fi
+
+echo "Logging into ECR with local credentials"
+aws ecr get-login-password --region ${REGION} |
+    docker login --username AWS --password-stdin ${ACCOUNT}.dkr.ecr.${REGION}.amazonaws.com
+
+echo "Pushing image to ${FULLNAME}"
+
+docker tag ${IMAGE_WITH_ENV}:${TAG} ${FULLNAME}
+
+docker push ${FULLNAME}
+
+if [ ${VERSION} = ${LATEST_VERSION} ]; then
+    docker tag ${IMAGE_WITH_ENV}:${TAG} ${LATEST_FULLNAME}
+    docker push ${LATEST_FULLNAME}
+fi

--- a/docker/sagemaker/Dockerfile.sm
+++ b/docker/sagemaker/Dockerfile.sm
@@ -1,11 +1,23 @@
 # Docker file for building a docker image for running GraphStorm code on Amazon SageMaker
+# Note: Distributed graph partition will use another docker image which will come soon.
+
 ARG DEVICE=gpu
-ARG SOURCE
-ARG USE_PARMETIS=false
-
-FROM ${SOURCE} as base
-
 ARG DGL_VERSION=2.3.0
+ARG SOURCE
+
+FROM ${SOURCE:-763104351884.dkr.ecr.us-east-1.amazonaws.com/pytorch-training:2.3.0-gpu-py311-cu121-ubuntu20.04-sagemaker} as branch-gpu
+ENV dev_type=GPU
+ARG DGL_VERSION
+# Install DGL GPU version
+RUN pip3 install dgl==${DGL_VERSION}+cu121 -f https://data.dgl.ai/wheels/torch-2.3/cu121/repo.html && rm -rf /root/.cache
+
+FROM ${SOURCE:-763104351884.dkr.ecr.us-east-1.amazonaws.com/pytorch-training:2.3.0-cpu-py311-ubuntu20.04-sagemaker} as branch-cpu
+ENV dev_type=CPU
+ARG DGL_VERSION
+# Install DGL CPU version
+RUN pip3 install dgl==${DGL_VERSION} -f https://data.dgl.ai/wheels/torch-2.3/repo.html && rm -rf /root/.cache
+
+FROM branch-${DEVICE} AS final
 
 LABEL maintainer="Amazon AI Graph ML team"
 
@@ -30,18 +42,6 @@ RUN apt-get update; apt-get install -y --no-install-recommends libopenmpi-dev \
 # Copy workaround script for incorrect hostname
 COPY build_artifacts/changehostname.c /opt/ml/code/
 COPY build_artifacts/start_with_right_hostname.sh /usr/local/bin/start_with_right_hostname.sh
-
-FROM base as base-cpu
-
-# Install DGL CPU version
-RUN pip3 install dgl==${DGL_VERSION} -f https://data.dgl.ai/wheels/torch-2.3/repo.html && rm -rf /root/.cache
-
-FROM base as base-gpu
-
-# Install DGL GPU version
-RUN pip3 install dgl==${DGL_VERSION}+cu121 -f https://data.dgl.ai/wheels/torch-2.3/cu121/repo.html && rm -rf /root/.cache
-
-FROM base-${DEVICE} AS runtime
 
 # /opt/ml and all subdirectories are utilized by SageMaker, we use the /code subdirectory to store our user code.
 # TODO(xiangsx): change to pip install when PIP package is available

--- a/docker/sagemaker/Dockerfile.sm
+++ b/docker/sagemaker/Dockerfile.sm
@@ -1,22 +1,11 @@
 # Docker file for building a docker image for running GraphStorm code on Amazon SageMaker
-# Note: Distributed graph partition will use another docker image which will come soon.
-
 ARG DEVICE=gpu
+ARG SOURCE
+ARG USE_PARMETIS=false
+
+FROM ${SOURCE} as base
+
 ARG DGL_VERSION=2.3.0
-
-FROM 763104351884.dkr.ecr.us-east-1.amazonaws.com/pytorch-training:2.3.0-gpu-py311-cu121-ubuntu20.04-sagemaker as branch-gpu
-ENV dev_type=GPU
-ARG DGL_VERSION
-# Install DGL GPU version
-RUN pip3 install dgl==${DGL_VERSION}+cu121 -f https://data.dgl.ai/wheels/torch-2.3/cu121/repo.html && rm -rf /root/.cache
-
-FROM 763104351884.dkr.ecr.us-east-1.amazonaws.com/pytorch-training:2.3.0-cpu-py311-ubuntu20.04-sagemaker as branch-cpu
-ENV dev_type=CPU
-ARG DGL_VERSION
-# Install DGL CPU version
-RUN pip3 install dgl==${DGL_VERSION} -f https://data.dgl.ai/wheels/torch-2.3/repo.html && rm -rf /root/.cache
-
-FROM branch-${DEVICE} AS final
 
 LABEL maintainer="Amazon AI Graph ML team"
 
@@ -41,6 +30,18 @@ RUN apt-get update; apt-get install -y --no-install-recommends libopenmpi-dev \
 # Copy workaround script for incorrect hostname
 COPY build_artifacts/changehostname.c /opt/ml/code/
 COPY build_artifacts/start_with_right_hostname.sh /usr/local/bin/start_with_right_hostname.sh
+
+FROM base as base-cpu
+
+# Install DGL CPU version
+RUN pip3 install dgl==${DGL_VERSION} -f https://data.dgl.ai/wheels/torch-2.3/repo.html && rm -rf /root/.cache
+
+FROM base as base-gpu
+
+# Install DGL GPU version
+RUN pip3 install dgl==${DGL_VERSION}+cu121 -f https://data.dgl.ai/wheels/torch-2.3/cu121/repo.html && rm -rf /root/.cache
+
+FROM base-${DEVICE} AS runtime
 
 # /opt/ml and all subdirectories are utilized by SageMaker, we use the /code subdirectory to store our user code.
 # TODO(xiangsx): change to pip install when PIP package is available

--- a/docs/source/cli/model-training-inference/distributed/sagemaker.rst
+++ b/docs/source/cli/model-training-inference/distributed/sagemaker.rst
@@ -444,7 +444,7 @@ To save computing resources, users can run the below command to clean up the Doc
 Legacy image building instructions
 ``````````````````````````````````
 
-Since GraphStorm version 0.4.0 we provide new build scripts to facilitate easier image building
+Since GraphStorm 0.4.0 we provide new build scripts to facilitate easier image building
 and pushing to ECR. In this section we provide the instructions for the legacy scripts.
 These scripts will be deprecated and no longer updated in future versions of GraphStorm.
 

--- a/docs/source/cli/model-training-inference/distributed/sagemaker.rst
+++ b/docs/source/cli/model-training-inference/distributed/sagemaker.rst
@@ -21,73 +21,20 @@ GraphStorm uses SageMaker's **BYOC** (Bring Your Own Container) mode. Therefore,
 
 .. _build_sagemaker_docker:
 
-Step 1: Build a SageMaker-compatible Docker image
-...................................................
+Building and pushing a SageMaker uses the same scripts as for building a local image,
+described in :ref:`GraphStorm Docker build instructions <_build_docker>`.
 
-.. note::
-    * Please make sure your account has access key (AK) and security access key (SK) configured to authenticate accesses to AWS services.
-    * For more details of Amazon ECR operation via CLI, users can refer to the `Using Amazon ECR with the AWS CLI document <https://docs.aws.amazon.com/AmazonECR/latest/userguide/getting-started-cli.html>`_.
-
-First, in a Linux machine, configure a Docker environment by following the `Docker documentation <https://docs.docker.com/get-docker/>`_ suggestions.
-
-In order to use the SageMaker base Docker image, users need to use the following command to authenticate to pull SageMaker images.
+In short you can run the following:
 
 .. code-block:: bash
 
-    aws ecr get-login-password --region us-east-1 | docker login --username AWS --password-stdin 763104351884.dkr.ecr.us-east-1.amazonaws.com
+    cd graphstorm/
+    bash docker/build_graphstorm_image.sh --environment sagemaker
+    bash docker/push_graphstorm_image.sh --environment sagemaker --region "us-east-1" --account "123456789012"
+    # Will push an image to '123456789012.dkr.ecr.us-east-1.amazonaws.com/graphstorm:sagemaker-gpu'
 
-Then, clone GraphStorm source code, and build a GraphStorm SageMaker compatible Docker image from source with commands:
-
-.. code-block:: bash
-
-    git clone https://github.com/awslabs/graphstorm.git
-
-    cd /path-to-graphstorm/docker/
-
-    bash /path-to-graphstorm/docker/build_docker_sagemaker.sh /path-to-graphstorm/ <DEVICE_TYPE> <IMAGE_NAME> <IMAGE_TAG>
-
-The ``build_docker_sagemaker.sh`` script takes four arguments:
-
-1. **path-to-graphstorm** (**required**), is the absolute path of the ``graphstorm`` folder, where you cloned the GraphStorm source code. For example, the path could be ``/code/graphstorm``.
-2. **DEVICE_TYPE** (optional), is the intended device type of the to-be built Docker image. There are two options: ``cpu`` for building CPU-compatible images, and ``gpu`` for building Nvidia GPU-compatible images. Default is ``gpu``.
-3. **IMAGE_NAME** (optional), is the assigned name of the to-be built Docker image. Default is ``graphstorm``.
-
-.. warning::
-    In order to upload the GraphStorm SageMaker Docker image to Amazon ECR, users need to define the <IMAGE_NAME> to include the ECR URI string, **<AWS_ACCOUNT_ID>.dkr.ecr.<REGION>.amazonaws.com/**, e.g., ``888888888888.dkr.ecr.us-east-1.amazonaws.com/graphstorm``.
-
-4. **IMAGE_TAG** (optional), is the assigned tag name of the to-be built Docker image. Default is ``sm-<DEVICE_TYPE>``,
-   that is, ``sm-gpu`` for GPU images, ``sm-cpu`` for CPU images.
-
-Once the ``build_docker_sagemaker.sh`` command completes successfully, there will be a Docker image, named ``<IMAGE_NAME>:<IMAGE_TAG>``,
-such as ``888888888888.dkr.ecr.us-east-1.amazonaws.com/graphstorm:sm-gpu``, in the local repository, which could be listed by running:
-
-.. code-block:: bash
-
-    docker image ls
-
-.. _upload_sagemaker_docker:
-
-Step 2: Upload Docker Images to Amazon ECR Repository
-.......................................................
-Because SageMaker relies on Amazon ECR to access customers' own Docker images, users need to upload Docker images built in the Step 1 to their own ECR repository.
-
-The following command will authenticate the user account to access to user's ECR repository via AWS CLI.
-
-.. code-block:: bash
-
-    aws ecr get-login-password --region <REGION> | docker login --username AWS --password-stdin <AWS_ACCOUNT_ID>.dkr.ecr.<REGION>.amazonaws.com
-
-Please replace the `<REGION>` and `<AWS_ACCOUNT_ID>` with your own account information and be consistent with the values used in the **Step 1**.
-
-In addition, users need to create an ECR repository at the specified `<REGION>` with the name as `<IMAGE_NAME>` **WITHOUT** the ECR URI string, e.g., ``graphstorm``.
-
-And then use the below command to push the built GraphStorm Docker image to users' own ECR repository.
-
-.. code-block:: bash
-
-    docker push <IMAGE_NAME>:<IMAGE_TAG>
-
-Please replace the `<IMAGE_NAME>` and `<IMAGE_TAG>` with the actual Docker image name and tag, e.g., ``888888888888.dkr.ecr.us-east-1.amazonaws.com/graphstorm:sm-gpu``.
+See ``bash docker/build_graphstorm_image.sh --help`` and ``bash docker/push_graphstorm_image.sh --help``
+for more build and push options.
 
 Run GraphStorm on SageMaker
 ----------------------------
@@ -261,8 +208,8 @@ from ``${DATASET_S3_PATH}`` as input and create a DistDGL graph with
 ``${NUM_PARTITIONS}`` under the output path, ``${OUTPUT_PATH}``.
 Currently we only support ``random`` as the partitioning algorithm.
 
-Passing additional arguments to the SageMaker
-`````````````````````````````````````````````
+Passing additional arguments to the SageMaker Estimator
+```````````````````````````````````````````````````````
 Sometimes you might want to pass additional arguments to the constructor
 of the SageMaker Estimator/Processor object that we use to launch SageMaker
 tasks, e.g. to set a max runtime, or set a VPC configuration. Our launch
@@ -493,3 +440,78 @@ To save computing resources, users can run the below command to clean up the Doc
 .. code-block:: bash
 
     docker compose -f docker-compose-file down
+
+Legacy image building instructions
+``````````````````````````````````
+
+Since GraphStorm version 0.4.0 we provide new build scripts to facilitate easier image building
+and pushing to ECR. In this section we provide the instructions for the legacy scripts.
+These scripts will be deprecated and no longer updated in future versions of GraphStorm.
+
+Step 1: Build a SageMaker-compatible Docker image
+...................................................
+
+.. note::
+    * Please make sure your account has access key (AK) and security access key (SK) configured to authenticate accesses to AWS services.
+    * For more details of Amazon ECR operation via CLI, users can refer to the `Using Amazon ECR with the AWS CLI document <https://docs.aws.amazon.com/AmazonECR/latest/userguide/getting-started-cli.html>`_.
+
+First, in a Linux machine, configure a Docker environment by following the `Docker documentation <https://docs.docker.com/get-docker/>`_ suggestions.
+
+In order to use the SageMaker base Docker image, users need to use the following command to authenticate to pull SageMaker images.
+
+.. code-block:: bash
+
+    aws ecr get-login-password --region us-east-1 | docker login --username AWS --password-stdin 763104351884.dkr.ecr.us-east-1.amazonaws.com
+
+Then, clone GraphStorm source code, and build a GraphStorm SageMaker compatible Docker image from source with commands:
+
+.. code-block:: bash
+
+    git clone https://github.com/awslabs/graphstorm.git
+
+    cd /path-to-graphstorm/docker/
+
+    bash /path-to-graphstorm/docker/build_docker_sagemaker.sh /path-to-graphstorm/ <DEVICE_TYPE> <IMAGE_NAME> <IMAGE_TAG>
+
+The ``build_docker_sagemaker.sh`` script takes four arguments:
+
+1. **path-to-graphstorm** (**required**), is the absolute path of the ``graphstorm`` folder, where you cloned the GraphStorm source code. For example, the path could be ``/code/graphstorm``.
+2. **DEVICE_TYPE** (optional), is the intended device type of the to-be built Docker image. There are two options: ``cpu`` for building CPU-compatible images, and ``gpu`` for building Nvidia GPU-compatible images. Default is ``gpu``.
+3. **IMAGE_NAME** (optional), is the assigned name of the to-be built Docker image. Default is ``graphstorm``.
+
+.. warning::
+    In order to upload the GraphStorm SageMaker Docker image to Amazon ECR, users need to define the <IMAGE_NAME> to include the ECR URI string, **<AWS_ACCOUNT_ID>.dkr.ecr.<REGION>.amazonaws.com/**, e.g., ``888888888888.dkr.ecr.us-east-1.amazonaws.com/graphstorm``.
+
+4. **IMAGE_TAG** (optional), is the assigned tag name of the to-be built Docker image. Default is ``sm-<DEVICE_TYPE>``,
+   that is, ``sm-gpu`` for GPU images, ``sm-cpu`` for CPU images.
+
+Once the ``build_docker_sagemaker.sh`` command completes successfully, there will be a Docker image, named ``<IMAGE_NAME>:<IMAGE_TAG>``,
+such as ``888888888888.dkr.ecr.us-east-1.amazonaws.com/graphstorm:sm-gpu``, in the local repository, which could be listed by running:
+
+.. code-block:: bash
+
+    docker image ls
+
+.. _upload_sagemaker_docker:
+
+Step 2: Upload Docker Images to Amazon ECR Repository
+.......................................................
+Because SageMaker relies on Amazon ECR to access customers' own Docker images, users need to upload Docker images built in the Step 1 to their own ECR repository.
+
+The following command will authenticate the user account to access to user's ECR repository via AWS CLI.
+
+.. code-block:: bash
+
+    aws ecr get-login-password --region <REGION> | docker login --username AWS --password-stdin <AWS_ACCOUNT_ID>.dkr.ecr.<REGION>.amazonaws.com
+
+Please replace the `<REGION>` and `<AWS_ACCOUNT_ID>` with your own account information and be consistent with the values used in the **Step 1**.
+
+In addition, users need to create an ECR repository at the specified `<REGION>` with the name as `<IMAGE_NAME>` **WITHOUT** the ECR URI string, e.g., ``graphstorm``.
+
+And then use the below command to push the built GraphStorm Docker image to users' own ECR repository.
+
+.. code-block:: bash
+
+    docker push <IMAGE_NAME>:<IMAGE_TAG>
+
+Please replace the `<IMAGE_NAME>` and `<IMAGE_TAG>` with the actual Docker image name and tag, e.g., ``888888888888.dkr.ecr.us-east-1.amazonaws.com/graphstorm:sm-gpu``.

--- a/docs/source/cli/model-training-inference/distributed/sagemaker.rst
+++ b/docs/source/cli/model-training-inference/distributed/sagemaker.rst
@@ -24,6 +24,11 @@ GraphStorm uses SageMaker's **BYOC** (Bring Your Own Container) mode. Therefore,
 Building and pushing a SageMaker uses the same scripts as for building a local image,
 described in :ref:`GraphStorm Docker build instructions <_build_docker>`.
 
+Your executing role should have full ECR access to be able to pull from ECR to build the image,
+create an ECR repository if it doesn't exist, and push the GSProcessing image to the repository.
+See the [official ECR docs](https://docs.aws.amazon.com/AmazonECR/latest/userguide/image-push-iam.html)
+for details.
+
 In short you can run the following:
 
 .. code-block:: bash
@@ -446,7 +451,7 @@ Legacy image building instructions
 
 Since GraphStorm 0.4.0 we provide new build scripts to facilitate easier image building
 and pushing to ECR. In this section we provide the instructions for the legacy scripts.
-These scripts will be deprecated and no longer updated in future versions of GraphStorm.
+These scripts will be deprecated in version 0.5 and removed in a future version of GraphStorm.
 
 Step 1: Build a SageMaker-compatible Docker image
 ...................................................

--- a/docs/source/install/env-setup.rst
+++ b/docs/source/install/env-setup.rst
@@ -132,6 +132,9 @@ To set up credentials for use with ``aws-cli`` see the
 
 Your executing role should have full ECR access to be able to pull from ECR to build the image,
 create an ECR repository if it doesn't exist, and push the GSProcessing image to the repository.
+See the [official ECR docs](https://docs.aws.amazon.com/AmazonECR/latest/userguide/image-push-iam.html)
+for details.
+
 
 Building the GraphStorm images using Docker
 -------------------------------------------
@@ -155,21 +158,33 @@ the following command to build the local image:
 
 .. code-block:: bash
 
+    git clone https://github.com/awslabs/graphstorm.git
+    cd graphstorm
     bash docker/build_graphstorm_image.sh --environment local
 
 The above will use the local Dockerfile for GraphStorm,
 build an image and tag it as ``graphstorm:local-gpu``.
 
 The script also supports other arguments to customize the image name,
-tag and other aspects of the build. See ``bash docker/build_graphstorm_image.sh --help``
-for more information.
+tag and other aspects of the build. We list the full argument list below:
 
-For example you can build an image to support CPU-only execution using
+* ``-x, --verbose``       Print script debug info (set -x)
+* ``-e, --environment``   Image execution environment. Must be one of 'local' or 'sagemaker'. Required.
+* ``-d, --device``        Device type, must be one of 'cpu' or 'gpu'. Default is 'gpu'.
+* ``-p, --path``          Path to graphstorm root directory, default is one level above the script's location.
+* ``-i, --image``         Docker image name, default is 'graphstorm'.
+* ``-s, --suffix``        Suffix for the image tag, can be used to push custom image tags. Default is "<environment>-<device>".
+* ``-b, --build``         Docker build directory prefix, default is '/tmp/graphstorm-build/docker'.
+
+For example you can build an image to support CPU-only execution using:
 
 .. code-block:: bash
 
     bash docker/build_graphstorm_image.sh --environment local --device cpu
     # Will build an image named 'graphstorm:local-cpu'
+
+See ``bash docker/build_graphstorm_image.sh --help``
+for more information.
 
 Push the image to Amazon Elastic Container Registry (ECR)
 -------------------------------------------------------------
@@ -186,10 +201,14 @@ and push the image tagged as ``<environment>-<device>```.
 In addition to ``-e/--environment``, the script supports several optional arguments, for a full list use
 ``bash push_graphstorm_image.sh --help``. We list the most important below:
 
-1. Image name/repository. (``-i/--image``) Default: ``graphstorm``
-2. ECR region. (``-r/--region``) Default: ``us-east-1``.
-3. AWS Account ID. (``-a/--account``) Default: Uses the account ID detected by the ``aws-cli``.
-4. Device type, (``-d/--device``) can be ``cpu`` or ``gpu``. Default: ``'gpu'``.
+* ``-e, --environment``   Image execution environment. Must be one of 'local' or 'sagemaker'. Required.
+* ``-a, --account``       AWS Account ID to use, we retrieve the default from the AWS cli configuration.
+* ``-r, --region``        AWS Region to push the image to, we retrieve the default from the AWS cli configuration.
+* ``-d, --device``        Device type, must be one of 'cpu' or 'gpu'. Default is 'gpu'.
+* ``-p, --path``          Path to graphstorm root directory, default is one level above the script's location.
+* ``-i, --image``         Docker image name, default is 'graphstorm'.
+* ``-s, --suffix``        Suffix for the image tag, can be used to push custom image tags. Default is "<environment>-<device>".
+
 
 Example:
 

--- a/docs/source/install/env-setup.rst
+++ b/docs/source/install/env-setup.rst
@@ -136,7 +136,7 @@ create an ECR repository if it doesn't exist, and push the GSProcessing image to
 Building the GraphStorm images using Docker
 -------------------------------------------
 
-With Docker installed, and your AWS credentials are set up,
+With Docker installed, and your AWS credentials set up,
 you can use the provided scripts
 in the ``graphstorm/docker`` directory to build the image.
 
@@ -151,7 +151,7 @@ are ``sagemaker`` and ``local``.
 
 For example, assuming our current directory is where
 we cloned ``graphstorm/``, we can use
-the following to build the local image:
+the following command to build the local image:
 
 .. code-block:: bash
 
@@ -171,11 +171,11 @@ For example you can build an image to support CPU-only execution using
     bash docker/build_graphstorm_image.sh --environment local --device cpu
     # Will build an image named 'graphstorm:local-cpu'
 
-Push the image to the Amazon Elastic Container Registry (ECR)
+Push the image to Amazon Elastic Container Registry (ECR)
 -------------------------------------------------------------
 
-Once the image is built we can use the ``push_graphstorm_image.sh`` script
-that will create an ECR repository if needed and push the image we just built.
+Once the image is built we can use the ``push_graphstorm_image.sh`` script to push the image we just built.
+The script will create an ECR repository if needed.
 
 The script again requires us to provide the intended execution environment using
 the ``-e/--environment`` argument,


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

* Introduce new Docker build files to allow unified and single command build and push for GSF local and Sagemaker. 
* The change is backwards compatible, we deprecate the old build scripts in 0.4 and 0.5 and remove them in 0.6.  

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
