### PR TITLE
[Feature] Add bias to edge decoder

### DIFF
--- a/python/graphstorm/config/argument.py
+++ b/python/graphstorm/config/argument.py
@@ -817,6 +817,7 @@ class GSConfig:
         _ = self.dropout
         _ = self.decoder_type
         _ = self.num_decoder_basis
+        _ = self.decoder_bias
         # Encoder related
         _ = self.construct_feat_ntype
         _ = self.construct_feat_encoder
@@ -1749,6 +1750,18 @@ class GSConfig:
         return 1000
 
     ###################### Model training related ######################
+    @property
+    def decoder_bias(self):
+        """ Node decoder bias. decoder_bias must be a boolean. Default is False.
+        """
+        # pylint: disable=no-member
+        if hasattr(self, "_decoder_bias"):
+            assert self._decoder_bias in [True, False], \
+                "decoder_bias should be in [True, False]"
+            return self._decoder_bias
+        # By default, node decoder bias is False
+        return False
+
     @property
     def dropout(self):
         """ Dropout probability. Dropout must be a float value in [0,1). Dropout is applied
@@ -3234,6 +3247,11 @@ def _add_hyperparam_args(parser):
     group = parser.add_argument_group(title="hp")
     group.add_argument("--dropout", type=float, default=argparse.SUPPRESS,
             help="dropout probability")
+    group.add_argument(
+            "--decoder-bias",
+            type=lambda x: (str(x).lower() in ['true', '1']),
+            default=argparse.SUPPRESS,
+            help="Whether to use decoder bias")
     group.add_argument("--gnn-norm", type=str, default=argparse.SUPPRESS, help="norm type")
     group.add_argument("--lr", type=float, default=argparse.SUPPRESS,
             help="learning rate")

--- a/python/graphstorm/config/argument.py
+++ b/python/graphstorm/config/argument.py
@@ -1752,15 +1752,15 @@ class GSConfig:
     ###################### Model training related ######################
     @property
     def decoder_bias(self):
-        """ Decoder bias. decoder_bias must be a boolean. Default is False.
+        """ Decoder bias. decoder_bias must be a boolean. Default is True.
         """
         # pylint: disable=no-member
         if hasattr(self, "_decoder_bias"):
             assert self._decoder_bias in [True, False], \
                 "decoder_bias should be in [True, False]"
             return self._decoder_bias
-        # By default, decoder bias is False
-        return False
+        # By default, decoder bias is True
+        return True
 
     @property
     def dropout(self):

--- a/python/graphstorm/config/argument.py
+++ b/python/graphstorm/config/argument.py
@@ -1752,14 +1752,14 @@ class GSConfig:
     ###################### Model training related ######################
     @property
     def decoder_bias(self):
