### PR TITLE
[GSProcessing] Reduce SageMaker logging

### DIFF
--- a/graphstorm-processing/docker/0.4.1/sagemaker/Dockerfile.cpu
+++ b/graphstorm-processing/docker/0.4.1/sagemaker/Dockerfile.cpu
@@ -20,7 +20,7 @@ COPY requirements.txt requirements.txt
 RUN /usr/local/bin/python3.9 -m pip install --no-cache-dir -r /usr/lib/spark/code/requirements.txt \
     && rm -rf /root/.cache
 
-# Graphloader codebase
+# GSProcessing codebase
 COPY code/ /usr/lib/spark/code/
 
 # Base container assumes this is the workdir
@@ -49,15 +49,8 @@ else \
 fi
 
 # Reduce excessive logging
-COPY log4j.properties $SPARK_HOME/conf/
 ENV SPARK_CONF_DIR=$SPARK_HOME/conf
-ENV SPARK_LOGGING_OPTS="-Dlog4j.configuration=file:/usr/lib/spark/conf/log4j.properties -Dlog4j.rootCategory=ERROR"
-ENV SPARK_DAEMON_JAVA_OPTS="-Dlog4j.configuration=file:/usr/lib/spark/conf/log4j.properties -Dlog4j.rootCategory=ERROR"
-ENV _JAVA_OPTIONS="-Dlog4j.configuration=file:/usr/lib/spark/conf/log4j.properties -Dlog4j.rootCategory=ERROR"
-ENV HADOOP_ROOT_LOGGER="ERROR,console"
-ENV YARN_ROOT_LOGGER="ERROR,console"
-
-
+COPY log4j.properties $SPARK_HOME/conf/
 
 # Starts framework
 ENTRYPOINT ["bash", "/usr/lib/spark/code/docker-entry.sh"]

--- a/graphstorm-processing/docker/0.4.1/sagemaker/log4j.properties
+++ b/graphstorm-processing/docker/0.4.1/sagemaker/log4j.properties
@@ -1,0 +1,12 @@
+# Create this as log4j.properties in your project
+log4j.rootCategory=ERROR, console
+log4j.appender.console=org.apache.log4j.ConsoleAppender
+log4j.appender.console.target=System.err
+log4j.appender.console.layout=org.apache.log4j.PatternLayout
+log4j.appender.console.layout.ConversionPattern=%d{yy/MM/dd HH:mm:ss} %p %c{1}: %m%n
+
+log4j.logger.yarn.containers=ERROR, YARN
+log4j.appender.YARN=org.apache.log4j.RollingFileAppender
+log4j.appender.YARN.File=${spark.yarn.app.container.log.dir}/yarn-container.log
+log4j.appender.YARN.MaxFileSize=10MB
+log4j.appender.YARN.MaxBackupIndex=5

--- a/graphstorm-processing/docker/build_gsprocessing_image.sh
+++ b/graphstorm-processing/docker/build_gsprocessing_image.sh
@@ -183,6 +183,12 @@ fi
 # Copy Docker entry point to build folder
 cp ${GSP_HOME}/docker-entry.sh "${BUILD_DIR}/docker/code/"
 
+# Copy log4j.properties if one exists
+if [[ -f "${GSP_HOME}/docker/${VERSION}/${EXEC_ENV}/log4j.properties" ]]; then
+    cp "${GSP_HOME}/docker/${VERSION}/${EXEC_ENV}/log4j.properties" \
+        "${BUILD_DIR}/docker/log4j.properties"
+fi
+
 # Copy or export requirements to requirements.txt file
 if [[ -f "${GSP_HOME}/docker/${VERSION}/requirements.txt" ]]; then
     cp "${GSP_HOME}/docker/${VERSION}/requirements.txt" "${BUILD_DIR}/docker/requirements.txt"


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

* The SageMaker image produces excessive logs. We use a config file to try to reduce those and bring in line with other execution environments.
* Will reduce the excessive yarn logs such as:

```
[/var/log/yarn/userlogs/application_1740449133449_0001/container_1740449133449_0001_01_000002/stderr] 25/02/25 02:08:49 INFO CodecConfig: Compression: SNAPPY
[/var/log/yarn/userlogs/application_1740449133449_0001/container_1740449133449_0001_01_000002/stderr] 25/02/25 02:08:49 INFO ParquetOutputFormat: ParquetRecordWriter [block size: 134217728b, row group padding size: 8388608b, validating: false]
[/var/log/yarn/userlogs/application_1740449133449_0001/container_1740449133449_0001_01_000002/stderr] 25/02/25 02:08:49 INFO ParquetWriteSupport: Initialized Parquet WriteSupport with Catalyst schema:
[/var/log/yarn/userlogs/application_1740449133449_0001/container_1740449133449_0001_01_000002/stderr] {
[/var/log/yarn/userlogs/application_1740449133449_0001/container_1740449133449_0001_01_000002/stderr]   "type" : "struct",
[/var/log/yarn/userlogs/application_1740449133449_0001/container_1740449133449_0001_01_000002/stderr]   "fields" : [ {
[/var/log/yarn/userlogs/application_1740449133449_0001/container_1740449133449_0001_01_000002/stderr]     "name" : "src_int_id",
[/var/log/yarn/userlogs/application_1740449133449_0001/container_1740449133449_0001_01_000002/stderr]     "type" : "long",
[/var/log/yarn/userlogs/application_1740449133449_0001/container_1740449133449_0001_01_000002/stderr]     "nullable" : true,
[/var/log/yarn/userlogs/application_1740449133449_0001/container_1740449133449_0001_01_000002/stderr]     "metadata" : 
{}
[/var/log/yarn/userlogs/application_1740449133449_0001/container_1740449133449_0001_01_000002/stderr]   }, {
[/var/log/yarn/userlogs/application_1740449133449_0001/container_1740449133449_0001_01_000002/stderr]     "name" : "dst_int_id",
[/var/log/yarn/userlogs/application_1740449133449_0001/container_1740449133449_0001_01_000002/stderr]     "type" : "long",
[/var/log/yarn/userlogs/application_1740449133449_0001/container_1740449133449_0001_01_000002/stderr]     "nullable" : true,
[/var/log/yarn/userlogs/application_1740449133449_0001/container_1740449133449_0001_01_000002/stderr]     "metadata" : 
{}
[/var/log/yarn/userlogs/application_1740449133449_0001/container_1740449133449_0001_01_000002/stderr]   } ]
[/var/log/yarn/userlogs/application_1740449133449_0001/container_1740449133449_0001_01_000002/stderr] }
[/var/log/yarn/userlogs/application_1740449133449_0001/container_1740449133449_0001_01_000002/stderr] and corresponding Parquet message type:
[/var/log/yarn/userlogs/application_1740449133449_0001/container_1740449133449_0001_01_000002/stderr] message spark_schema {
[/var/log/yarn/userlogs/application_1740449133449_0001/container_1740449133449_0001_01_000002/stderr]   optional int64 src_int_id;
[/var/log/yarn/userlogs/application_1740449133449_0001/container_1740449133449_0001_01_000002/stderr]   optional int64 dst_int_id;
[/var/log/yarn/userlogs/application_1740449133449_0001/container_1740449133449_0001_01_000002/stderr] }
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
