### PR TITLE
[SageMaker] Fix download location for model inference

### DIFF
--- a/python/graphstorm/sagemaker/sagemaker_infer.py
+++ b/python/graphstorm/sagemaker/sagemaker_infer.py
@@ -173,7 +173,7 @@ def run_infer(args, unknownargs):
     """
     num_gpus = args.num_gpus
     data_path = args.data_path
-    model_path = '/opt/ml/gsgnn_model'
+    model_path = '/tmp/gsgnn_model'
     output_path = '/tmp/infer_output'
     os.makedirs(model_path, exist_ok=True)
     os.makedirs(output_path, exist_ok=True)

--- a/sagemaker/launch/launch_infer.py
+++ b/sagemaker/launch/launch_infer.py
@@ -118,7 +118,6 @@ def run_job(input_args, image, unknownargs):
         role=role,
         instance_count=instance_count,
         instance_type=instance_type,
-        model_uri=model_artifact_s3,
         py_version="py3",
         base_job_name=prefix,
         hyperparameters=params,

--- a/sagemaker/launch/launch_train.py
+++ b/sagemaker/launch/launch_train.py
@@ -92,15 +92,15 @@ def run_job(input_args, image, unknowargs):
 
     est = PyTorch(
         entry_point=os.path.basename(entry_point),
-        source_dir=os.path.dirname(entry_point),
+        hyperparameters=params,
         image_uri=container_image_uri,
-        role=role,
         instance_count=instance_count,
         instance_type=instance_type,
         output_path=model_artifact_s3,
         py_version="py3",
-        base_job_name=prefix,
-        hyperparameters=params,
+        role=role,
+        sagemaker_session=sess,
+        source_dir=os.path.dirname(entry_point),
         tags=[{"Key":"GraphStorm", "Value":"oss"},
               {"Key":"GraphStorm_Task", "Value":"Training"}],
         **estimator_kwargs

--- a/sagemaker/launch/launch_train.py
+++ b/sagemaker/launch/launch_train.py
@@ -66,8 +66,6 @@ def run_job(input_args, image, unknowargs):
 
     container_image_uri = image
 
-    prefix = f"gs-train-{graph_name}"
-
     params = {
         "graph-data-s3": graph_data_s3,
         "graph-name": graph_name,


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

* Remove double download of model files and ensure models are downloaded under /tmp
* Tested by running a node classification job with ogb-arxiv data

Fixes #949

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