-        """ Node decoder bias. decoder_bias must be a boolean. Default is False.
+        """ Decoder bias. decoder_bias must be a boolean. Default is False.
         """
         # pylint: disable=no-member
         if hasattr(self, "_decoder_bias"):
             assert self._decoder_bias in [True, False], \
                 "decoder_bias should be in [True, False]"
             return self._decoder_bias
-        # By default, node decoder bias is False
+        # By default, decoder bias is False
         return False
 
     @property

--- a/python/graphstorm/gsf.py
+++ b/python/graphstorm/gsf.py
@@ -439,7 +439,8 @@ def create_builtin_reconstruct_efeat_decoder(g, decoder_input_dim, config, train
     decoder = EdgeRegression(decoder_input_dim,
                              target_etype=target_etype,
                              out_dim=feat_dim,
-                             dropout=dropout)
+                             dropout=dropout,
+                             use_bias=config.decoder_bias)
 
     loss_func = RegressionLossFunc()
     return decoder, loss_func
@@ -617,14 +618,16 @@ def create_builtin_edge_decoder(g, decoder_input_dim, config, train_task):
                                      dropout_rate=dropout,
                                      regression=False,
                                      target_etype=target_etype,
-                                     norm=config.decoder_norm)
+                                     norm=config.decoder_norm,
+                                     use_bias=config.decoder_bias)
         elif decoder_type == "MLPDecoder":
             decoder = MLPEdgeDecoder(decoder_input_dim,
                                      num_classes,
                                      multilabel=config.multilabel,
                                      target_etype=target_etype,
                                      num_ffn_layers=config.num_ffn_layers_in_decoder,
-                                     norm=config.decoder_norm)
+                                     norm=config.decoder_norm,
+                                     use_bias=config.decoder_bias)
         elif decoder_type == "MLPEFeatEdgeDecoder":
             decoder_edge_feat = config.decoder_edge_feat
             assert decoder_edge_feat is not None, \
@@ -648,7 +651,8 @@ def create_builtin_edge_decoder(g, decoder_input_dim, config, train_task):
                 target_etype=target_etype,
                 dropout=config.dropout,
                 num_ffn_layers=config.num_ffn_layers_in_decoder,
-                norm=config.decoder_norm)
+                norm=config.decoder_norm,
+                use_bias=config.decoder_bias)
         else:
             assert False, f"decoder {decoder_type} is not supported."
 
@@ -680,7 +684,8 @@ def create_builtin_edge_decoder(g, decoder_input_dim, config, train_task):
                                      target_etype=target_etype,
                                      dropout_rate=dropout,
                                      regression=True,
-                                     norm=config.decoder_norm)
+                                     norm=config.decoder_norm,
+                                     use_bias=config.decoder_bias)
         elif decoder_type == "MLPDecoder":
             decoder = MLPEdgeDecoder(decoder_input_dim,
                                      1,
@@ -688,7 +693,8 @@ def create_builtin_edge_decoder(g, decoder_input_dim, config, train_task):
                                      target_etype=target_etype,
                                      regression=True,
                                      num_ffn_layers=config.num_ffn_layers_in_decoder,
-                                     norm=config.decoder_norm)
+                                     norm=config.decoder_norm,
+                                     use_bias=config.decoder_bias)
         elif decoder_type == "MLPEFeatEdgeDecoder":
             decoder_edge_feat = config.decoder_edge_feat
             assert decoder_edge_feat is not None, \
@@ -713,7 +719,8 @@ def create_builtin_edge_decoder(g, decoder_input_dim, config, train_task):
                 dropout=config.dropout,
                 regression=True,
                 num_ffn_layers=config.num_ffn_layers_in_decoder,
-                norm=config.decoder_norm)
+                norm=config.decoder_norm,
+                use_bias=config.decoder_bias)
         else:
             assert False, "decoder not supported"
         loss_func = RegressionLossFunc()

--- a/python/graphstorm/gsf.py
+++ b/python/graphstorm/gsf.py
@@ -397,7 +397,8 @@ def create_builtin_reconstruct_nfeat_decoder(g, decoder_input_dim, config, train
 
     decoder = EntityRegression(decoder_input_dim,
                                dropout=dropout,
-                               out_dim=feat_dim)
+                               out_dim=feat_dim,
+                               use_bias=config.decoder_bias)
 
     loss_func = RegressionLossFunc()
     return decoder, loss_func
@@ -472,7 +473,8 @@ def create_builtin_node_decoder(g, decoder_input_dim, config, train_task):
                                        config.num_classes,
                                        config.multilabel,
                                        dropout=dropout,
-                                       norm=config.decoder_norm)
+                                       norm=config.decoder_norm,
+                                       use_bias=config.decoder_bias)
             if config.class_loss_func == BUILTIN_CLASS_LOSS_CROSS_ENTROPY:
                 loss_func = ClassifyLossFunc(config.multilabel,
                                              config.multilabel_weights,
@@ -497,7 +499,8 @@ def create_builtin_node_decoder(g, decoder_input_dim, config, train_task):
                                                   config.num_classes[ntype],
                                                   config.multilabel[ntype],
                                                   dropout=dropout,
-                                                  norm=config.decoder_norm)
+                                                  norm=config.decoder_norm,
+                                                  use_bias=config.decoder_bias)
 
                 if config.class_loss_func == BUILTIN_CLASS_LOSS_CROSS_ENTROPY:
                     loss_func[ntype] = ClassifyLossFunc(config.multilabel[ntype],
@@ -515,7 +518,8 @@ def create_builtin_node_decoder(g, decoder_input_dim, config, train_task):
     elif config.task_type == BUILTIN_TASK_NODE_REGRESSION:
         decoder  = EntityRegression(decoder_input_dim,
                                     dropout=dropout,
-                                    norm=config.decoder_norm)
+                                    norm=config.decoder_norm,
+                                    use_bias=config.decoder_bias)
         loss_func = RegressionLossFunc()
     else:
         raise ValueError('unknown node task: {}'.format(config.task_type))

--- a/python/graphstorm/model/__init__.py
+++ b/python/graphstorm/model/__init__.py
@@ -61,7 +61,8 @@ from .edge_decoder import (DenseBiDecoder,
                            LinkPredictWeightedRotatEDecoder,
                            LinkPredictTransEDecoder,
                            LinkPredictContrastiveTransEDecoder,
-                           LinkPredictWeightedTransEDecoder)
+                           LinkPredictWeightedTransEDecoder,
+                           EdgeRegression)
 
 from .gnn_encoder_base import GraphConvEncoder
 

--- a/python/graphstorm/model/edge_decoder.py
+++ b/python/graphstorm/model/edge_decoder.py
@@ -581,7 +581,7 @@ class MLPEdgeDecoder(GSEdgeDecoder):
                 The dictionary containing the embeddings
             Returns
             -------
-            out
+            out: th.Tensor
                 Output of forward.
         """
         with g.local_scope():

