### PR TITLE
[GSProcessing] Remove requirement to have poetry installed for GSP im…

### DIFF
--- a/graphstorm-processing/docker/push_gsprocessing_image.sh
+++ b/graphstorm-processing/docker/push_gsprocessing_image.sh
@@ -3,7 +3,7 @@
 set -Eeuo pipefail
 trap cleanup SIGINT SIGTERM ERR EXIT
 
-script_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd -P)
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd -P)
 
 usage() {
   cat <<EOF
@@ -40,10 +40,9 @@ die() {
 parse_params() {
   # default values of variables set from params
   IMAGE='graphstorm-processing'
-  VERSION=`poetry version --short`
+  VERSION=$(find "$SCRIPT_DIR" -maxdepth 1 -type d | sort --version-sort | tail -1 | xargs basename)
   LATEST_VERSION=${VERSION}
-  REGION=$(aws configure get region) || REGION=""
-  REGION=${REGION:-us-west-2}
+  REGION=${REGION:-$(aws configure get region)}
   ACCOUNT=$(aws sts get-caller-identity --query Account --output text)
   ARCH='x86_64'
   SUFFIX=""

--- a/graphstorm-processing/docker/push_gsprocessing_image.sh
+++ b/graphstorm-processing/docker/push_gsprocessing_image.sh
@@ -42,6 +42,7 @@ parse_params() {
   IMAGE='graphstorm-processing'
   VERSION=$(find "$SCRIPT_DIR" -maxdepth 1 -type d | sort --version-sort | tail -1 | xargs basename)
   LATEST_VERSION=${VERSION}
+  # If the user did not provide a region, try to get from config
   REGION=${REGION:-$(aws configure get region)}
   ACCOUNT=$(aws sts get-caller-identity --query Account --output text)
   ARCH='x86_64'
@@ -88,6 +89,7 @@ parse_params() {
   done
 
   [[ -z "${EXEC_ENV-}" ]] && die "Missing required parameter: -e/--environment [emr|emr-serverless|sagemaker]"
+  [[ -z "${REGION-}" ]] && die "Missing required parameter: -r/--region <aws-region>"
 
   return 0
 }


### PR DESCRIPTION

*Issue #, if available:*

*Description of changes:*

* Before our push script still needed poetry to determine the latest package version if not provided by the user. 
* This PR brings it in line with the build script that parses the latest version by listing the version directories under `graphstorm-processing/docker/`, doing a version-aware sort and selecting the last directory name (e.g. base name of graphstorm-processing/docker/0.4.1 -> 0.4.1)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
