### PR TITLE
Handle the cases when the input edge file(s) are empty

### DIFF
--- a/python/graphstorm/gconstruct/file_io.py
+++ b/python/graphstorm/gconstruct/file_io.py
@@ -188,8 +188,9 @@ def read_data_csv(data_file, data_fields=None, delimiter=','):
     """
     data = pd.read_csv(data_file, delimiter=delimiter)
     if data.shape[0] == 0:
-        logging.warning(f"{data_file} has an empty data. "
-                        f"The data frame shape is {data.shape}")
+        logging.warning("%s has an empty data. "
+                        "The data frame shape is %s",
+                        data_file, data.shape)
         return None
 
     if data_fields is not None:
@@ -244,7 +245,7 @@ def read_data_json(data_file, data_fields):
         for line in json_file.readlines():
             record = json.loads(line)
             data_records.append(record)
-    logging.warning(f"JSON as graph input data support is deprecated "
+    logging.warning("JSON as graph input data support is deprecated "
                     "and no longer maintained. Please use CSV or parquet.")
 
     assert len(data_records) > 0, \
@@ -315,8 +316,9 @@ def read_data_parquet(data_file, data_fields=None):
     df_table = table.to_pandas()
 
     if df_table.shape[0] == 0:
-        logging.warning(f"{data_file} has an empty data. "
-                        f"The data frame shape is {df_table.shape}")
+        logging.warning("%s has an empty data. "
+                        "The data frame shape is %s",
+                        data_file, data.shape)
         return None
 
     if data_fields is None:

--- a/python/graphstorm/gconstruct/file_io.py
+++ b/python/graphstorm/gconstruct/file_io.py
@@ -187,8 +187,10 @@ def read_data_csv(data_file, data_fields=None, delimiter=','):
     dict of Numpy arrays.
     """
     data = pd.read_csv(data_file, delimiter=delimiter)
-    assert data.shape[0] > 0, \
-        f"{data_file} has an empty data. The data frame shape is {data.shape}"
+    if data.shape[0] == 0:
+        logging.warning(f"{data_file} has an empty data. "
+                        "The data frame shape is {data.shape}")
+        return None
 
     if data_fields is not None:
         for field in data_fields:
@@ -242,8 +244,9 @@ def read_data_json(data_file, data_fields):
         for line in json_file.readlines():
             record = json.loads(line)
             data_records.append(record)
-    assert len(data_records) > 0, \
-        f"{data_file} is empty {data_records}."
+    if len(data_records) == 0:
+        logging.warning(f"{data_file} is empty {data_records}.")
+        return None
 
     data = {key: [] for key in data_fields}
     for record in data_records:
@@ -308,6 +311,12 @@ def read_data_parquet(data_file, data_fields=None):
     table = pq.read_table(data_file)
     data = {}
     df_table = table.to_pandas()
+
+    if df_table.shape[0] == 0:
+        logging.warning(f"{data_file} has an empty data. "
+                        "The data frame shape is {df_table.shape}")
+        return None
+
     assert df_table.shape[0] > 0, \
         f"{data_file} has an empty data. The data frame shape is {df_table.shape}"
 

--- a/python/graphstorm/gconstruct/file_io.py
+++ b/python/graphstorm/gconstruct/file_io.py
@@ -318,7 +318,7 @@ def read_data_parquet(data_file, data_fields=None):
     if df_table.shape[0] == 0:
         logging.warning("%s has an empty data. "
                         "The data frame shape is %s",
-                        data_file, data.shape)
+                        data_file, df_table.shape)
         return None
 
     if data_fields is None:

--- a/python/graphstorm/gconstruct/file_io.py
+++ b/python/graphstorm/gconstruct/file_io.py
@@ -189,7 +189,7 @@ def read_data_csv(data_file, data_fields=None, delimiter=','):
     data = pd.read_csv(data_file, delimiter=delimiter)
     if data.shape[0] == 0:
         logging.warning(f"{data_file} has an empty data. "
-                        "The data frame shape is {data.shape}")
+                        f"The data frame shape is {data.shape}")
         return None
 
     if data_fields is not None:
