### PR TITLE
[Feature] Supports edge features in HGT model

### DIFF
--- a/python/graphstorm/model/__init__.py
+++ b/python/graphstorm/model/__init__.py
@@ -44,7 +44,7 @@ from .rgat_encoder import RelationalGATEncoder, RelationalAttLayer
 from .sage_encoder import SAGEEncoder, SAGEConv
 from .gat_encoder import GATEncoder, GATConv
 from .gatv2_encoder import GATv2Encoder, GATv2Conv
-from .hgt_encoder import HGTEncoder, HGTLayer
+from .hgt_encoder import HGTEncoder, HGTLayer, HGTLayerwithEdgeFeat
 
 from .node_decoder import EntityClassifier, EntityRegression
 from .edge_decoder import (DenseBiDecoder,

--- a/python/graphstorm/model/hgt_encoder.py
+++ b/python/graphstorm/model/hgt_encoder.py
@@ -17,7 +17,7 @@
 """
 import logging
 import math
-import torch
+import torch as th
 import torch.nn.functional as F
 import dgl.function as fn
 
@@ -27,6 +27,7 @@ from ..config import BUILDIN_GNN_BATCH_NORM, BUILDIN_GNN_LAYER_NORM, BUILTIN_GNN
 from .ngnn_mlp import NGNNMLP
 from .gnn_encoder_base import (GraphConvEncoder,
                                GSgnnGNNEncoderInterface)
+from ..config import BUILTIN_EDGE_FEAT_MP_OPS
 
 
 class HGTLayer(nn.Module):
@@ -135,6 +136,33 @@ class HGTLayer(nn.Module):
             self.use_norm = False
 
         # Node type parameters
+        self.k_linears, \
+            self.q_linears, \
+            self.v_linears, \
+            self.a_linears, \
+            self.norms, \
+            self.skip = self._create_node_parameters(ntypes, in_dim, out_dim,
+                                                     self.use_norm, norm)
+
+        # Edge type parameters
+        self.relation_pri, \
+            self.relation_att, \
+            self.relation_msg = self._create_edge_parameters(canonical_etypes,
+                                                             self.num_heads,
+                                                             self.d_k)
+
+        # ngnn
+        self.num_ffn_layers_in_gnn = num_ffn_layers_in_gnn
+        self.ngnn_mlp = NGNNMLP(out_dim, out_dim,
+                                num_ffn_layers_in_gnn, fnn_activation, dropout)
+
+        # Dropout
+        self.drop = nn.Dropout(dropout)
+        self.warn_msg = set()
+
+    def _create_node_parameters(self, ntypes, in_dim, out_dim, use_norm, norm):
+        """ Internal method for creating node type related HGT parameters.
+        """
         k_linears = {}
         q_linears = {}
         v_linears = {}
@@ -146,45 +174,42 @@ class HGTLayer(nn.Module):
             q_linears[ntype] = nn.Linear(in_dim, out_dim)
             v_linears[ntype] = nn.Linear(in_dim, out_dim)
             a_linears[ntype] = nn.Linear(in_dim, out_dim)
-            if self.use_norm:
+            if use_norm:
                 if norm == BUILDIN_GNN_BATCH_NORM:
                     norms[ntype] = nn.BatchNorm1d(out_dim)
                 elif norm == BUILDIN_GNN_LAYER_NORM:
                     norms[ntype] = nn.LayerNorm(out_dim)
-            skip[ntype] = nn.Parameter(torch.ones(1))
+            skip[ntype] = nn.Parameter(th.ones(1))
 
-        self.k_linears = nn.ParameterDict(k_linears)
-        self.q_linears = nn.ParameterDict(q_linears)
-        self.v_linears = nn.ParameterDict(v_linears)
-        self.a_linears = nn.ParameterDict(a_linears)
-        if self.use_norm:
-            self.norms = nn.ParameterDict(norms)
-        self.skip = nn.ParameterDict(skip)
+        para_k_linears = nn.ParameterDict(k_linears)
+        para_q_linears = nn.ParameterDict(q_linears)
+        para_v_linears = nn.ParameterDict(v_linears)
+        para_a_linears = nn.ParameterDict(a_linears)
+        if use_norm:
+            para_norms = nn.ParameterDict(norms)
+        para_skip = nn.ParameterDict(skip)
 
-        # Edge type parameters
+        return para_k_linears, para_q_linears, para_v_linears, \
+               para_a_linears, para_norms, para_skip
+
+    def _create_edge_parameters(self, canonical_etypes, num_heads, d_k):
+        """ Internal method for creating edge type related HGT parameters.
+        """
         relation_pri = {}
         relation_att = {}
         relation_msg = {}
         for canonical_etype in canonical_etypes:
             c_etype_str = '_'.join(canonical_etype)
-            relation_pri[c_etype_str] = nn.Parameter(torch.ones(self.num_heads))
+            relation_pri[c_etype_str] = nn.Parameter(th.ones(num_heads))
             relation_att[c_etype_str] = nn.init.xavier_uniform_(
-                nn.Parameter(torch.Tensor(self.num_heads, self.d_k, self.d_k)))
+                nn.Parameter(th.Tensor(num_heads, d_k, d_k)))
             relation_msg[c_etype_str] = nn.init.xavier_uniform_(
-                nn.Parameter(torch.Tensor(self.num_heads, self.d_k, self.d_k)))
+                nn.Parameter(th.Tensor(num_heads, d_k, d_k)))
 
-        self.relation_pri = nn.ParameterDict(relation_pri)
-        self.relation_att = nn.ParameterDict(relation_att)
-        self.relation_msg = nn.ParameterDict(relation_msg)
-
-        # ngnn
-        self.num_ffn_layers_in_gnn = num_ffn_layers_in_gnn
-        self.ngnn_mlp = NGNNMLP(out_dim, out_dim,
-                                num_ffn_layers_in_gnn, fnn_activation, dropout)
-
-        # Dropout
-        self.drop = nn.Dropout(dropout)
-        self.warn_msg = set()
+        para_relation_pri = nn.ParameterDict(relation_pri)
+        para_relation_att = nn.ParameterDict(relation_att)
+        para_relation_msg = nn.ParameterDict(relation_msg)
+        return para_relation_pri, para_relation_att, para_relation_msg
 
     def warning_once(self, warn_msg):
         """ Print same warning msg only once
@@ -240,8 +265,8 @@ class HGTLayer(nn.Module):
                 relation_pri = self.relation_pri[c_etype_str]
                 relation_msg = self.relation_msg[c_etype_str]
 
-                k_val = torch.einsum("bij,ijk->bik", k_val, relation_att)
-                v_val = torch.einsum("bij,ijk->bik", v_val, relation_msg)
+                k_val = th.einsum("bij,ijk->bik", k_val, relation_att)
+                v_val = th.einsum("bij,ijk->bik", v_val, relation_msg)
 
                 sub_graph.srcdata['k'] = k_val
                 sub_graph.dstdata['q'] = q_val
@@ -261,7 +286,7 @@ class HGTLayer(nn.Module):
             new_h = {}
             for k, _ in h.items():
                 if g.num_dst_nodes(k) > 0:
-                    alpha = torch.sigmoid(self.skip[k])
+                    alpha = th.sigmoid(self.skip[k])
                     if g.dstnodes[k].data.get('t') is not None:
                         t = g.dstnodes[k].data['t'].view(-1, self.out_dim)
                         trans_out = self.drop(t)
@@ -304,6 +329,10 @@ class HGTEncoder(GraphConvEncoder, GSgnnGNNEncoderInterface):
     The ``HGTEncoder`` employs several ``HGTLayer`` as its encoding mechanism.
     The ``HGTEncoder`` should be designated as the model's encoder within Graphstorm.
 
+    .. versionchanged:: 0.4.1
+        Add two new arguments ``edge_feat_name`` and ``edge_feat_mp_op`` in v0.4.1 to
+        support edge features in HGT encoder.
+
     Parameters
     -----------
     g: DistGraph
@@ -316,6 +345,17 @@ class HGTEncoder(GraphConvEncoder, GSgnnGNNEncoderInterface):
         Number of hidden layers. Total GNN layers is equal to ``num_hidden_layers + 1``.
     num_heads: int
         Number of attention heads.
+    edge_feat_name: dict of list of str
+        User provided edge feature names in the format of {etype1:[feat1, feat2, ...],
+        etype2:[...], ...}, or None if not provided.
+    edge_feat_mp_op: str
+        The opration method to combine source node embeddings with edge embeddings in message
+        passing. Options include `concat`, `add`, `sub`, `mul`, and `div`.
+        ``concat`` operation will concatenate the source node features with edge features;
+        ``add`` operation will add the source node features with edge features together;
+        ``sub`` operation will subtract the source node features by edge features;
+        ``mul`` operation will multiply the source node features with edge features; and
+        ``div`` operation will divide the source node features by edge features.
     dropout: float
         Dropout rate. Default: 0.2.
     norm: str
@@ -366,6 +406,8 @@ class HGTEncoder(GraphConvEncoder, GSgnnGNNEncoderInterface):
                  out_dim,
                  num_hidden_layers,
                  num_heads,
+                 edge_feat_name=None,
+                 edge_feat_mp_op='concat',
                  dropout=0.2,
                  norm=BUILDIN_GNN_LAYER_NORM,
                  num_ffn_layers_in_gnn=0):
