### PR TITLE
[SageMaker] Make default region value be None, so AWS config takes precedence

### DIFF
--- a/sagemaker/launch/common_parser.py
+++ b/sagemaker/launch/common_parser.py
@@ -52,8 +52,9 @@ def get_common_parser() -> argparse.ArgumentParser:
         default=1,
         help="number of instances")
     common_args.add_argument("--region", type=str,
-        default="us-west-2",
-        help="Region")
+        default=None,
+        help="AWS region to launch jobs in. Default is None, "
+        "which will rely on you AWS configuration to determine the region.")
     common_args.add_argument("--task-name", type=str,
         default=None, help="User defined SageMaker task name")
     common_args.add_argument("--sm-estimator-parameters", type=str,


### PR DESCRIPTION


*Issue #, if available:*

*Description of changes:*

* Our current default for region in SageMaker jobs will override users' local configuration. By setting this to None by default we respect the local config, while allowing users to specify a different region if needed.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
