### PR TITLE
[GSProcessing] Update GSProcessing custom split config parsing and documentation to match GConstruct.

### DIFF
--- a/docs/source/cli/graph-construction/distributed/gsprocessing/input-configuration.rst
+++ b/docs/source/cli/graph-construction/distributed/gsprocessing/input-configuration.rst
@@ -173,15 +173,23 @@ objects:
          assign to the validation set [0.0, 1.0).
       -  ``test``: The percentage of the data with available labels to
          assign to the test set [0.0, 1.0).
-   -  ``custom_split_filenames`` (JSON object, optional): Specifies the customized
-      training/validation/test mask. Once it is defined, GSProcessing will ignore
-      the ``split_rate``.
-      -  ``train``: Path of the training mask parquet file such that each line contains
-    the original ID for node tasks, or the pair [source_id, destination_id] for edge tasks.
-      -  ``val``: Path of the validation mask parquet file such that each line contains
-    the original ID for node tasks, or the pair [source_id, destination_id] for edge tasks.
-      -  ``test``: Path of the test mask parquet file such that each line contains
-    the original ID for node tasks, or the pair [source_id, destination_id] for edge tasks.
+   -  ``custom_split_filenames`` (JSON object, optional): Specifies pre-assigned
+      training/validation/test masks. If defined, GSProcessing will ignore
+      ``split_rate`` if provided.
+
+      -  ``column``: (List[String], optional) A list of length one for node splits, or two for edge splits,
+         containing the name(s) of the column(s) that contain the node/edge ids for each split. For example,
+         if the node ids to include in each split exist in column ``"nid"`` of the custom train/val/test files, this
+         needs to be ``["nid"]``. For edges it would be a value like ``["src_id", "dst_id"]``.
+         If not provided for nodes we assume the first column in the data contains the node ids to include.
+         For edges, we assume the first column is the source id and the second the destination id.
+      -  ``train``: (List[String], optional) Paths of the training mask parquet file such that each line contains
+         the original ID for node tasks, or the pair ``[source_id, destination_id]`` for edge tasks.
+      -  ``val``: (List[String], optional) Paths of the validation mask parquet file such that each line contains
+         the original ID for node tasks, or the pair ``[source_id, destination_id]`` for edge tasks.
+      -  ``test``: (List[String], optional) Paths of the test mask parquet file such that each line contains
+         the original ID for node tasks, or the pair ``[source_id, destination_id]`` for edge tasks.
+      -  Note: At least one of the ``["train", "val", "test"]`` keys must be present.
 
 -  ``features`` (List of JSON objects, optional)\ **:** Describes
    the set of features for the current edge type. See the :ref:`features-object` section for details.

--- a/graphstorm-processing/graphstorm_processing/config/config_conversion/gconstruct_converter.py
+++ b/graphstorm-processing/graphstorm_processing/config/config_conversion/gconstruct_converter.py
@@ -61,7 +61,7 @@ class GConstructConfigConverter(ConfigConverter):
                         # check if split_pct is valid
                         assert (
                             math.fsum(label_splitrate) == 1.0
-                        ), f"sum of the label split rate should be ==1.0, got {label_splitrate=}"
+                        ), f"sum of the label split rate should be == 1.0, got {label_splitrate}"
                         label_dict["split_rate"] = {
                             "train": label_splitrate[0],
                             "val": label_splitrate[1],

--- a/graphstorm-processing/graphstorm_processing/config/config_conversion/gconstruct_converter.py
+++ b/graphstorm-processing/graphstorm_processing/config/config_conversion/gconstruct_converter.py
@@ -50,7 +50,7 @@ class GConstructConfigConverter(ConfigConverter):
         labels_list = []
         if labels in [[], [{}]]:
             return []
-        for label in labels:
+        for label in labels:  # pylint: disable=too-many-nested-blocks
             try:
                 label_column = label["label_col"] if "label_col" in label else ""
                 label_type = label["task_type"]
@@ -61,7 +61,7 @@ class GConstructConfigConverter(ConfigConverter):
                         # check if split_pct is valid
                         assert (
                             math.fsum(label_splitrate) == 1.0
-                        ), "sum of the label split rate should be ==1.0"
+                        ), f"sum of the label split rate should be ==1.0, got {label_splitrate=}"
                         label_dict["split_rate"] = {
                             "train": label_splitrate[0],
                             "val": label_splitrate[1],
@@ -69,11 +69,31 @@ class GConstructConfigConverter(ConfigConverter):
                         }
                 else:
                     label_custom_split_filenames = label["custom_split_filenames"]