@@ -374,25 +416,55 @@ class HGTEncoder(GraphConvEncoder, GSgnnGNNEncoderInterface):
         self.layers = nn.ModuleList()
         # h2h
         for _ in range(num_hidden_layers):
+            if edge_feat_name is None:
+                self.layers.append(HGTLayer(hid_dim,
+                                            hid_dim,
+                                            g.ntypes,
+                                            g.canonical_etypes,
+                                            activation=F.relu,
+                                            num_heads=num_heads,
+                                            dropout=dropout,
+                                            norm=norm,
+                                            num_ffn_layers_in_gnn=num_ffn_layers_in_gnn,
+                                            fnn_activation=F.relu))
+            else:
+                self.layers.append(HGTLayerwithEdgeFeat(
+                                            hid_dim,
+                                            hid_dim,
+                                            g.ntypes,
+                                            g.canonical_etypes,
+                                            activation=F.relu,
+                                            num_heads=num_heads,
+                                            edge_feat_name=edge_feat_name,
+                                            edge_feat_mp_op=edge_feat_mp_op,
+                                            dropout=dropout,
+                                            norm=norm,
+                                            num_ffn_layers_in_gnn=num_ffn_layers_in_gnn,
+                                            fnn_activation=F.relu))
+        # h2o
+        if edge_feat_name is None:
             self.layers.append(HGTLayer(hid_dim,
+                                        out_dim,
+                                        g.ntypes,
+                                        g.canonical_etypes,
+                                        num_heads=num_heads,
+                                        activation=F.relu,
+                                        dropout=dropout,
+                                        norm=norm))
+        else:
+            self.layers.append(HGTLayerwithEdgeFeat(
+                                        hid_dim,
                                         hid_dim,
                                         g.ntypes,
                                         g.canonical_etypes,
                                         activation=F.relu,
                                         num_heads=num_heads,
+                                        edge_feat_name=edge_feat_name,
+                                        edge_feat_mp_op=edge_feat_mp_op,
                                         dropout=dropout,
                                         norm=norm,
                                         num_ffn_layers_in_gnn=num_ffn_layers_in_gnn,
                                         fnn_activation=F.relu))
