### PR TITLE
[Docker] Ensure hostname fix is at right place for SageMaker image. Use recommended paths for code

### DIFF
--- a/docker/sagemaker/Dockerfile.sm
+++ b/docker/sagemaker/Dockerfile.sm
@@ -52,7 +52,7 @@ COPY build_artifacts/start_with_right_hostname.sh /usr/local/bin/start_with_righ
 COPY code/graphstorm/ /usr/local/lib/graphstorm/
 ENV PYTHONPATH="/usr/local/lib/graphstorm/python/:${PYTHONPATH}"
 
-RUN cp /usr/local/lib/graphstorm/sagemaker/run/* /usr/local/lib/
+COPY code/graphstorm/sagemaker/run/* /opt/ml/code/
 
 # Download DGL source code
 RUN cd /root; git clone --branch v${DGL_VERSION} --single-branch https://github.com/dmlc/dgl.git
@@ -60,7 +60,7 @@ RUN cd /root; git clone --branch v${DGL_VERSION} --single-branch https://github.
 # COPY dgl /root/dgl
 ENV PYTHONPATH="/root/dgl/tools/:${PYTHONPATH}"
 
-WORKDIR /usr/local/lib/
+WORKDIR  /opt/ml/code/
 
 ENTRYPOINT ["bash", "-m", "/usr/local/bin/start_with_right_hostname.sh"]
 CMD ["/bin/bash"]

--- a/docker/sagemaker/Dockerfile.sm
+++ b/docker/sagemaker/Dockerfile.sm
@@ -48,11 +48,11 @@ COPY build_artifacts/changehostname.c /usr/local/bin/changehostname.c
 COPY build_artifacts/start_with_right_hostname.sh /usr/local/bin/start_with_right_hostname.sh
 
 # /opt/ml and all subdirectories are utilized by SageMaker,
-# we use the /usr/local/bin subdirectory to store our user code.
-COPY code/graphstorm/ /usr/local/bin/graphstorm/
-ENV PYTHONPATH="/usr/local/bin/graphstorm/python/:${PYTHONPATH}"
+# we use the /usr/local/lib subdirectory to store our user code.
+COPY code/graphstorm/ /usr/local/lib/graphstorm/
+ENV PYTHONPATH="/usr/local/lib/graphstorm/python/:${PYTHONPATH}"
 
-RUN cp /usr/local/bin/graphstorm/sagemaker/run/* /usr/local/bin/
+RUN cp /usr/local/lib/graphstorm/sagemaker/run/* /usr/local/lib/
 
 # Download DGL source code
 RUN cd /root; git clone --branch v${DGL_VERSION} --single-branch https://github.com/dmlc/dgl.git
@@ -60,7 +60,7 @@ RUN cd /root; git clone --branch v${DGL_VERSION} --single-branch https://github.
 # COPY dgl /root/dgl
 ENV PYTHONPATH="/root/dgl/tools/:${PYTHONPATH}"
 
-WORKDIR /usr/local/bin/
+WORKDIR /usr/local/lib/
 
 ENTRYPOINT ["bash", "-m", "/usr/local/bin/start_with_right_hostname.sh"]
 CMD ["/bin/bash"]

--- a/docker/sagemaker/Dockerfile.sm
+++ b/docker/sagemaker/Dockerfile.sm
@@ -44,15 +44,15 @@ RUN pip3 install \
 
 
 # Copy workaround script for incorrect hostname
-COPY build_artifacts/changehostname.c /opt/ml/code/
+COPY build_artifacts/changehostname.c /usr/local/bin/changehostname.c
 COPY build_artifacts/start_with_right_hostname.sh /usr/local/bin/start_with_right_hostname.sh
 
-# /opt/ml and all subdirectories are utilized by SageMaker, we use the /code subdirectory to store our user code.
-# TODO(xiangsx): change to pip install when PIP package is available
-COPY code/graphstorm/ /opt/ml/code/graphstorm/
-ENV PYTHONPATH="/opt/ml/code/graphstorm/python/:${PYTHONPATH}"
+# /opt/ml and all subdirectories are utilized by SageMaker,
+# we use the /usr/local/bin subdirectory to store our user code.
+COPY code/graphstorm/ /usr/local/bin/graphstorm/
+ENV PYTHONPATH="/usr/local/bin/graphstorm/python/:${PYTHONPATH}"
 
-RUN cp /opt/ml/code/graphstorm/sagemaker/run/* /opt/ml/code/
+RUN cp /usr/local/bin/graphstorm/sagemaker/run/* /usr/local/bin/
 
 # Download DGL source code
 RUN cd /root; git clone --branch v${DGL_VERSION} --single-branch https://github.com/dmlc/dgl.git
@@ -60,7 +60,7 @@ RUN cd /root; git clone --branch v${DGL_VERSION} --single-branch https://github.
 # COPY dgl /root/dgl
 ENV PYTHONPATH="/root/dgl/tools/:${PYTHONPATH}"
 
-WORKDIR /opt/ml/code
+WORKDIR /usr/local/bin/
 
 ENTRYPOINT ["bash", "-m", "/usr/local/bin/start_with_right_hostname.sh"]
 CMD ["/bin/bash"]

--- a/docker/sagemaker/build_artifacts/start_with_right_hostname.sh
+++ b/docker/sagemaker/build_artifacts/start_with_right_hostname.sh
@@ -2,8 +2,8 @@
 
 if [[ "$1" = "train" ]]; then
      CURRENT_HOST=$(jq .current_host  /opt/ml/input/config/resourceconfig.json)
-     sed -ie "s/PLACEHOLDER_HOSTNAME/$CURRENT_HOST/g" changehostname.c
-     gcc -o changehostname.o -c -fPIC -Wall changehostname.c
+     sed -ie "s/PLACEHOLDER_HOSTNAME/$CURRENT_HOST/g" /usr/local/bin/changehostname.c
+     gcc -o changehostname.o -c -fPIC -Wall /usr/local/bin/changehostname.c
      gcc -o libchangehostname.so -shared -export-dynamic changehostname.o -ldl
      CWD=$(pwd)
      LD_PRELOAD=$CWD/libchangehostname.so train


### PR DESCRIPTION
…

*Issue #, if available:*

*Description of changes:*

* Previously our SageMaker jobs would log errors like `ERROR: ld.so: object '/libchangehostname.so' from LD_PRELOAD cannot be preloaded (cannot open shared object file): ignored.` at the beginning of the job because the entry point script is trying to use a library (changehostname.c) that gets compiled at launch time, but we were using the wrong path there, which meant there was no library compiled.
  * This PR fixes the path for the `changehostname.c`
* Our containers use a custom entry point, and code under `/opt/ml/code/` is usually reserved to be executed straight from SageMaker i.e. we do [this](https://docs.aws.amazon.com/sagemaker/latest/dg/your-algorithms-training-algo-dockerfile.html#your-algorithms-training-algo-dockerfile-api-ep-in) and not [this](https://docs.aws.amazon.com/sagemaker/latest/dg/adapt-training-container.html#byoc-training-step2). The presence of the code under `/opt/ml/code/` would occasionally cause problems in cases like HPO.
   * This PR uses `/usr/local/bin/` as our destination for our code to ensure we don't modify the files that SageMaker itself creates.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
