### PR TITLE
Fix typo in sagemaker launcher

### DIFF
--- a/sagemaker/launch/common_parser.py
+++ b/sagemaker/launch/common_parser.py
@@ -25,7 +25,7 @@ SUPPORTED_INFER_TASKS = {
     "edge_classification",
     "edge_regression",
     "link_prediction",
-    "comput_emb",
+    "compute_emb",
     "multi_task"
 }
 


### PR DESCRIPTION
*Issue #, if available:*
There is a typo in SUPPORTED_INFER_TASKS.

*Description of changes:*
Change `comput_emb` to `compute_emb`


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
