### PR TITLE
[GSProcessing] Have 'mean' default imputation when converting GConstr…

### DIFF
--- a/graphstorm-processing/graphstorm_processing/config/config_conversion/gconstruct_converter.py
+++ b/graphstorm-processing/graphstorm_processing/config/config_conversion/gconstruct_converter.py
@@ -150,7 +150,7 @@ class GConstructConfigConverter(ConfigConverter):
                     gsp_transformation_dict["name"] = "numerical"
                     gsp_transformation_dict["kwargs"] = {
                         "normalizer": "min-max",
-                        "imputer": "none",
+                        "imputer": "mean",
                     }
                     if gconstruct_transform_dict.get("out_dtype") in VALID_OUTDTYPE:
                         gsp_transformation_dict["kwargs"]["out_dtype"] = gconstruct_transform_dict[
@@ -160,7 +160,7 @@ class GConstructConfigConverter(ConfigConverter):
                     gsp_transformation_dict["name"] = "numerical"
                     gsp_transformation_dict["kwargs"] = {
                         "normalizer": "standard",
-                        "imputer": "none",
+                        "imputer": "mean",
                     }
 
                     if gconstruct_transform_dict.get("out_dtype") in VALID_OUTDTYPE:
@@ -179,13 +179,13 @@ class GConstructConfigConverter(ConfigConverter):
                         "bucket_cnt": gconstruct_transform_dict["bucket_cnt"],
                         "range": gconstruct_transform_dict["range"],
                         "slide_window_size": gconstruct_transform_dict["slide_window_size"],
-                        "imputer": "none",
+                        "imputer": "mean",
                     }
                 elif gconstruct_transform_dict["name"] == "rank_gauss":
                     gsp_transformation_dict["name"] = "numerical"
                     gsp_transformation_dict["kwargs"] = {
                         "normalizer": "rank-gauss",
-                        "imputer": "none",
+                        "imputer": "mean",
                     }
 
                     if "epsilon" in gconstruct_transform_dict:

--- a/graphstorm-processing/tests/test_converter.py
+++ b/graphstorm-processing/tests/test_converter.py
@@ -145,7 +145,7 @@ def test_try_convert_out_dtype(
                 "column": "paper_title",
                 "transformation": {
                     "kwargs": {
-                        "imputer": "none",
+                        "imputer": "mean",
                         "normalizer": normalizer_dict[transform],
                         "out_dtype": "float32",
                     },
@@ -159,7 +159,7 @@ def test_try_convert_out_dtype(
                 "column": "paper_title",
                 "transformation": {
                     "kwargs": {
-                        "imputer": "none",
+                        "imputer": "mean",
                         "normalizer": normalizer_dict[transform],
                         "out_dtype": "float64",
                     },
@@ -172,7 +172,7 @@ def test_try_convert_out_dtype(
             {
                 "column": "paper_title",
                 "transformation": {
-                    "kwargs": {"imputer": "none", "normalizer": normalizer_dict[transform]},
+                    "kwargs": {"imputer": "mean", "normalizer": normalizer_dict[transform]},
                     "name": "numerical",
                 },
             }
@@ -464,7 +464,7 @@ def test_convert_gsprocessing(converter: GConstructConfigConverter):
             "column": "num_citations",
             "transformation": {
                 "name": "numerical",
-                "kwargs": {"normalizer": "min-max", "imputer": "none"},
+                "kwargs": {"normalizer": "min-max", "imputer": "mean"},
             },
         },
         {
@@ -475,7 +475,7 @@ def test_convert_gsprocessing(converter: GConstructConfigConverter):
                     "bucket_cnt": 9,
                     "range": [10, 100],
                     "slide_window_size": 5,
-                    "imputer": "none",
+                    "imputer": "mean",
                 },
             },
         },
@@ -484,7 +484,7 @@ def test_convert_gsprocessing(converter: GConstructConfigConverter):
             "name": "rank_gauss1",
             "transformation": {
                 "name": "numerical",
-                "kwargs": {"normalizer": "rank-gauss", "imputer": "none"},
+                "kwargs": {"normalizer": "rank-gauss", "imputer": "mean"},
             },
         },
         {
@@ -492,7 +492,7 @@ def test_convert_gsprocessing(converter: GConstructConfigConverter):
             "name": "rank_gauss2",
             "transformation": {
                 "name": "numerical",
-                "kwargs": {"epsilon": 0.1, "normalizer": "rank-gauss", "imputer": "none"},
+                "kwargs": {"epsilon": 0.1, "normalizer": "rank-gauss", "imputer": "mean"},
             },
         },
         {
@@ -550,7 +550,7 @@ def test_convert_gsprocessing(converter: GConstructConfigConverter):
             "column": "num_feature",
             "transformation": {
                 "name": "numerical",
-                "kwargs": {"normalizer": "standard", "imputer": "none"},
+                "kwargs": {"normalizer": "standard", "imputer": "mean"},
             },
         },
     ]


### PR DESCRIPTION
…uct configs

*Issue #, if available:*

*Description of changes:*

* GConstruct numerical configs do not have an imputer entry so we add an imputation for GSProcessing when converting GConstruct configs. This ensure we can parse data with missing values by default, even when the config is GConstruct.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
