### PR TITLE
[Fix] Fix an HGT Encoder Corner Case: 0 edge in a block

### DIFF
--- a/python/graphstorm/model/hgt_encoder.py
+++ b/python/graphstorm/model/hgt_encoder.py
@@ -716,7 +716,6 @@ class HGTLayerwithEdgeFeat(HGTLayer):
             total_num_edge = 0
             for can_etype in self.edge_feat_name.keys():
                 total_num_edge += g.num_edges(etype=can_etype)
-            # print(f'Total number of feature associated edges are {total_num_edge}.')
             assert total_num_edge == 0, f"No edge features provided for {total_num_edge} edges " + \
                 "in HGTLayerwithEdgeFeat, please provide edge feature " + \
                 "dictionary specified in the \"edge_feat_name\" argument."
@@ -734,10 +733,6 @@ class HGTLayerwithEdgeFeat(HGTLayer):
                 c_etype_str = '_'.join((srctype, etype, dsttype))
                 # extract each relation as a sub graph
                 sub_graph = g[srctype, etype, dsttype]
-
-                # no edge, no message passing computation
-                if sub_graph.num_edges() == 0:
-                    continue
 
                 # extract source, destination, and edge embeds
                 src_nh = h[srctype]

--- a/python/graphstorm/model/hgt_encoder.py
+++ b/python/graphstorm/model/hgt_encoder.py
@@ -718,7 +718,7 @@ class HGTLayerwithEdgeFeat(HGTLayer):
                 total_num_edge += g.num_edges(etype=can_etype)
             assert total_num_edge == 0, f"No edge features provided for {total_num_edge} edges " + \
                 "in HGTLayerwithEdgeFeat, please check the edge feature " + \
-                "dictionary specified in the \"edge_feat_name\" argument."
+                "information specified in the \"edge_feat_name\" argument during initialization or check the \"e_h\" argument of the forward function.."
             e_h = {}
 
         # pylint: disable=no-member

--- a/python/graphstorm/model/hgt_encoder.py
+++ b/python/graphstorm/model/hgt_encoder.py
@@ -716,9 +716,9 @@ class HGTLayerwithEdgeFeat(HGTLayer):
             total_num_edge = 0
             for can_etype in self.edge_feat_name.keys():
                 total_num_edge += g.num_edges(etype=can_etype)
-            assert total_num_edge == 0, f"No edge features provided for {total_num_edge} edges" + \
-                " in HGTLayerwithEdgeFeat, please check the edge feature " + \
-                "information specified in the \"edge_feat_name\" argument during initialization " + \
+            assert total_num_edge == 0, f"No edge features provided for {total_num_edge} " + \
+                "edges in HGTLayerwithEdgeFeat, please check the edge feature information " + \
+                "specified in the \"edge_feat_name\" argument during initialization " + \
                 "or check the \"e_h\" argument of the forward function.."
             e_h = {}
 

--- a/python/graphstorm/model/hgt_encoder.py
+++ b/python/graphstorm/model/hgt_encoder.py
@@ -716,9 +716,10 @@ class HGTLayerwithEdgeFeat(HGTLayer):
             total_num_edge = 0
             for can_etype in self.edge_feat_name.keys():
                 total_num_edge += g.num_edges(etype=can_etype)
-            assert total_num_edge == 0, f"No edge features provided for {total_num_edge} edges " + \
-                "in HGTLayerwithEdgeFeat, please check the edge feature " + \
-                "information specified in the \"edge_feat_name\" argument during initialization or check the \"e_h\" argument of the forward function.."
+            assert total_num_edge == 0, f"No edge features provided for {total_num_edge} edges" + \
+                " in HGTLayerwithEdgeFeat, please check the edge feature " + \
+                "information specified in the \"edge_feat_name\" argument during initialization " + \
+                "or check the \"e_h\" argument of the forward function.."
             e_h = {}
 
         # pylint: disable=no-member

--- a/python/graphstorm/model/hgt_encoder.py
+++ b/python/graphstorm/model/hgt_encoder.py
@@ -717,7 +717,7 @@ class HGTLayerwithEdgeFeat(HGTLayer):
             for can_etype in self.edge_feat_name.keys():
                 total_num_edge += g.num_edges(etype=can_etype)
             assert total_num_edge == 0, f"No edge features provided for {total_num_edge} edges " + \
-                "in HGTLayerwithEdgeFeat, please provide edge feature " + \
+                "in HGTLayerwithEdgeFeat, please check the edge feature " + \
                 "dictionary specified in the \"edge_feat_name\" argument."
             e_h = {}
 

--- a/python/graphstorm/model/hgt_encoder.py
+++ b/python/graphstorm/model/hgt_encoder.py
@@ -712,7 +712,7 @@ class HGTLayerwithEdgeFeat(HGTLayer):
         """
         # A corner case, there is 0 edges of edge type with edge features. So no input e_h will
         # be given.
-        if e_h is None:
+        if e_h is None or len(e_h) == 0:
             total_num_edge = 0
             for can_etype in self.edge_feat_name.keys():
                 total_num_edge += g.num_edges(etype=can_etype)
@@ -720,11 +720,6 @@ class HGTLayerwithEdgeFeat(HGTLayer):
                 "in HGTLayerwithEdgeFeat, please provide edge feature " + \
                 "dictionary specified in the \"edge_feat_name\" argument."
             e_h = {}
-        else:
-            # all other cases, should provide valid e_h
-            assert e_h is not None and len(e_h) != 0,  "No edge features provided for message " + \
-                "passing computation in HGTLayerwithEdgeFeat, please provide edge feature " + \
-                "dictionary specified in the \"edge_feat_name\" argument."
 
         # pylint: disable=no-member
         with g.local_scope():

--- a/tests/unit-tests/test_nn_model.py
+++ b/tests/unit-tests/test_nn_model.py
@@ -1186,7 +1186,12 @@ def test_hgt_with_edge_features(input_dim, output_dim, dev):
 
     # Test case 8: a corner case, layer was set with edge feature name, but the input block has 0
     #              number of edge types that should have edge features.
-    #       8.1 normal case, set layer with ('n0', 'r0', 'n1') edge feature name, but 0 input edges
+    #       8.1 abnormal case, set layer with  ('n0', 'r0', 'n1') edge feature name, but has >0
+    #           input edges, but don't pass edge features to forward. This will trigger an
+    #       asserttion error.
+    #       This has been tested in Test Case 5.
+
+    #       8.2 normal case, set layer with ('n0', 'r0', 'n1') edge feature name, but 0 input edges
 
     # remove all edges in ('n0', 'r0', 'n1') edge type
     subg.remove_edges(th.tensor([0,1]), etype=('n0', 'r0', 'n1'))
@@ -1243,8 +1248,3 @@ def test_hgt_with_edge_features(input_dim, output_dim, dev):
 
     assert_almost_equal(baseline_emb['n1'].detach().cpu().numpy(),
                         emb['n1'].detach().cpu().numpy())
-
-    #       8.2 abnormal case, set layer with  ('n0', 'r0', 'n1') edge feature name, but has >0
-    #           input edges. This will trigger an asserttion error.
-    #       This has been tested in Test Case 5.
-    


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This PR fixes an HGT Encoder corner case, where the edge type with feature has 0 edge in a block. In such case the input of edge feature become empty dict, and will trigger an assertion error in the previous implementation. This PR handles this corner case.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