--- a/python/graphstorm/model/edge_decoder.py
+++ b/python/graphstorm/model/edge_decoder.py
@@ -340,9 +340,6 @@ class EdgeRegression(GSEdgeDecoder):
         implementation. Default: None.
     use_bias: bool
         Whether the edge decoder uses a bias parameter. Default: True.
-
-    .. versionchanged:: 0.4.0
-        Add a new argument "use_bias" so users can control whether decoders have bias.
     """
     def __init__(self,
                  h_dim,

--- a/python/graphstorm/model/edge_decoder.py
+++ b/python/graphstorm/model/edge_decoder.py
@@ -134,6 +134,9 @@ class DenseBiDecoder(GSEdgeDecoder):
         implementation. Default: None.
     use_bias: bool
         Whether the edge decoder uses a bias parameter. Default: True.
+
+    .. versionchanged:: 0.4.0
+        Add a new argument "use_bias" so users can control whether decoders have bias.
     """
     def __init__(self,
                  in_units,
@@ -337,6 +340,9 @@ class EdgeRegression(GSEdgeDecoder):
         implementation. Default: None.
     use_bias: bool
         Whether the edge decoder uses a bias parameter. Default: True.
+
+    .. versionchanged:: 0.4.0
+        Add a new argument "use_bias" so users can control whether decoders have bias.
     """
     def __init__(self,
                  h_dim,
@@ -510,6 +516,9 @@ class MLPEdgeDecoder(GSEdgeDecoder):
         implementation. Default: None.
     use_bias: bool
         Whether the edge decoder uses a bias parameter. Default: True.
+
+    .. versionchanged:: 0.4.0
+        Add a new argument "use_bias" so users can control whether decoders have bias.
     """
     def __init__(self,
                  h_dim,
@@ -575,8 +584,8 @@ class MLPEdgeDecoder(GSEdgeDecoder):
                 The dictionary containing the embeddings
             Returns
             -------
-            th.Tensor
-                Output of forward
+            out
+                Output of forward.
         """
         with g.local_scope():
             u, v = g.edges(etype=self.target_etype)
@@ -724,6 +733,9 @@ class MLPEFeatEdgeDecoder(MLPEdgeDecoder):
         class implementation. Default: None.
     use_bias: bool
         Whether the edge decoder uses a bias parameter. Default: True.
+
+    .. versionchanged:: 0.4.0
+        Add a new argument "use_bias" so users can control whether decoders have bias.
     """
     def __init__(self,
                  h_dim,

--- a/python/graphstorm/model/edge_decoder.py
+++ b/python/graphstorm/model/edge_decoder.py
@@ -806,10 +806,12 @@ class MLPEFeatEdgeDecoder(MLPEdgeDecoder):
                 The minibatch graph
             h: dict of Tensors
                 The dictionary containing the embeddings
+            e_h: dict of Tensor
+                The input edge embeddings in the format of {(src_ntype, etype, dst_ntype): emb}.
             Returns
             -------
-            th.Tensor
-                Output of forward
+            out: Tensor
+                Output of forward.
         """
         assert e_h is not None, "edge feature is required"
         with g.local_scope():

--- a/python/graphstorm/model/node_decoder.py
+++ b/python/graphstorm/model/node_decoder.py
@@ -39,7 +39,7 @@ class EntityClassifier(GSLayer):
         Normalization methods. Not used, but reserved for complex node classifier
         implementation. Default: None.
     use_bias: bool
-        Whether the node decoder uses a bias parameter. Default: False.
+        Whether the node decoder uses a bias parameter. Default: True.
     """
     def __init__(self,
                  in_dim,
@@ -47,7 +47,7 @@ class EntityClassifier(GSLayer):
                  multilabel,
                  dropout=0,
                  norm=None,
-                 use_bias=False):
+                 use_bias=True):
         super(EntityClassifier, self).__init__()
         self._in_dim = in_dim
         self._num_classes = num_classes
@@ -170,14 +170,14 @@ class EntityRegression(GSLayer):
         Normalization methods. Not used, but reserved for complex node regression
         implementation. Default: None.
     use_bias: bool
-        Whether the node decoder uses a bias parameter. Default: False.
+        Whether the node decoder uses a bias parameter. Default: True.
     """
     def __init__(self,
                  h_dim,
                  dropout=0,
                  out_dim=1,
                  norm=None,
-                 use_bias=False):
+                 use_bias=True):
         super(EntityRegression, self).__init__()
         self._h_dim = h_dim
         self._out_dim = out_dim

--- a/python/graphstorm/model/node_decoder.py
+++ b/python/graphstorm/model/node_decoder.py
@@ -40,6 +40,9 @@ class EntityClassifier(GSLayer):
         implementation. Default: None.
     use_bias: bool
         Whether the node decoder uses a bias parameter. Default: True.
+
+    .. versionchanged:: 0.4.0
+        Add a new argument "use_bias" so users can control whether decoders have bias.
     """
     def __init__(self,
                  in_dim,
@@ -171,6 +174,9 @@ class EntityRegression(GSLayer):
         implementation. Default: None.
     use_bias: bool
         Whether the node decoder uses a bias parameter. Default: True.
+
+    .. versionchanged:: 0.4.0
+        Add a new argument "use_bias" so users can control whether decoders have bias.
     """
     def __init__(self,
                  h_dim,

--- a/tests/end2end-tests/graphstorm-nc/test.sh
+++ b/tests/end2end-tests/graphstorm-nc/test.sh
@@ -52,6 +52,11 @@ python3 -m graphstorm.run.gs_node_classification --workspace $GS_HOME/training_s
 
 error_and_exit $?
 
+echo "**************dataset: MovieLens, RGCN layer: 1, node feat: fixed HF BERT, BERT nodes: movie, inference: mini-batch, add bias and dropout"
+python3 -m graphstorm.run.gs_node_classification --workspace $GS_HOME/training_scripts/gsgnn_np/ --num-trainers $NUM_TRAINERS --num-servers 1 --num-samplers 0 --part-config /data/movielen_100k_train_val_1p_4t/movie-lens-100k.json --ip-config ip_list.txt --ssh-port 2222 --cf ml_nc.yaml --dropout 0.5 --decoder-bias True
+
+error_and_exit $?
+
 echo "**************dataset: MovieLens, RGCN layer: 1, node feat: fixed HF BERT, BERT nodes: movie, inference: mini-batch, no test_set"
 python3 -m graphstorm.run.gs_node_classification --workspace $GS_HOME/training_scripts/gsgnn_np/ --num-trainers $NUM_TRAINERS --num-servers 1 --num-samplers 0 --part-config /data/movielen_100k_train_notest_1p_4t/movie-lens-100k.json --ip-config ip_list.txt --ssh-port 2222 --cf ml_nc.yaml --logging-file /tmp/train_log.txt
 

--- a/tests/unit-tests/data_utils.py
+++ b/tests/unit-tests/data_utils.py
@@ -46,6 +46,32 @@ def generate_mask(idx, length):
     th_mask = th.tensor(mask, dtype=th.bool)
     return th_mask
 
+def generate_dummy_constant_graph(in_units):
+    """
+    Generate a dummy heterogeneous graph to test edge decoder.
+
+    Return
+    -------
+    g: a heterogeneous graph.
+
+    h: node embeddings.
+
+    edge_type: graph schema ("n0", "r0", "n1")
+    """
+    u = th.tensor([0, 0])
+    v = th.tensor([1, 2])
+    edge_type = ("n0", "r0", "n1")
+    g = dgl.heterograph({
+        edge_type: (u, v)
+    })
+
+    h = {
+        "n0": th.ones(g.num_nodes("n0"), in_units),
+        "n1": th.ones(g.num_nodes("n1"), in_units)
+    }
+
+    return g, h, edge_type
+
 def generate_dummy_hetero_graph_for_efeat_gnn(is_random=True):
     """
     generate a dummy heterogeneous graph to test the get_edge_feat_size() method.

--- a/tests/unit-tests/test_decoder.py
+++ b/tests/unit-tests/test_decoder.py
@@ -1024,7 +1024,6 @@ def test_DenseBiDecoder(in_units, num_classes):
     assert decoder.in_dims == in_units
     assert decoder.out_dims == num_classes
     assert not hasattr(decoder, "regression_head")
-    assert decoder.use_bias
 
     decoder.eval()
     with th.no_grad():
@@ -1074,12 +1073,7 @@ def test_EdgeRegression(in_dim, out_dim):
         use_bias=False
     )
 
-    try:
-        th.nn.init.zeros_(decoder.linear.bias)
-    except AttributeError:
-        pass
-    else:
-        raise AssertionError('Expected no bias.') 
+    assert not decoder.linear.bias
 
     # Test cases when bias exists (zero and nonzero)
     decoder = EdgeRegression(
@@ -1169,7 +1163,6 @@ def test_MLPEdgeDecoder(in_dim, out_dim, num_ffn_layers):
         for layer in decoder.ngnn_mlp.ngnn_gnn:
             th.nn.init.eye_(layer)
         th.nn.init.eye_(decoder.decoder)
-        th.nn.init.zeros_(decoder.bias)
         decoder.decoder[0][TARGET_CLASS] += INCREMENT_VALUE # Trick decoder
 
         prediction = decoder.predict(g, h)
@@ -1181,7 +1174,6 @@ def test_MLPEdgeDecoder(in_dim, out_dim, num_ffn_layers):
         for layer in decoder.ngnn_mlp.ngnn_gnn:
             th.nn.init.eye_(layer)
         th.nn.init.eye_(decoder.decoder)
-        th.nn.init.zeros_(decoder.bias)
         decoder.bias[TARGET_CLASS] += INCREMENT_VALUE # Trick decoder
 
         prediction = decoder.predict(g, h)
@@ -1225,7 +1217,6 @@ def test_MLPEdgeDecoder(in_dim, out_dim, num_ffn_layers):
         for layer in decoder.ngnn_mlp.ngnn_gnn:
             th.nn.init.eye_(layer)
         th.nn.init.eye_(decoder.decoder)
-        th.nn.init.zeros_(decoder.bias)
         th.nn.init.eye_(decoder.regression_head.weight)
         th.nn.init.zeros_(decoder.regression_head.bias)
         prediction = decoder.predict(g, h)
@@ -1317,7 +1308,6 @@ def test_MLPEFeatEdgeDecoder_hardcoded(in_dim, out_dim, feat_dim, num_ffn_layers
         # Test classification with nonzero bias
         TARGET_CLASS = 3
         prepareMLPEFeatEdgeDecoder(decoder)
-        th.nn.init.zeros_(decoder.bias)
         decoder.bias[TARGET_CLASS] += INCREMENT_VALUE # Trick decoder
 
         prediction = decoder.predict(g, h, efeat)
@@ -1360,7 +1350,6 @@ def test_MLPEFeatEdgeDecoder_hardcoded(in_dim, out_dim, feat_dim, num_ffn_layers
     with th.no_grad():
         # Test regression output, should be all 1s because of identity matrix weights and 1s tensor input.
         prepareMLPEFeatEdgeDecoder(decoder)
-        th.nn.init.zeros_(decoder.bias)
         th.nn.init.eye_(decoder.regression_head.weight)
         th.nn.init.zeros_(decoder.regression_head.bias)
         prediction = decoder.predict(g, h, efeat)

--- a/tests/unit-tests/test_decoder.py
+++ b/tests/unit-tests/test_decoder.py
@@ -1480,6 +1480,11 @@ if __name__ == '__main__':
     test_MLPEFeatEdgeDecoder(16,8,2,0)
     test_MLPEFeatEdgeDecoder(16,32,2,2)
 
+    test_MLPEFeatEdgeDecoder_hardcoded(16,4,8,0)
+    test_MLPEFeatEdgeDecoder_hardcoded(16,8,32,0)
+    test_MLPEFeatEdgeDecoder_hardcoded(64,8,8,2)
+    test_MLPEFeatEdgeDecoder_hardcoded(64,4,32,2)
+
     test_DenseBiDecoder(16, 4)
     test_DenseBiDecoder(16, 8)
     test_DenseBiDecoder(64, 4)

--- a/tests/unit-tests/test_gsf.py
+++ b/tests/unit-tests/test_gsf.py
@@ -205,6 +205,7 @@ def test_create_builtin_edge_decoder():
             "num_ffn_layers_in_decoder": 0,
             "multilabel_weights": None,
             "imbalance_class_weights": None,
+            "decoder_bias": True,
         }
     )
     decoder, loss_func = create_builtin_edge_decoder(g, decoder_input_dim, config, train_task)
@@ -225,6 +226,7 @@ def test_create_builtin_edge_decoder():
             "num_ffn_layers_in_decoder": 0,
             "alpha": None,
             "gamma": None,
+            "decoder_bias": True,
         }
     )
     decoder, loss_func = create_builtin_edge_decoder(g, decoder_input_dim, config, train_task)
@@ -246,6 +248,7 @@ def test_create_builtin_edge_decoder():
             "num_ffn_layers_in_decoder": 0,
             "alpha": 0.3,
             "gamma": 3.,
+            "decoder_bias": True,
         }
     )
     decoder, loss_func = create_builtin_edge_decoder(g, decoder_input_dim, config, train_task)
