### PR TITLE
[GSProcessing] Prevent poetry-core 2.0 from being used.

### DIFF
--- a/graphstorm-processing/pyproject.toml
+++ b/graphstorm-processing/pyproject.toml
@@ -53,7 +53,7 @@ classifiers = [
 
 
 [build-system]
-requires = ["poetry-core>=1.0.8"]
+requires = ["poetry-core<2.0.0"]
 build-backend = "poetry.core.masonry.api"
 
 [tool.black]


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

* poetry-core 2.0 seems to introduce some breaking changes, we try to prevent it from being used here. See also https://github.com/HumanSignal/label-studio-sdk/pull/382

Observed errors like the following in the GSP CI ([link](https://github.com/awslabs/graphstorm/actions/runs/12716501505/job/35454257790?pr=1099)):

```
[2025-01-10T21:37:40.821Z] AWS_BATCH_JQ_NAME=graphstorm-queue-v2
[2025-01-10T21:37:40.821Z] _=/usr/bin/env
[2025-01-10T21:37:40.821Z] jobId: 0e118ab7-26f4-4086-bcc2-6b4dfbcac20b
[2025-01-10T21:37:40.821Z] jobQueue: graphstorm-queue-v2
[2025-01-10T21:37:40.821Z] computeEnvironment: graphstorm-compute-v2
[2025-01-10T21:37:40.823Z] Cloning into 'graphstorm'...
[2025-01-10T21:37:41.380Z] REMOTE: https://github.com/jalencato/graphstorm
[2025-01-10T21:37:41.380Z] SOURCE-REF: 603c8db3a755809946944473d6732eceb40ed502
[2025-01-10T21:37:41.496Z] From https://github.com/jalencato/graphstorm
[2025-01-10T21:37:41.496Z]  * [new ref]         603c8db3a755809946944473d6732eceb40ed502 -> working
[2025-01-10T21:37:41.541Z] Switched to branch 'working'
[2025-01-10T21:37:41.940Z] Processing /usr/lib/spark/graphstorm/graphstorm-processing
[2025-01-10T21:37:41.943Z]   Installing build dependencies: started
[2025-01-10T21:37:43.300Z]   Installing build dependencies: finished with status 'done'
[2025-01-10T21:37:43.301Z]   Getting requirements to build wheel: started
[2025-01-10T21:37:43.387Z]   Getting requirements to build wheel: finished with status 'done'
[2025-01-10T21:37:43.388Z]   Preparing metadata (pyproject.toml): started
[2025-01-10T21:37:43.539Z]   Preparing metadata (pyproject.toml): finished with status 'error'
[2025-01-10T21:37:43.545Z]   error: subprocess-exited-with-error
[2025-01-10T21:37:43.545Z]   
[2025-01-10T21:37:43.545Z]   × Preparing metadata (pyproject.toml) did not run successfully.
[2025-01-10T21:37:43.545Z]   │ exit code: 1
[2025-01-10T21:37:43.545Z]   ╰─> [14 lines of output]
[2025-01-10T21:37:43.545Z]       Traceback (most recent call last):
[2025-01-10T21:37:43.545Z]         File "/usr/local/lib/python3.9/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 353, in <module>
[2025-01-10T21:37:43.545Z]           main()
[2025-01-10T21:37:43.545Z]         File "/usr/local/lib/python3.9/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 335, in main
[2025-01-10T21:37:43.545Z]           json_out['return_val'] = hook(**hook_input['kwargs'])
[2025-01-10T21:37:43.545Z]         File "/usr/local/lib/python3.9/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 149, in prepare_metadata_for_build_wheel
[2025-01-10T21:37:43.545Z]           return hook(metadata_directory, config_settings)
[2025-01-10T21:37:43.545Z]         File "/tmp/pip-build-env-t6h1_uy0/overlay/lib/python3.9/site-packages/poetry/core/masonry/api.py", line 42, in prepare_metadata_for_build_wheel
[2025-01-10T21:37:43.545Z]           poetry = Factory().create_poetry(Path().resolve(), with_groups=False)
[2025-01-10T21:37:43.545Z]         File "/tmp/pip-build-env-t6h1_uy0/overlay/lib/python3.9/site-packages/poetry/core/factory.py", line 58, in create_poetry
[2025-01-10T21:37:43.545Z]           raise RuntimeError("The Poetry configuration is invalid:\n" + message)
[2025-01-10T21:37:43.545Z]       RuntimeError: The Poetry configuration is invalid:
[2025-01-10T21:37:43.545Z]         - project must contain ['name'] properties
[2025-01-10T21:37:43.545Z]       
[2025-01-10T21:37:43.545Z]       [end of output]
[2025-01-10T21:37:43.545Z]   
[2025-01-10T21:37:43.545Z]   note: This error originates from a subprocess, and is likely not a problem with pip.
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