@@ -244,9 +244,11 @@ def read_data_json(data_file, data_fields):
         for line in json_file.readlines():
             record = json.loads(line)
             data_records.append(record)
-    if len(data_records) == 0:
-        logging.warning(f"{data_file} is empty {data_records}.")
-        return None
+    logging.warning(f"JSON as graph input data support is deprecated "
+                    "and no longer maintained. Please use CSV or parquet.")
+
+    assert len(data_records) > 0, \
+        f"{data_file} is empty {data_records}."
 
     data = {key: [] for key in data_fields}
     for record in data_records:
@@ -314,11 +316,8 @@ def read_data_parquet(data_file, data_fields=None):
 
     if df_table.shape[0] == 0:
         logging.warning(f"{data_file} has an empty data. "
-                        "The data frame shape is {df_table.shape}")
+                        f"The data frame shape is {df_table.shape}")
         return None
-
-    assert df_table.shape[0] > 0, \
-        f"{data_file} has an empty data. The data frame shape is {df_table.shape}"
 
     if data_fields is None:
         data_fields = list(df_table.keys())

--- a/python/graphstorm/gconstruct/utils.py
+++ b/python/graphstorm/gconstruct/utils.py
@@ -162,7 +162,9 @@ def _estimate_sizeof(data):
     data: dict/tuple/list of tensors
         Data returned by user_parser
     """
-    if th.is_tensor(data):
+    if data is None:
+        return 0
+    elif th.is_tensor(data):
         data_size = data.element_size() * data.nelement()
     elif isinstance(data, np.ndarray):
         assert data.dtype is not np.object_, \
@@ -257,6 +259,9 @@ def update_two_phase_feat_ops(phase_one_info, ops):
     """
     feat_info = {}
     for _, finfo in phase_one_info.items():
+        if finfo is None:
+            # the info is empty, skip
+            continue
         for feat_name, info in finfo.items():
             if feat_name not in feat_info:
                 feat_info[feat_name] = [info]