-        # h2o
-        self.layers.append(HGTLayer(hid_dim,
-                                    out_dim,
-                                    g.ntypes,
-                                    g.canonical_etypes,
-                                    num_heads=num_heads,
-                                    activation=F.relu,
-                                    dropout=dropout,
-                                    norm=norm))
 
     def skip_last_selfloop(self):
         # HGT does not have explicit self-loop
@@ -402,8 +474,18 @@ class HGTEncoder(GraphConvEncoder, GSgnnGNNEncoderInterface):
         # HGT does not have explicit self-loop
         pass
 
-    def forward(self, blocks, h):
+    def is_support_edge_feat(self):
+        """ Overwrite ``GraphConvEncoder`` class' method, indicating HGTEncoder
+       supports edge features.
+        """
+        return True
+
+    def forward(self, blocks, n_h, e_hs=None):
         """HGT encoder forward computation.
+
+        .. versionchanged:: 0.4.1
+            Change inputs into blocks, n_h and e_hs in v0.4.1 to support edge feature
+            in HGT encoder.
 
         Parameters
         ----------
@@ -412,15 +494,291 @@ class HGTEncoder(GraphConvEncoder, GSgnnGNNEncoderInterface):
             detailed information about DGL MFG can be found in `DGL Neighbor Sampling
             Overview
             <https://docs.dgl.ai/stochastic_training/neighbor_sampling_overview.html>`_.
-        h: dict of Tensor
+        n_h: dict of Tensor
             Input node features for each node type in the format of {ntype: tensor}.
+        e_hs: list of dict of Tensor
+            Input edge features for each edge type in the format of [{etype: tensor}, ...],
+            or [{}, {}. ...] for zero number of edges in input blocks. The length of e_hs
+            should be equal to the number of gnn layers. Default is None.
 
         Returns
         ----------
         h: dict of Tensor
             New node embeddings for each node type in the format of {ntype: tensor}.
         """