@@ -263,6 +266,7 @@ def test_create_builtin_edge_decoder():
             "decoder_type": "DenseBiDecoder",
             "num_decoder_basis": 2,
             "decoder_norm": None,
+            "decoder_bias": False,
         }
     )
     decoder, loss_func = create_builtin_edge_decoder(g, decoder_input_dim, config, train_task)
@@ -278,6 +282,7 @@ def test_create_builtin_edge_decoder():
             "decoder_type": "MLPDecoder",
             "num_ffn_layers_in_decoder": 0,
             "decoder_norm": None,
+            "decoder_bias": False,
         }
     )
     decoder, loss_func = create_builtin_edge_decoder(g, decoder_input_dim, config, train_task)

--- a/tests/unit-tests/test_gsf.py
+++ b/tests/unit-tests/test_gsf.py
@@ -75,7 +75,8 @@ def test_create_builtin_node_decoder():
             "class_loss_func": BUILTIN_CLASS_LOSS_CROSS_ENTROPY,
             "multilabel_weights": None,
             "decoder_norm": None,
-            "imbalance_class_weights": None
+            "imbalance_class_weights": None,
+            "decoder_bias": False,
         }
     )
 
@@ -95,6 +96,7 @@ def test_create_builtin_node_decoder():
             "imbalance_class_weights": None,
             "alpha": None,
             "gamma": None,