--- a/tests/end2end-tests/data_process/data_gen.py
+++ b/tests/end2end-tests/data_process/data_gen.py
@@ -168,6 +168,19 @@ df.to_parquet(os.path.join(in_dir,
 
 write_data_hdf5(edge_data3_2, os.path.join(in_dir, f'edge_data3_2.hdf5'))
 
+# Last file is empty
+for i, edge_data in enumerate(split_data(edge_data1, 10)):
+    write_data_csv(edge_data, os.path.join(in_dir, f'last_empty_edata_{i}.csv'))
+empty_csv = ",".join(edge_data1.keys())
+with open(os.path.join(in_dir, f"last_empty_edata_{10}.csv"), "w", encoding="utf-8") as file:
+    file.write(f"{empty_csv}\n")
+
+# Last file is empty
+for i, edge_data in enumerate(split_data(edge_data1, 10)):
+    write_data_parquet(edge_data, os.path.join(in_dir, f'last_empty_edata_{i}.parquet'))
+
+empty_df = pd.DataFrame(columns=edge_data1.keys())
+empty_df.to_parquet(os.path.join(in_dir, f"last_empty_edata_{10}.parquet"), engine="pyarrow", index=False)
 
 node_conf = [
     {
@@ -459,7 +472,21 @@ edge_conf = [
                 "feature_name": "feat2",
             },
         ],
-    }
+    },
+    {
+        "source_id_col":    "src",
+        "dest_id_col":      "dst",
+        "relation":         ("node1", "relation_empty_csv0", "node2"),
+        "format":           {"name": "csv"},
+        "files":            os.path.join(in_dir, "last_empty_edata_*.csv")
+    },
+    {
+        "source_id_col":    "src",
+        "dest_id_col":      "dst",
+        "relation":         ("node1", "relation_empty_pa0", "node2"),
+        "format":           {"name": "parquet"},
+        "files":            os.path.join(in_dir, "last_empty_edata_*.parquet")
+    },
 ]
 transform_conf = {
     "nodes": node_conf,

--- a/tests/end2end-tests/data_process/data_gen.py
+++ b/tests/end2end-tests/data_process/data_gen.py
@@ -119,7 +119,7 @@ edge_data3 = {
     "neg" : np.array([f"{str(nid)},{str(nid)}" for nid in dst3]).astype(str)
 }
 edge_data3_2 = {
-    'data': src3 + node_id3[dst_idx],
+    'data': (src3 + node_id3[dst_idx])//10000,
 }
 edge_data3_3 = {
     'data': [[nid, nid] for nid in dst3]

--- a/tests/end2end-tests/data_process/data_gen.py
+++ b/tests/end2end-tests/data_process/data_gen.py
@@ -119,7 +119,7 @@ edge_data3 = {
     "neg" : np.array([f"{str(nid)},{str(nid)}" for nid in dst3]).astype(str)
 }
 edge_data3_2 = {
-    'data': (src3 + node_id3[dst_idx])//10000,
+    'data': (src3 + node_id3[dst_idx]),
 }
 edge_data3_3 = {
     'data': [[nid, nid] for nid in dst3]
@@ -147,21 +147,21 @@ write_index_json(paired_data[:100], os.path.join(in_dir, "edge1_train.json"))
 write_index_json(paired_data[100: 120], os.path.join(in_dir, "edge1_valid.json"))
 write_index_json(paired_data[120: 140], os.path.join(in_dir, "edge1_test.json"))
 for i, node_data in enumerate(split_data(node_data1, 5)):
-    write_data_parquet(node_data, os.path.join(in_dir, f'node_data1_{i}.parquet'))
+    write_data_parquet(node_data, os.path.join(in_dir, f'node_data1_{str(i).zfill(3)}.parquet'))
 write_data_hdf5(node_data1_2, os.path.join(in_dir, f'node_data1_2.hdf5'))
 for i, node_data in enumerate(split_data(node_data2, 5)):
-    write_data_parquet(node_data, os.path.join(in_dir, f'node_data2_{i}.parquet'))
+    write_data_parquet(node_data, os.path.join(in_dir, f'node_data2_{str(i).zfill(3)}.parquet'))
 for i, node_data in enumerate(split_data(node_data3, 10)):
-    write_data_json(node_data, os.path.join(in_dir, f'node_data3_{i}.json'))
+    write_data_json(node_data, os.path.join(in_dir, f'node_data3_{str(i).zfill(3)}.json'))
 for i, node_data in enumerate(split_data(node_data4, 10)):
-    write_data_json(node_data, os.path.join(in_dir, f'node_data4_{i}.json'))
+    write_data_json(node_data, os.path.join(in_dir, f'node_data4_{str(i).zfill(3)}.json'))
 for i, edge_data in enumerate(split_data(edge_data1, 10)):
-    write_data_csv(edge_data, os.path.join(in_dir, f'edge_data1_{i}.csv'))
+    write_data_csv(edge_data, os.path.join(in_dir, f'edge_data1_{str(i).zfill(3)}.csv'))
 for i, edge_data in enumerate(split_data(edge_data2, 10)):
-    write_data_parquet(edge_data, os.path.join(in_dir, f'edge_data2_{i}.parquet'))
+    write_data_parquet(edge_data, os.path.join(in_dir, f'edge_data2_{str(i).zfill(3)}.parquet'))
 write_data_hdf5(edge_data1_2, os.path.join(in_dir, f'edge_data1_2.hdf5'))
 for i, edge_data in enumerate(split_data(edge_data3, 10)):
-    write_data_parquet(edge_data, os.path.join(in_dir, f'edge_data3_{i}.parquet'))
+    write_data_parquet(edge_data, os.path.join(in_dir, f'edge_data3_{str(i).zfill(3)}.parquet'))
 df = pd.DataFrame(edge_data3_3)
 df.to_parquet(os.path.join(in_dir,
                            f'ng_edge_data3.parquet'))
@@ -170,17 +170,17 @@ write_data_hdf5(edge_data3_2, os.path.join(in_dir, f'edge_data3_2.hdf5'))
 
 # Last file is empty
 for i, edge_data in enumerate(split_data(edge_data1, 10)):
-    write_data_csv(edge_data, os.path.join(in_dir, f'last_empty_edata_{i}.csv'))
+    write_data_csv(edge_data, os.path.join(in_dir, f'last_empty_edata_{str(i).zfill(3)}.csv'))
 empty_csv = ",".join(edge_data1.keys())
-with open(os.path.join(in_dir, f"last_empty_edata_{10}.csv"), "w", encoding="utf-8") as file:
+with open(os.path.join(in_dir, f"last_empty_edata_{str(10).zfill(3)}.csv"), "w", encoding="utf-8") as file:
     file.write(f"{empty_csv}\n")
 
 # Last file is empty
 for i, edge_data in enumerate(split_data(edge_data1, 10)):
-    write_data_parquet(edge_data, os.path.join(in_dir, f'last_empty_edata_{i}.parquet'))
+    write_data_parquet(edge_data, os.path.join(in_dir, f'last_empty_edata_{str(i).zfill(3)}.parquet'))
 
 empty_df = pd.DataFrame(columns=edge_data1.keys())
-empty_df.to_parquet(os.path.join(in_dir, f"last_empty_edata_{10}.parquet"), engine="pyarrow", index=False)
+empty_df.to_parquet(os.path.join(in_dir, f"last_empty_edata_{str(10).zfill(3)}.parquet"), engine="pyarrow", index=False)
 
 node_conf = [
     {

--- a/tests/end2end-tests/data_process/test.sh
+++ b/tests/end2end-tests/data_process/test.sh
@@ -59,13 +59,15 @@ python3 $GS_HOME/tests/end2end-tests/data_process/test_data.py --graph-format Di
 
 error_and_exit $?
 
+rm -fr /tmp/test_out
+
 # Test the DistDGL graph format with reverse edges.
 echo "*********** Test the DistDGL graph format with reverse edges *********"
-python3 -m graphstorm.gconstruct.construct_graph --conf-file /tmp/test_data/test_data_transform.conf --num-processes 2 --output-dir /tmp/test_out_rev --graph-name test --add-reverse-edges --output-conf-file /tmp/test_data/test_data_transform_new.conf
+python3 -m graphstorm.gconstruct.construct_graph --conf-file /tmp/test_data/test_data_transform.conf --num-processes 2 --output-dir /tmp/test_out --graph-name test --add-reverse-edges --output-conf-file /tmp/test_data/test_data_transform_new.conf
 
 error_and_exit $?
 
-python3 $GS_HOME/tests/end2end-tests/data_process/test_data.py --graph_dir /tmp/test_out_rev --conf_file /tmp/test_data/test_data_transform_new.conf --graph-format DistDGL --reverse-edges
+python3 $GS_HOME/tests/end2end-tests/data_process/test_data.py --graph_dir /tmp/test_out --conf_file /tmp/test_data/test_data_transform_new.conf --graph-format DistDGL --reverse-edges
 
 # Test create both DGL and DistDGL graph
 echo "********* Test the DGLGraph format *********"

--- a/tests/end2end-tests/data_process/test.sh
+++ b/tests/end2end-tests/data_process/test.sh
@@ -61,9 +61,11 @@ error_and_exit $?
 
 # Test the DistDGL graph format with reverse edges.
 echo "*********** Test the DistDGL graph format with reverse edges *********"
-python3 -m graphstorm.gconstruct.construct_graph --conf-file /tmp/test_data/test_data_transform.conf --num-processes 2 --output-dir /tmp/test_out --graph-name test --add-reverse-edges
+python3 -m graphstorm.gconstruct.construct_graph --conf-file /tmp/test_data/test_data_transform.conf --num-processes 2 --output-dir /tmp/test_out --graph-name test --add-reverse-edges --output-conf-file /tmp/test_data/test_data_transform_new.conf
 
 error_and_exit $?
+
+python3 $GS_HOME/tests/end2end-tests/data_process/test_data.py --graph_dir /tmp/test_out --conf_file /tmp/test_data/test_data_transform_new.conf --graph-format DistDGL --reverse-edges
 
 # Test create both DGL and DistDGL graph
 echo "********* Test the DGLGraph format *********"

--- a/tests/end2end-tests/data_process/test.sh
+++ b/tests/end2end-tests/data_process/test.sh
@@ -61,11 +61,11 @@ error_and_exit $?
 
 # Test the DistDGL graph format with reverse edges.
 echo "*********** Test the DistDGL graph format with reverse edges *********"
-python3 -m graphstorm.gconstruct.construct_graph --conf-file /tmp/test_data/test_data_transform.conf --num-processes 2 --output-dir /tmp/test_out --graph-name test --add-reverse-edges --output-conf-file /tmp/test_data/test_data_transform_new.conf
+python3 -m graphstorm.gconstruct.construct_graph --conf-file /tmp/test_data/test_data_transform.conf --num-processes 2 --output-dir /tmp/test_out_rev --graph-name test --add-reverse-edges --output-conf-file /tmp/test_data/test_data_transform_new.conf
 
 error_and_exit $?
 
-python3 $GS_HOME/tests/end2end-tests/data_process/test_data.py --graph_dir /tmp/test_out --conf_file /tmp/test_data/test_data_transform_new.conf --graph-format DistDGL --reverse-edges
+python3 $GS_HOME/tests/end2end-tests/data_process/test_data.py --graph_dir /tmp/test_out_rev --conf_file /tmp/test_data/test_data_transform_new.conf --graph-format DistDGL --reverse-edges
 
 # Test create both DGL and DistDGL graph
 echo "********* Test the DGLGraph format *********"

--- a/tests/end2end-tests/data_process/test_data.py
+++ b/tests/end2end-tests/data_process/test_data.py
@@ -208,7 +208,7 @@ dst_ids = np.array([int(reverse_node3_map[dst_id]) for dst_id in dst_ids.numpy()
 # After graph construction, any 1D features will be converted to 2D features, so
 # here need to convert feat back to 1D to pass test
 np.testing.assert_allclose(src_ids + dst_ids, feat.reshape(-1,))
-np.testing.assert_allclose((src_ids + dst_ids)//10000, feat2.reshape(-1,))
+np.testing.assert_allclose((src_ids + dst_ids), feat2.reshape(-1,))
 
 assert os.path.exists(os.path.join(out_dir, "node_label_stats.json"))
 assert os.path.exists(os.path.join(out_dir, "edge_label_stats.json"))

--- a/tests/end2end-tests/data_process/test_data.py
+++ b/tests/end2end-tests/data_process/test_data.py
@@ -35,6 +35,9 @@ argparser.add_argument("--graph_dir", type=str, required=True,
                        help="The path of the constructed graph.")
 argparser.add_argument("--conf_file", type=str, required=True,
                        help="The configuration file.")
+argparser.add_argument("--reverse-edges",  action='store_true',
+                       help="The configuration file.")
+
 args = argparser.parse_args()
 out_dir = args.graph_dir
 with open(args.conf_file, 'r') as f:
@@ -258,3 +261,21 @@ ground_truth = th.cat([dst_ids.reshape(-1,1), dst_ids.reshape(-1,1), th.full((ds
 ground_truth[0][2] = dst_ids[0]
 ground_truth[0][3] = dst_ids[0]
 assert th.sum(hard_neg-ground_truth) == 0
+
+# Test empty edges
+src_ids, dst_ids = g.edges(etype=('node1', 'relation_empty_csv0', 'node2'))
+src_ids = np.array([reverse_node1_map[src_id] for src_id in src_ids.numpy()])
+dst_ids = dst_ids.numpy()
+assert np.all((src_ids + dst_ids) % 100 == label)
+
+src_ids, dst_ids = g.edges(etype=('node1', 'relation_empty_pa0', 'node2'))
+src_ids = np.array([reverse_node1_map[src_id] for src_id in src_ids.numpy()])
+dst_ids = dst_ids.numpy()
+assert np.all((src_ids + dst_ids) % 100 == label)
+
+if args.reverse_edges:
+    assert g.num_edges(('node2', 'relation1-rev', 'node1')) == g.num_edges(('node1', 'relation1', 'node2'))
+
+    assert g.num_edges(('node2', 'relation_empty_csv0-rev', 'node1')) == g.num_edges(('node1', 'relation_empty_csv0', 'node2'))
+
+    assert g.num_edges(('node2', 'relation_empty_pa0-rev', 'node1')) == g.num_edges(('node1', 'relation_empty_pa0', 'node2'))

--- a/tests/end2end-tests/data_process/test_data.py
+++ b/tests/end2end-tests/data_process/test_data.py
@@ -208,7 +208,7 @@ dst_ids = np.array([int(reverse_node3_map[dst_id]) for dst_id in dst_ids.numpy()
 # After graph construction, any 1D features will be converted to 2D features, so
 # here need to convert feat back to 1D to pass test
 np.testing.assert_allclose(src_ids + dst_ids, feat.reshape(-1,))
-np.testing.assert_allclose(src_ids + dst_ids, feat2.reshape(-1,))
+np.testing.assert_allclose((src_ids + dst_ids)//10000, feat2.reshape(-1,))
 
 assert os.path.exists(os.path.join(out_dir, "node_label_stats.json"))
 assert os.path.exists(os.path.join(out_dir, "edge_label_stats.json"))

--- a/tests/unit-tests/gconstruct/test_construct_graph.py
+++ b/tests/unit-tests/gconstruct/test_construct_graph.py
@@ -1900,6 +1900,7 @@ def test_multiprocessing_checks():
     assert multiprocessing == False
 
 def test_parse_edge_data():
+    np.random.seed(1)
     with tempfile.TemporaryDirectory() as tmpdirname:
         str_src_ids = np.array([str(i) for i in range(10)])
         str_dst_ids = np.array([str(i) for i in range(15)])

--- a/tests/unit-tests/gconstruct/test_construct_graph.py
+++ b/tests/unit-tests/gconstruct/test_construct_graph.py
@@ -31,7 +31,8 @@ from numpy.testing import assert_equal, assert_almost_equal
 from graphstorm.gconstruct.construct_graph import (parse_edge_data,
                                                    prepare_edge_data,
                                                    verify_confs,
-                                                   is_homogeneous)
+                                                   is_homogeneous,
+                                                   _collect_parsed_edge_data)
 from graphstorm.gconstruct.file_io import write_data_parquet, read_data_parquet
 from graphstorm.gconstruct.file_io import write_data_json, read_data_json
 from graphstorm.gconstruct.file_io import write_data_csv, read_data_csv
@@ -2532,7 +2533,117 @@ def test_homogeneous():
     conf["nodes"][1]["node_type"] = "movie_fake"
     assert not is_homogeneous(conf)
 
+def test_collect_parsed_edge_data():
+    file_ids = [0,1,2,3,4,5,6,7,8,9]
+    random.shuffle(file_ids)
+    src = [np.random.randint(10, size=4) for _ in range(10)]
+    dst = [np.random.randint(10, size=4) for _ in range(10)]
+    data = {
+        "feat0": [np.random.rand(4, 10) for _ in range(10)],
+        "feat1": [np.random.rand(4, 10) for _ in range(10)]
+    }
+
+    gt_src = np.concatenate(src)
+    gt_dst = np.concatenate(dst)
+    gt_data = {
+        "feat0": np.concatenate(data["feat0"], axis=0),
+        "feat1": np.concatenate(data["feat1"], axis=0)
+    }
+    input_data = {
+        file_ids[i]: (src[file_ids[i]],
+                      dst[file_ids[i]],
+                      {
+                          "feat0": data["feat0"][file_ids[i]],
+                          "feat1": data["feat1"][file_ids[i]]
+                      }) \
+        for i in range(len(file_ids))
+    }
+
+    type_src_ids, type_dst_ids, type_edge_data = \
+        _collect_parsed_edge_data(input_data)
+
+    type_src_ids = np.concatenate(type_src_ids)
+    type_dst_ids = np.concatenate(type_dst_ids)
+    type_edge_data = {
+        "feat0": np.concatenate(type_edge_data["feat0"], axis=0),
+        "feat1": np.concatenate(type_edge_data["feat1"], axis=0)
+    }
+    assert_equal(gt_src, type_src_ids)
+    assert_equal(gt_dst, type_dst_ids)
+    assert_equal(gt_data["feat0"], type_edge_data["feat0"])
+    assert_equal(gt_data["feat1"], type_edge_data["feat1"])
+    assert type_src_ids.shape[0] == type_edge_data["feat0"].shape[0]
+    assert type_src_ids.shape[0] == type_edge_data["feat1"].shape[0]
+
+    def test_none(idx_none):
+        # add an empty in the middle
+        new_input_data = {}
+        for i, i_data in input_data.items():
+            if i < idx_none:
+                new_input_data[i] = i_data
+            elif i == idx_none:
+                new_input_data[i] = None
+                new_input_data[i+1] = i_data
+            else:
+                new_input_data[i+1] = i_data
+        print(new_input_data.keys())
+        type_src_ids, type_dst_ids, type_edge_data = \
+            _collect_parsed_edge_data(new_input_data)
+
+        type_src_ids = np.concatenate(type_src_ids)
+        type_dst_ids = np.concatenate(type_dst_ids)
+        type_edge_data = {
+            "feat0": np.concatenate(type_edge_data["feat0"], axis=0),
+            "feat1": np.concatenate(type_edge_data["feat1"], axis=0)
+        }
+        assert_equal(gt_src, type_src_ids)
+        assert_equal(gt_dst, type_dst_ids)
+        assert_equal(gt_data["feat0"], type_edge_data["feat0"])
+        assert_equal(gt_data["feat1"], type_edge_data["feat1"])
+        assert type_src_ids.shape[0] == type_edge_data["feat0"].shape[0]
+        assert type_src_ids.shape[0] == type_edge_data["feat1"].shape[0]
+
+    test_none(0)
+    test_none(5)
+    test_none(10)
+
+    def test_two_none(idx_none_0, idx_none_1):
+        # add an empty in the middle
+        new_input_data = {}
+        for i, i_data in input_data.items():
+            if i < idx_none_0:
+                new_input_data[i] = i_data
+            elif i == idx_none_0:
+                new_input_data[i] = None
+                new_input_data[i+1] = i_data
+            elif i < idx_none_1:
+                new_input_data[i+1] = i_data
+            elif i == idx_none_1:
+                new_input_data[i+1] = None
+                new_input_data[i+2] = i_data
+            else:
+                new_input_data[i+2] = i_data
+        type_src_ids, type_dst_ids, type_edge_data = \
+            _collect_parsed_edge_data(new_input_data)
+
+        type_src_ids = np.concatenate(type_src_ids)
+        type_dst_ids = np.concatenate(type_dst_ids)
+        type_edge_data = {
+            "feat0": np.concatenate(type_edge_data["feat0"], axis=0),
+            "feat1": np.concatenate(type_edge_data["feat1"], axis=0)
+        }
+        assert_equal(gt_src, type_src_ids)
+        assert_equal(gt_dst, type_dst_ids)
+        assert_equal(gt_data["feat0"], type_edge_data["feat0"])
+        assert_equal(gt_data["feat1"], type_edge_data["feat1"])
+        assert type_src_ids.shape[0] == type_edge_data["feat0"].shape[0]
+        assert type_src_ids.shape[0] == type_edge_data["feat1"].shape[0]
+
+    test_two_none(0, 4)
+    test_two_none(4, 10)
+
 if __name__ == '__main__':
+    test_collect_parsed_edge_data()
     test_prepare_edge_data()
     test_multitask_label()
     test_partition_graph(2)

--- a/tests/unit-tests/gconstruct/test_construct_graph.py
+++ b/tests/unit-tests/gconstruct/test_construct_graph.py
@@ -2006,7 +2006,7 @@ def test_prepare_edge_data():
         }
         keys = ["src_id", "dst_id", "feat"]
 
-        feat_ops = [NumericalMinMaxTransform("feat", "feat", None)]
+        feat_ops = [NumericalMinMaxTransform("feat", "feat")]
         data_file = os.path.join(tmpdirname, "data.parquet")
         write_data_parquet(data, data_file)
         info = prepare_edge_data(data_file, feat_ops,

--- a/tests/unit-tests/gconstruct/test_gconstruct_utils.py
+++ b/tests/unit-tests/gconstruct/test_gconstruct_utils.py
@@ -237,12 +237,8 @@ def test_read_empty_parquet():
         empty_table = pa.Table.from_pandas(empty_df)
         pq.write_table(empty_table, data_file)
 
-        pass_test = False
-        try:
-            read_data_parquet(data_file, fields)
-        except:
-            pass_test = True
-        assert pass_test
+        ret = read_data_parquet(data_file, fields)
+        assert ret is None
 
 def test_read_empty_csv():
     with tempfile.TemporaryDirectory() as tmpdirname:
@@ -251,12 +247,8 @@ def test_read_empty_csv():
         empty_df = pd.DataFrame(columns=fields)
         empty_df.to_csv(data_file, index=True, sep=",")
 
-        pass_test = False
-        try:
-            read_data_csv(data_file, fields, ",")
-        except:
-            pass_test = True
-        assert pass_test
+        ret = read_data_csv(data_file, fields, ",")
+        assert ret is None
 
 def test_read_empty_json():
     with tempfile.TemporaryDirectory() as tmpdirname:
@@ -265,27 +257,8 @@ def test_read_empty_json():
         with open(data_file, 'w', encoding="utf8") as json_file:
             json.dump(data, json_file)
 
-        pass_test = False
-        try:
-            read_data_json(data_file)
-        except:
-            pass_test = True
-        assert pass_test
-
-def test_read_empty_parquet():
-    with tempfile.TemporaryDirectory() as tmpdirname:
-        data_file = os.path.join(tmpdirname, "test.parquet")
-        fields = ["a", "b"]
-        empty_df = pd.DataFrame(columns=fields)
-        empty_table = pa.Table.from_pandas(empty_df)
-        pq.write_table(empty_table, data_file)
-
-        pass_test = False
-        try:
-            read_data_parquet(data_file, fields)
-        except:
-            pass_test = True
-        assert pass_test
+        ret = read_data_json(data_file)
+        assert ret is None
 
 def test_get_in_files():
     with tempfile.TemporaryDirectory() as tmpdirname:

--- a/tests/unit-tests/gconstruct/test_gconstruct_utils.py
+++ b/tests/unit-tests/gconstruct/test_gconstruct_utils.py
@@ -25,7 +25,7 @@ import pyarrow.parquet as pq
 import pyarrow as pa
 import torch as th
 
-from numpy.testing import assert_almost_equal
+from numpy.testing import assert_almost_equal, assert_raises
 
 from graphstorm.gconstruct.utils import _estimate_sizeof, _to_numpy_array, _to_shared_memory
 from graphstorm.gconstruct.utils import HDF5Array, ExtNumpyWrapper
@@ -257,8 +257,8 @@ def test_read_empty_json():
         with open(data_file, 'w', encoding="utf8") as json_file:
             json.dump(data, json_file)
 
-        ret = read_data_json(data_file)
-        assert ret is None
+        with assert_raises(AssertionError):
+            _ = read_data_json(data_file)
 
 def test_get_in_files():
     with tempfile.TemporaryDirectory() as tmpdirname:

--- a/tests/unit-tests/gconstruct/test_gconstruct_utils.py
+++ b/tests/unit-tests/gconstruct/test_gconstruct_utils.py
@@ -254,11 +254,12 @@ def test_read_empty_json():
     with tempfile.TemporaryDirectory() as tmpdirname:
         data_file = os.path.join(tmpdirname, "test.json")
         data = {}
+        fields = ["a", "b"]
         with open(data_file, 'w', encoding="utf8") as json_file:
             json.dump(data, json_file)
 
         with assert_raises(AssertionError):
-            _ = read_data_json(data_file)
+            _ = read_data_json(data_file, fields)
 
 def test_get_in_files():
     with tempfile.TemporaryDirectory() as tmpdirname:


### PR DESCRIPTION
*Issue #, if available:*
#996 

*Description of changes:*
GConstruct will handle the corner cases when some edge files are empty files.

Note: DGL graph partition forces every edge type should have at least one edges.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