-                    if isinstance(label_custom_split_filenames["column"], list):
-                        assert len(label_custom_split_filenames["column"]) <= 2, (
-                            "Custom split filenames should have one column for node labels, "
-                            "and two columns for edges labels exactly"
-                        )
+                    # Ensure at least one of ["train", "valid", "test"] is in the keys
+                    assert any(
+                        x in label_custom_split_filenames.keys() for x in ["train", "valid", "test"]
+                    ), (
+                        "At least one of ['train', 'valid', 'test'] "
+                        "needs to exist in custom split configs."
+                    )
+
+                    # Fill in missing values if needed
+                    for entry in ["train", "valid", "test", "column"]:
+                        entry_val = label_custom_split_filenames.get(entry, None)
+                        if entry_val:
+                            if isinstance(entry_val, str):
+                                label_custom_split_filenames[entry] = [entry_val]
+                            else:
+                                assert isinstance(
+                                    entry_val, list
+                                ), "Custom split filenames should be a string or a list of strings"
+                        else:
+                            label_custom_split_filenames[entry] = []
+                    assert len(label_custom_split_filenames["column"]) <= 2, (
+                        "Custom split filenames should have one column for node labels, "
+                        "and two columns for edges labels exactly"
+                    )
+
                     label_dict["custom_split_filenames"] = {
                         "train": label_custom_split_filenames["train"],
                         "valid": label_custom_split_filenames["valid"],
@@ -213,7 +233,7 @@ class GConstructConfigConverter(ConfigConverter):
         return gsp_feats_list
 
     @staticmethod
-    def convert_nodes(nodes_entries):
+    def convert_nodes(nodes_entries) -> list[NodeConfig]:
         res = []
         for n in nodes_entries:
             # type, column id

--- a/graphstorm-processing/graphstorm_processing/config/config_parser.py
+++ b/graphstorm-processing/graphstorm_processing/config/config_parser.py
@@ -194,6 +194,8 @@ class EdgeConfig(StructureConfig):
         self._dst_ntype = edge_dict["dest"]["type"]
         self._rel_type = edge_dict["relation"]["type"]
         self._rel_col: Optional[str] = edge_dict["relation"].get("column", None)
+        self._feature_configs = []
+        self._labels = []
 
         if "features" in edge_dict:
             for feature_dict in edge_dict["features"]:

--- a/graphstorm-processing/graphstorm_processing/data_transformations/dist_label_loader.py
+++ b/graphstorm-processing/graphstorm_processing/data_transformations/dist_label_loader.py
@@ -75,9 +75,9 @@ class CustomSplit:
     ----------
     train : list[str]
         Paths of the training mask parquet files.
-    valid : str
+    valid : list[str]
         Paths of the validation mask parquet files.
-    test : str
+    test : list[str]
         Paths of the testing mask parquet files.
     mask_columns : list[str]
         List of columns that contain original string ids.

--- a/graphstorm-processing/graphstorm_processing/data_transformations/dist_label_loader.py
+++ b/graphstorm-processing/graphstorm_processing/data_transformations/dist_label_loader.py
@@ -73,19 +73,19 @@ class CustomSplit:
 
     Parameters
     ----------
-    train : str
-        Path of the training mask parquet file.
+    train : list[str]
+        Paths of the training mask parquet files.
     valid : str
-        Path of the validation mask parquet file.
+        Paths of the validation mask parquet files.
     test : str
-        Path of the testing mask parquet file.
+        Paths of the testing mask parquet files.
     mask_columns : list[str]
         List of columns that contain original string ids.
     """
 
-    train: str
-    valid: str
-    test: str
+    train: list[str]
+    valid: list[str]
+    test: list[str]
     mask_columns: list[str]
 
 

--- a/graphstorm-processing/pyproject.toml
+++ b/graphstorm-processing/pyproject.toml
@@ -41,6 +41,7 @@ pre-commit = "^3.3.3"
 types-mock = "^5.1.0.1"
 pylint = "~2.17.5"
 diff-cover = "^9.0.0"
+pytest-cov = "^6.0.0"
 
 [project]
 requires-python = ">=3.9" # TODO: Do we need a tilde here?

--- a/graphstorm-processing/tests/test_dist_heterogenous_loader.py
+++ b/graphstorm-processing/tests/test_dist_heterogenous_loader.py
@@ -955,9 +955,9 @@ def test_node_custom_label(spark, dghl_loader: DistHeterogeneousGraphLoader, tmp
         "type": "classification",
         "split_rate": {"train": 0.8, "val": 0.1, "test": 0.1},
         "custom_split_filenames": {
-            "train": f"{tmp_path}/train.parquet",
-            "valid": f"{tmp_path}/val.parquet",
-            "test": f"{tmp_path}/test.parquet",
+            "train": [f"{tmp_path}/train.parquet"],
+            "valid": [f"{tmp_path}/val.parquet"],
+            "test": [f"{tmp_path}/test.parquet"],
             "column": ["mask_id"],
         },
     }
@@ -1010,9 +1010,9 @@ def test_edge_custom_label(spark, dghl_loader: DistHeterogeneousGraphLoader, tmp
         "column": "",
         "type": "link_prediction",
         "custom_split_filenames": {
-            "train": f"{tmp_path}/train.parquet",
-            "valid": f"{tmp_path}/val.parquet",
-            "test": f"{tmp_path}/test.parquet",
+            "train": [f"{tmp_path}/train.parquet"],
+            "valid": [f"{tmp_path}/val.parquet"],
+            "test": [f"{tmp_path}/test.parquet"],
             "column": ["mask_src_id", "mask_dst_id"],
         },
     }
@@ -1061,9 +1061,9 @@ def test_node_custom_label_multitask(spark, dghl_loader: DistHeterogeneousGraphL
         "type": "classification",
         "split_rate": {"train": 0.8, "val": 0.1, "test": 0.1},
         "custom_split_filenames": {
-            "train": f"{tmp_path}/train.parquet",
-            "valid": f"{tmp_path}/val.parquet",
-            "test": f"{tmp_path}/test.parquet",
+            "train": [f"{tmp_path}/train.parquet"],
+            "valid": [f"{tmp_path}/val.parquet"],
+            "test": [f"{tmp_path}/test.parquet"],
             "column": ["mask_id"],
         },
         "mask_field_names": class_mask_names,
@@ -1173,9 +1173,9 @@ def test_edge_custom_label_multitask(spark, dghl_loader: DistHeterogeneousGraphL
         "column": "",
         "type": "link_prediction",
         "custom_split_filenames": {
-            "train": f"{tmp_path}/train.parquet",
-            "valid": f"{tmp_path}/val.parquet",
-            "test": f"{tmp_path}/test.parquet",
+            "train": [f"{tmp_path}/train.parquet"],
+            "valid": [f"{tmp_path}/val.parquet"],
+            "test": [f"{tmp_path}/test.parquet"],
             "column": ["mask_src_id", "mask_dst_id"],
         },
         "mask_field_names": class_mask_names,

--- a/graphstorm-processing/tests/test_gsprocessing_config.py
+++ b/graphstorm-processing/tests/test_gsprocessing_config.py
@@ -1,0 +1,161 @@
+"""
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License").
+You may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+import pytest
+
+from graphstorm_processing.config.config_parser import (
+    NodeConfig,
+    EdgeConfig,
+    create_config_objects,
+    parse_feat_config,
+)
+from graphstorm_processing.config.numerical_configs import (
+    NumericalFeatureConfig,
+)
+from graphstorm_processing.config.label_config_base import (
+    EdgeLabelConfig,
+    NodeLabelConfig,
+)
+
+
+def test_parse_edge_lp_config():
+    """Test parsing an edge configuration with link prediction task"""
+    label_config_dict = [
+        {
+            "column": "",
+            "type": "link_prediction",
+            "split_rate": {"train": 0.8, "val": 0.1, "test": 0.1},
+        }
+    ]
+    edge_dict = {
+        "source": {"column": "~from", "type": "movie"},
+        "relation": {"type": "included_in"},
+        "dest": {"column": "~to", "type": "genre"},
+        "labels": label_config_dict,
+    }
+    data_dict = {"format": "csv", "files": ["edges/movie-included_in-genre.csv"], "separator": ","}
+    edge_config = EdgeConfig(edge_dict, data_dict)
+
+    assert edge_config.src_ntype == "movie"
+    assert edge_config.dst_ntype == "genre"
+    assert edge_config.rel_type == "included_in"
+    assert edge_config.src_col == "~from"
+    assert edge_config.dst_col == "~to"
+    assert edge_config.rel_col is None
+    assert edge_config.format == "csv"
+    assert edge_config.files == ["edges/movie-included_in-genre.csv"]
+    assert edge_config.separator == ","
+    assert edge_config.label_configs
+    assert len(edge_config.label_configs) == 1
+    lp_config = edge_config.label_configs[0]
+    assert isinstance(lp_config, EdgeLabelConfig)
+    assert lp_config.task_type == "link_prediction"
+    assert lp_config.split_rate == {"train": 0.8, "val": 0.1, "test": 0.1}
+
+
+def test_parse_basic_node_config():
+    """Test parsing a basic node configuration"""
+    node_config = {"column": "~id", "type": "user"}
+    data_config = {"format": "csv", "files": ["nodes/user.csv"], "separator": ","}
+    node_config_obj = NodeConfig(node_config, data_config)
+
+    assert node_config_obj.ntype == "user"
+    assert node_config_obj.node_col == "~id"
+    assert node_config_obj.format == "csv"
+    assert node_config_obj.files == ["nodes/user.csv"]
+    assert node_config_obj.separator == ","
+
+
+def test_parse_num_configs():
+    """Test parsing a numerical features configuration"""
+    feature_dict = {
+        "column": "age",
+        "transformation": {
+            "name": "numerical",
+            "kwargs": {"imputer": "mean", "normalizer": "min-max"},
+        },
+    }
+    feature_config = parse_feat_config(feature_dict)
+
+    assert isinstance(feature_config, NumericalFeatureConfig)
+    assert feature_config._cols == ["age"]
+    assert feature_config.feat_type == "numerical"
+    assert feature_config._transformation_kwargs["imputer"] == "mean"
+    assert feature_config._transformation_kwargs["normalizer"] == "min-max"
+
+
+def test_parse_node_label_configs():
+    """Test parsing a node configuration with a classification label"""
+    label_config_dict = {
+        "column": "gender",
+        "type": "classification",
+        "split_rate": {"train": 0.8, "val": 0.1, "test": 0.1},
+    }
+    node_config_dict = {"column": "~id", "type": "user", "labels": [label_config_dict]}
+    data_config = {"format": "csv", "files": ["nodes/user.csv"], "separator": ","}
+    node_config_obj = NodeConfig(node_config_dict, data_config)
+
+    assert node_config_obj.label_configs
+    assert len(node_config_obj.label_configs) == 1
+    label_config = node_config_obj.label_configs[0]
+    assert isinstance(label_config, NodeLabelConfig)
+    assert label_config.label_column == "gender"
+    assert label_config.task_type == "classification"
+    assert label_config.split_rate == {"train": 0.8, "val": 0.1, "test": 0.1}
+
+
+def test_create_config_objects():
+    """Test conversion of input dicts to config objects"""
+    graph_config = {
+        "edges": [
+            {
+                "data": {
+                    "format": "csv",
+                    "files": ["edges/movie-included_in-genre.csv"],
+                    "separator": ",",
+                },
+                "source": {"column": "~from", "type": "movie"},
+                "relation": {"type": "included_in"},
+                "dest": {"column": "~to", "type": "genre"},
+            }
+        ],
+        "nodes": [
+            {
+                "data": {"format": "csv", "files": ["nodes/genre.csv"], "separator": ","},
+                "column": "~id",
+                "type": "genre",
+            }
+        ],
+    }
+
+    config_objects = create_config_objects(graph_config)
+
+    assert len(config_objects["edges"]) == 1
+    assert len(config_objects["nodes"]) == 1
+    assert isinstance(config_objects["edges"][0], EdgeConfig)
+    assert isinstance(config_objects["nodes"][0], NodeConfig)
+
+
+def test_unsupported_transformation():
+    """Test that an unsupported transformation raises an error"""
+
+    feature_dict = {"column": "feature", "transformation": {"name": "unsupported_transform"}}
+
+    with pytest.raises(
+        RuntimeError,
+        match="Unknown transformation name: 'unsupported_transform'",
+    ):
+        parse_feat_config(feature_dict)

--- a/python/graphstorm/gconstruct/file_io.py
+++ b/python/graphstorm/gconstruct/file_io.py
@@ -118,7 +118,7 @@ def read_index_parquet(data_file, column):
 
     if len(column) == 1:
         res_array = df[column[0]].to_numpy()
-    elif len(df.columns) == 2:
+    elif len(column) == 2:
         res_array = list(zip(df[column[0]].to_numpy(), df[column[1]].to_numpy()))
     else:
         raise ValueError("The Parquet file on node mask must contain exactly one column, "


### PR DESCRIPTION
NOTE: GSProcessing now requires list[str] for its custom split file config input.

*Issue #, if available:*

*Description of changes:*

* Update GSProcessingdocumentation for custom split files to match implementation.
* Make GSProcessing config parsing be equivalent to GConstruct by allowing only one of train/val/test to be defined. Previously GSProcessing required all, but GConstruct did not.
* Make the custom file input for GSProcessing to _require_ list of files. When possible we want GSProcessing input config to have _one_ way to define things, allowing easier verification and reducing use confusion.
* Also used GenAI to generate some tests for `gsprocessing.config` classes and functions that were previously untested.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