+            "decoder_bias": False,
         }
     )
     decoder, loss_func = create_builtin_node_decoder(g, decoder_input_dim, config, train_task)
@@ -126,7 +128,8 @@ def test_create_builtin_node_decoder():
                 "n0": None,
                 "n1": None
             },
-            "decoder_norm": None
+            "decoder_norm": None,
+            "decoder_bias": False,
         }
     )
     decoder, loss_func = create_builtin_node_decoder(g, decoder_input_dim, config, train_task)
@@ -158,6 +161,7 @@ def test_create_builtin_node_decoder():
             "decoder_norm": None,
             "alpha": 0.3,
             "gamma": 3.,
+            "decoder_bias": False,
         }
     )
     decoder, loss_func = create_builtin_node_decoder(g, decoder_input_dim, config, train_task)
@@ -174,7 +178,8 @@ def test_create_builtin_node_decoder():
     config = GSTestConfig(
         {
             "task_type": BUILTIN_TASK_NODE_REGRESSION,
-            "decoder_norm": None
+            "decoder_norm": None,
+            "decoder_bias": False,
         }
     )
     decoder, loss_func = create_builtin_node_decoder(g, decoder_input_dim, config, train_task)


### PR DESCRIPTION
*Issue #, if available:*
An extension of issue #335 

*Description of changes:*
Adding bias to edge decoders.

Regression test results after my changes:
```
Dataset		Test Performance	Validation Performance	Total Time	Epoch Time/Seconds
OGB-MAG-NC	Acc: 0.4070		Acc: 0.4151		0:25:08		69.963
OGB-PROD-NC	Acc: 0.7254		Acc: 0.9137		0:46:33		108.104
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
