### PR TITLE
[GSProcessing] Add standard numerical transformation to gconstruct config converter.

### DIFF
--- a/graphstorm-processing/graphstorm_processing/config/config_conversion/gconstruct_converter.py
+++ b/graphstorm-processing/graphstorm_processing/config/config_conversion/gconstruct_converter.py
@@ -145,10 +145,21 @@ class GConstructConfigConverter(ConfigConverter):
             if "transform" in gconstruct_feat_dict:
                 gconstruct_transform_dict = gconstruct_feat_dict["transform"]
 
+                ### START TRANSFORMATION ALTERNATIVES ###
                 if gconstruct_transform_dict["name"] == "max_min_norm":
                     gsp_transformation_dict["name"] = "numerical"
                     gsp_transformation_dict["kwargs"] = {
                         "normalizer": "min-max",
+                        "imputer": "none",
+                    }
+                    if gconstruct_transform_dict.get("out_dtype") in VALID_OUTDTYPE:
+                        gsp_transformation_dict["kwargs"]["out_dtype"] = gconstruct_transform_dict[
+                            "out_dtype"
+                        ]
+                elif gconstruct_transform_dict["name"] == "standard":
+                    gsp_transformation_dict["name"] = "numerical"
+                    gsp_transformation_dict["kwargs"] = {
+                        "normalizer": "standard",
                         "imputer": "none",
                     }
 
@@ -219,6 +230,7 @@ class GConstructConfigConverter(ConfigConverter):
                         "Unsupported GConstruct transformation name: "
                         f"{gconstruct_transform_dict['name']}"
                     )
+                ### END TRANSFORMATION ALTERNATIVES ###
             else:
                 gsp_transformation_dict["name"] = "no-op"
 

--- a/graphstorm-processing/graphstorm_processing/data_transformations/dist_transformations/dist_hf_transformation.py
+++ b/graphstorm-processing/graphstorm_processing/data_transformations/dist_transformations/dist_hf_transformation.py
@@ -109,7 +109,7 @@ def apply_transform(
             device = f"cuda:{gpu}"
         else:
             device = "cpu"
-        logging.warning("The device to run huggingface transformation is %s", device)
+            logging.warning("Running HuggingFace transformation on CPU, runtime can be very long.")
         tokenizer = AutoTokenizer.from_pretrained(hf_model)
         if max_seq_length > tokenizer.model_max_length:
             # TODO: Could we possibly raise this at config time?

--- a/graphstorm-processing/tests/test_converter.py
+++ b/graphstorm-processing/tests/test_converter.py
@@ -432,6 +432,10 @@ def test_convert_gsprocessing(converter: GConstructConfigConverter):
                     "feature_name": "hard_negative",
                     "transform": {"name": "edge_dst_hard_negative", "separator": ";"},
                 },
+                {
+                    "feature_col": ["num_feature"],
+                    "transform": {"name": "standard"},
+                },
             ],
             "labels": [
                 {
@@ -541,6 +545,13 @@ def test_convert_gsprocessing(converter: GConstructConfigConverter):
             "column": "author",
             "name": "hard_negative",
             "transformation": {"name": "edge_dst_hard_negative", "kwargs": {"separator": ";"}},
+        },
+        {
+            "column": "num_feature",
+            "transformation": {
+                "name": "numerical",
+                "kwargs": {"normalizer": "standard", "imputer": "none"},
+            },
         },
     ]
     assert edges_output["labels"] == [


### PR DESCRIPTION


*Issue #, if available:*

*Description of changes:*

* The `standard` transform was added to gconstruct in #1101 but we haven't added it to the gconstruct-to-gsp config converter.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
