### PR TITLE
Fix the error case when the label is a 1D tensor for regression tasks

### DIFF
--- a/python/graphstorm/eval/eval_func.py
+++ b/python/graphstorm/eval/eval_func.py
@@ -655,6 +655,11 @@ def compute_rmse(pred, labels):
     assert th.is_floating_point(pred) and th.is_floating_point(labels), \
         "prediction and labels must be floating points"
 
+    # Handle the case when the label is a 1D tensor and
+    # the prediction result has the shape as (len(labels), 1)
+    if len(labels.shape) == 1 and pred.shape[-1] == 1:
+        pred = pred.squeeze(-1)
+
     assert pred.shape == labels.shape, \
         f"prediction and labels have different shapes. {pred.shape} vs. {labels.shape}"
     if pred.dtype != labels.dtype:
@@ -672,6 +677,11 @@ def compute_mse(pred, labels):
     # TODO: check dtype of label before training or evaluation
     assert th.is_floating_point(pred) and th.is_floating_point(labels), \
         "prediction and labels must be floating points"
+
+    # Handle the case when the label is a 1D tensor and
+    # the prediction result has the shape as (len(labels), 1)
+    if len(labels.shape) == 1 and pred.shape[-1] == 1:
+        pred = pred.squeeze(-1)
 
     assert pred.shape == labels.shape, \
         f"prediction and labels have different shapes. {pred.shape} vs. {labels.shape}"

--- a/tests/unit-tests/test_eval_func.py
+++ b/tests/unit-tests/test_eval_func.py
@@ -48,6 +48,12 @@ def test_compute_mse():
     assert_almost_equal(mse32, mse_pred64)
     assert_almost_equal(mse32, mse_label64)
 
+    # Test the case when label is a 1D tensor
+    # and pred is a 2D tensor
+    label32 = label32.squeeze()
+    mse32_2 = compute_mse(pred32, label32)
+    assert_almost_equal(mse32, mse32_2)
+
 def test_compute_rmse():
     pred64 = th.rand((100,1), dtype=th.float64)
     label64 = pred64 + th.rand((100,1), dtype=th.float64) / 10
@@ -61,6 +67,12 @@ def test_compute_rmse():
 
     assert_almost_equal(rmse32, rmse_pred64)
     assert_almost_equal(rmse32, rmse_label64)
+
+    # Test the case when label is a 1D tensor
+    # and pred is a 2D tensor
+    label32 = label32.squeeze()
+    rmse32_2 = compute_rmse(pred32, label32)
+    assert_almost_equal(rmse32, rmse32_2)
 
 def test_eval_roc_auc():
     # GraphStorm inputs: preds are logits>= 2D, and labels are all 1D list.
@@ -610,25 +622,3 @@ def test_compute_amri():
         expected_amri,
         decimal=2
     )
-
-
-
-if __name__ == '__main__':
-    test_LinkPredictionMetrics()
-    test_compute_hit_at_link_prediction()
-
-    test_ClassificationMetrics()
-    test_compute_hit_at_classification()
-
-    test_compute_mse()
-    test_compute_rmse()
-
-    test_eval_roc_auc()
-    test_compute_roc_auc()
-    test_compute_per_class_roc_auc()
-
-    test_compute_f1_score()
-
-    test_eval_acc()
-
-    test_compute_precision_recall_auc()


### PR DESCRIPTION
*Issue #, if available:*
#1198 

*Description of changes:*
The prediction results of regression tasks are always 2D tensors, even when the prediction target is a single float value for each node. If the label is a 1D tensor, it will trigger a tensor shape mismatch error. This PR fixes this error.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
