### PR TITLE
[Doc] Add warning for previous dependencies installation

### DIFF
--- a/docs/source/install/env-setup.rst
+++ b/docs/source/install/env-setup.rst
@@ -32,7 +32,7 @@ Install Dependencies
 Users should install PyTorch v2.1.0 and DGL v1.1.3 that is the core dependency of GraphStorm using the following commands.
 
 .. warning::
-    Please ensure using Python version 3.11 or earlier. Torch 2.1.0 and DGL 1.1.3 do not support Python >= 3.12.0.
+    Please ensure you are using Python version 3.11 or earlier. Torch 2.1.0 and DGL 1.1.3 do not support Python >= 3.12.0.
 
 For Nvidia GPU environment:
 

--- a/docs/source/install/env-setup.rst
+++ b/docs/source/install/env-setup.rst
@@ -31,6 +31,9 @@ Install Dependencies
 .....................
 Users should install PyTorch v2.1.0 and DGL v1.1.3 that is the core dependency of GraphStorm using the following commands.
 
+.. warning::
+    Please ensure using Python version 3.11 or earlier.
+
 For Nvidia GPU environment:
 
 .. code-block:: bash

--- a/docs/source/install/env-setup.rst
+++ b/docs/source/install/env-setup.rst
@@ -32,7 +32,7 @@ Install Dependencies
 Users should install PyTorch v2.1.0 and DGL v1.1.3 that is the core dependency of GraphStorm using the following commands.
 
 .. warning::
-    Please ensure using Python version 3.11 or earlier.
+    Please ensure using Python version 3.11 or earlier. Torch 2.1.0 and DGL 1.1.3 do not support Python >= 3.12.0.
 
 For Nvidia GPU environment:
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Torch 2.1.0 and DGL 1.1.3 does not support Python >= 3.12.0.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