-        for layer, block in zip(self.layers, blocks):
-            h = layer(block, h)
+        if e_hs is not None:
+            assert len(e_hs) == len(blocks), 'The layer of edge features should be equal to ' + \
+                f'the number of blocks, but got {len(e_hs)} layers of edge features ' + \
+                f'and {len(blocks)} blocks.'
 
-        return h
+            for layer, block, e_h in zip(self.layers, blocks, e_hs):
+                n_h = layer(block, n_h, e_h)
+        else:
+            for layer, block in zip(self.layers, blocks):
+                n_h = layer(block, n_h)
+
+        return n_h
+
+
+class HGTLayerwithEdgeFeat(HGTLayer):
+    r""" Enhanced heterogenous graph transformer (HGT) layer with edge feature supported.
+
+    .. versionadded:: 0.4.1
+        In version 0.4.1, add a new HGT layer that supports edge features.
+
+    This class extends from `HGTLayer` so as to reuse its variables and methods.
+
+    Implementation in this class uses a simple idea to include edge feature into the original
+    HGT model, i.e., combine embeddings of source node with embeddings of edge as the new `K`,
+    and `V`, then use this new `K` and `V` in HGT formulas. And the way of combination is same
+    as the RGCN conv model, including `concat`, `add`, `sub`, `mul`, and `div`.
+
+    Parameters
+    ----------
+    in_dim: int
+        Input dimension size.
+    out_dim: int
+        Output dimension size.
+    ntypes: list of str
+        List of node types in the format of [ntype1, ntype2, ...].
+    canonical_etypes: list of tuple
+        List of canonical edge types in the format of [('src_ntyp1', 'etype1', 'dst_ntype1`),
+        ...].
+    num_heads: int
+        Number of attention heads.
+    edge_feat_name: dict of list of str
+        User provided edge feature names in the format of {etype1:[feat1, feat2, ...],
+        etype2:[...], ...}, or None if not provided.
+    edge_feat_mp_op: str
+        The opration method to combine source node embeddings with edge embeddings in message
+        passing. Options include ``concat``, ``add``, ``sub``, ``mul``, and ``div``.
+        ``concat`` operation will concatenate the source node features with edge features;
+        ``add`` operation will add the source node features with edge features together;
+        ``sub`` operation will subtract the source node features by edge features;
+        ``mul`` operation will multiply the source node features with edge features; and
+        ``div`` operation will divide the source node features by edge features.
+    activation: callable
+        Activation function. Default: None.
+    dropout: float
+        Dropout rate. Default: 0.2.
+    norm: str
+        Normalization methods. Options:``batch``, ``layer``, and ``None``. Default: ``layer``.
+    num_ffn_layers_in_gnn: int
+        Number of fnn layers between gnn layers. Default: 0.
+    """
+    def __init__(self,
+                 in_dim,
+                 out_dim,
+                 ntypes,
+                 canonical_etypes,
+                 num_heads,
+                 edge_feat_name=None,
+                 edge_feat_mp_op='concat',
+                 activation=None,
+                 dropout=0.2,
+                 norm=BUILDIN_GNN_LAYER_NORM,
+                 num_ffn_layers_in_gnn=0,
+                 fnn_activation=F.relu):
+        # initialize base HGT parameters
+        super(HGTLayerwithEdgeFeat, self).__init__(
+            in_dim=in_dim,
+            out_dim=out_dim,
+            ntypes=ntypes,
+            canonical_etypes=canonical_etypes,
+            num_heads=num_heads,
+            activation=activation,
+            dropout=dropout,
+            norm=norm,
+            num_ffn_layers_in_gnn=num_ffn_layers_in_gnn,
+            fnn_activation=fnn_activation
+        )
+        # set edge feature related variables
+        assert edge_feat_name, 'To use HGTLayerwithEdgeFeat, must provide non-empty edge, ' + \
+            f'feature name, but got {edge_feat_name}.'
+        self.edge_feat_name=edge_feat_name
+
+        assert edge_feat_mp_op in BUILTIN_EDGE_FEAT_MP_OPS, 'GraphStorm only support edge' + \
+            f' message passing operation in {BUILTIN_EDGE_FEAT_MP_OPS}, bug got ' + \
+            f'{edge_feat_mp_op}.'
+        self.edge_feat_mp_op=edge_feat_mp_op
+
+        # initialize edge feature related parameters for `concat` op
+        if edge_feat_mp_op in ['concat']:
+            self.ef_linears = self._create_ef_parameters(in_dim, out_dim, canonical_etypes,
+                                                         edge_feat_name)
+        
+    def _create_ef_parameters(self, in_dim, out_dim, canonical_etypes, edge_feat_name):
+        """ Create edge feature specific parameters when message passing operator is `concat`.
+        
+        With the design idea of combining edge feature into HGT algorithm, only when the
+        message passing operator is `concat`, will we need addition weight parameters. For
+        other operators, there is no addition parameters required because edge embeddings have
+        the same dimension as embeddings of source nodes so can be directly added, substracted,
+        mutilied and devided.
+        
+        In this implementation, we use a linear algebra trick for concatination operation, i.e.,
+        concat([e1, e2], dim=-1) @ w ==  e1 @ w1 + e2 @ w2, where e1 and e2 have the same
+        dimension (N * in_dim), w1 and w2 have the same dimension (in_dim, out_dim), and w has
+        the dimension (in_dim * 2, out_dim).
+
+        Based on this trick, we only define additional parameters for an edge type with features
+        and the massage passing operation is `concat`.
+        """
+        ef_linears = {}
+        for canonical_etype in canonical_etypes:
+            if canonical_etype in edge_feat_name:
+                c_etype_str = '_'.join(canonical_etype)
+                ef_linears[c_etype_str] = nn.Linear(in_dim, out_dim)
+
+        para_ef_linears = nn.ParameterDict(ef_linears)
+        
+        return para_ef_linears
+
+    def forward(self, g, n_h, e_h):
+        """ HGT with edge feature support layer forward computation.
+
+        Parameters
+        ----------
+        g: DGLHeteroGraph
+            Input DGL heterogenous graph.
+        n_h: dict of Tensor
+            Node features for each node type in the format of {ntype: tensor}.
+        e_h: dict of Tensor
+            edge features for each edge type in the format of {etype: tensor}. Default is None.
+
+        Returns
+        -------
+        dict of Tensor: New node embeddings for each node type in the format of {ntype: tensor}.
+        """
+        assert len(e_h) == 0 or self.edge_feat_name is not None, "Since you want to use " + \
+        f"edge features on edge type {list(e_h.keys())} in message passing " + \
+        "computation, please initialize the HGTLayerwithEdgeFeat by setting the " + \
+        "\"edge_feat_name\" argument."
+
+        # pylint: disable=no-member
+        with g.local_scope():
+            edge_fn = {}
+            for srctype, etype, dsttype in g.canonical_etypes:
+                c_etype_str = '_'.join((srctype, etype, dsttype))
+                # extract each relation as a sub graph
+                sub_graph = g[srctype, etype, dsttype]
+
+                # extract source, destination, and edge embeds
+                src_nh = n_h[srctype]
+                sub_graph.srcdata['src_nh'] = src_nh
+                
+                # copy source embed to edges, and extract from edata
+                sub_graph.apply_edges(fn.copy_u('src_nh', 'src_eh'))
+                src_eh = sub_graph.edata['src_eh']
+
+                # extract src, dst, and edge parameters
+                k_linear = self.k_linears[srctype]
+                v_linear = self.v_linears[srctype]
+                q_linear = self.q_linears[dsttype]
+
+                relation_att = self.relation_att[c_etype_str]
+                relation_pri = self.relation_pri[c_etype_str]
+                relation_msg = self.relation_msg[c_etype_str]
+
+                # combine src_eh with e_h
+                if (srctype, etype, dsttype) in e_h:
+                    edge_h = e_h[(srctype, etype, dsttype)]
+                    if self.edge_feat_mp_op == 'concat':
+                        ef_linear = self.ef_linears[c_etype_str]
+
+                        src_k_val = k_linear(src_eh)
+                        edge_val = ef_linear(edge_h)
+                        k_val = src_k_val + edge_val
+                        
+                        src_v_val = v_linear(src_eh)
+                        v_val = src_v_val + edge_val
+                    elif self.edge_feat_mp_op == 'add':
+                        new_src_h = src_eh + edge_h
+                        k_val = k_linear(new_src_h)
+                        v_val = v_linear(new_src_h)
+                    elif self.edge_feat_mp_op == 'sub':
+                        new_src_h = src_eh - edge_h
+                        k_val = k_linear(new_src_h)
+                        v_val = v_linear(new_src_h)
+                    elif self.edge_feat_mp_op == 'mul':
+                        new_src_h = src_eh * edge_h
+                        k_val = k_linear(new_src_h)
+                        v_val = v_linear(new_src_h)
+                    elif self.edge_feat_mp_op == 'div':
+                        new_src_h = src_eh / edge_h
+                        k_val = k_linear(new_src_h)
+                        v_val = v_linear(new_src_h)
+                    else:
+                        raise ValueError('Unknown edge message passing operation: ' + \
+                                        f'{self.edge_feat_mp_op}. It should be one of ' + \
+                                        f'{BUILTIN_EDGE_FEAT_MP_OPS}.')
+
+                    k_val = k_val.view(-1, self.num_heads, self.d_k)
+                    v_val = v_val.view(-1, self.num_heads, self.d_k)
+                else:
+                    k_val = k_linear(src_eh).view(-1, self.num_heads, self.d_k)
+                    v_val = v_linear(src_eh).view(-1, self.num_heads, self.d_k)
+
+                k_val = th.einsum("bij,ijk->bik", k_val, relation_att)
+                v_val = th.einsum("bij,ijk->bik", v_val, relation_msg)
+
+                if g.is_block:
+                    q_val = q_linear(n_h[dsttype][:sub_graph.num_dst_nodes()]).view(-1,
+                                                                            self.num_heads,
+                                                                            self.d_k)
+                else:
+                    q_val = q_linear(n_h[dsttype]).view(-1, self.num_heads, self.d_k)
+
+                # compute attention scores
+                sub_graph.edata['k'] = k_val
+                sub_graph.dstdata['q'] = q_val
+                sub_graph.apply_edges(fn.v_dot_e('q', 'k', 't'))
+
+                attn_score = sub_graph.edata.pop('t').sum(-1) * relation_pri / self.sqrt_dk
+                attn_score = edge_softmax(sub_graph, attn_score, norm_by='dst')
+                attn_v_val = v_val * attn_score.unsqueeze(-1)
+                sub_graph.edata[f'h_{c_etype_str}'] = attn_v_val
+
+                edge_fn[srctype, etype, dsttype] = (fn.copy_e(f'h_{c_etype_str}', 'm'),
+                                                    fn.sum('m', 't'))
+
+            g.multi_update_all(edge_fn, cross_reducer="mean")
+
+            new_h = {}
+            for k, _ in n_h.items():
+                if g.num_dst_nodes(k) > 0:
+                    alpha = th.sigmoid(self.skip[k])
+                    if g.dstnodes[k].data.get('t') is not None:
+                        t = g.dstnodes[k].data['t'].view(-1, self.out_dim)
+                        trans_out = self.drop(t)
+                        if g.is_block:
+                            trans_out = trans_out * alpha + \
+                                self.a_linears[k](n_h[k][:g.num_dst_nodes(k)]) * (1-alpha)
+                        else:
+                            trans_out = trans_out * alpha + self.a_linears[k](n_h[k]) * (1-alpha)
+                    else:                       # Nodes not really in destination side.
+                        warn_msg = "Warning. Graph convolution returned empty " \
+                            f"dictionary for nodes in type: {str(k)}. Please check your data" \
+                            f" for no in-degree nodes in type: {str(k)}."
+                        self.warning_once(warn_msg)
+                        # So add psudo self-loop for the destination nodes with its own feature.
+                        dst_h = self.a_linears[k](n_h[k][:g.num_dst_nodes(k)])
+                        trans_out = self.drop(dst_h)
+                        trans_out = trans_out * alpha + dst_h * (1-alpha)
+                else:
+                    # Handle zero number of dst nodes, which is an extreme case
+                    if g.dstnodes[k].data.get('t') is not None:
+                        trans_out = self.a_linears[k](n_h[k])
+                    else:
+                        continue
+
+                if self.use_norm:
+                    new_h[k] = self.norms[k](trans_out)
+                else:
+                    new_h[k] = trans_out
+                if self.activation:
+                    new_h[k] = self.activation(new_h[k])
+                if self.num_ffn_layers_in_gnn > 0:
+                    new_h[k] = self.ngnn_mlp(new_h[k])
+
+            return new_h

--- a/tests/unit-tests/test_nn_model.py
+++ b/tests/unit-tests/test_nn_model.py
@@ -768,16 +768,16 @@ def test_hgt_with_edge_features(input_dim, output_dim, dev):
 
 
 if __name__ == '__main__':
-    # test_rgcn_with_zero_input(32, 64)
-    # test_rgat_with_zero_input(32, 64)
-    # test_hgt_with_zero_input(32, 64)
+    test_rgcn_with_zero_input(32, 64)
+    test_rgat_with_zero_input(32, 64)
+    test_hgt_with_zero_input(32, 64)
 
-    # test_rgcn_with_no_indegree_dstnodes(32, 64)
-    # test_rgat_with_no_indegree_dstnodes(32, 64)
-    # test_hgt_with_no_indegree_dstnodes(32, 64)
+    test_rgcn_with_no_indegree_dstnodes(32, 64)
+    test_rgat_with_no_indegree_dstnodes(32, 64)
+    test_hgt_with_no_indegree_dstnodes(32, 64)
 
-    # test_rgcn_with_edge_features(32, 64, 'cpu')
-    # test_rgcn_with_edge_features(64, 64, 'cpu')
-    # test_rgcn_with_edge_features(32, 64, 'cuda:0')
+    test_rgcn_with_edge_features(32, 64, 'cpu')
+    test_rgcn_with_edge_features(64, 64, 'cpu')
+    test_rgcn_with_edge_features(32, 64, 'cuda:0')
 
     test_hgt_with_edge_features(32, 64, 'cpu')


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This PR implements edge feature support for HGT model, including,
1. Add a new `HGTLayerwithEdgeFeat` class dedicated for edge feature cases;
2. Add two new arguments, `edge_feat_name` and `edge_feat_mp_op` in `HGTEncoder` construction to support edge feature, and modify `__init__()` function to create HGT layers according to the `edge_feat_name` argument.
3. Change `HGTEncoder` input argument `h` in `forward()` function into `n_h` and `e_hs`.
4. Change the `forward()` function logic to decided whether to use edge features or not.
5. Add new unit test cases for the `HGTLayerwithEdgeFeat` class.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
