### PR TITLE
[GConstruct] [GSProcessing] Allow no-op operation in gconstruct to read strings of delimited numbers as vectors

### DIFF
--- a/docs/source/cli/graph-construction/single-machine-gconstruct.rst
+++ b/docs/source/cli/graph-construction/single-machine-gconstruct.rst
@@ -187,14 +187,22 @@ GraphStorm provides a set of transformation operations for different types of fe
                   "bucket_cnt": 2,
                   "slide_window_size": 10},
 
-* **No-op vector truncation (experimental)** truncates feature vectors to the length requested. The ``name`` field can be empty (e.g., ``{name: }``), and an integer ``truncate_dim`` value will determine the length of the output vector. This can be useful when experimenting with input features that were trained using `Matryoshka Representation Learning <https://arxiv.org/abs/2205.13147>`_.
+* **No-op vector parsing and truncation (experimental)** This is an no-op transformation that passes data along as-is. The ``name`` field needs to be ``no-op``.
+  Optionally it can parse vectors formatted as strings, splitting each string in a row with a user-defined separator string. For example,
+  if your file contains entries like ``0.4;0.3;0.9`` you can parse this as a numerical vector by setting the ``separator`` field to ``;``.
+  This operation can also truncate feature vectors to a specific length, by setting
+  the field ``truncate_dim`` to an integer value that will determine the length of the output vector.
+  This can be useful when experimenting with input features that were trained using `Matryoshka Representation Learning <https://arxiv.org/abs/2205.13147>`_.
 
   Example:
 
   .. code:: json
 
-    "transform": {"name": ,
-                  "truncate_dim": 24},
+    "transform": {
+        "name": "no-op",
+        "separator": ";",
+        "truncate_dim": 64
+    }
 
 .. _gcon-output-format:
 

--- a/docs/source/cli/graph-construction/single-machine-gconstruct.rst
+++ b/docs/source/cli/graph-construction/single-machine-gconstruct.rst
@@ -187,7 +187,7 @@ GraphStorm provides a set of transformation operations for different types of fe
                   "bucket_cnt": 2,
                   "slide_window_size": 10},
 
-* **No-op vector parsing and truncation (experimental)** This is an no-op transformation that passes data along as-is. The ``name`` field needs to be ``no-op``.
+* **No-op vector parsing and truncation (experimental)** This is a no-op transformation that passes data along as-is. The ``name`` field needs to be ``no-op``.
   Optionally it can parse vectors formatted as strings, splitting each string in a row with a user-defined separator string. For example,
   if your file contains entries like ``0.4;0.3;0.9`` you can parse this as a numerical vector by setting the ``separator`` field to ``;``.
   This operation can also truncate feature vectors to a specific length, by setting

--- a/graphstorm-processing/graphstorm_processing/config/config_conversion/gconstruct_converter.py
+++ b/graphstorm-processing/graphstorm_processing/config/config_conversion/gconstruct_converter.py
@@ -225,6 +225,16 @@ class GConstructConfigConverter(ConfigConverter):
                         gsp_transformation_dict["kwargs"] = {
                             "separator": gconstruct_transform_dict["separator"],
                         }
+                elif gconstruct_transform_dict["name"] == "no-op":
+                    gsp_transformation_dict["name"] = "no-op"
+                    if "separator" in gconstruct_transform_dict:
+                        gsp_transformation_dict["kwargs"] = {
+                            "separator": gconstruct_transform_dict["separator"],
+                        }
+                    if "truncate_dim" in gconstruct_transform_dict:
+                        gsp_transformation_dict["kwargs"]["truncate_dim"] = (
+                            gconstruct_transform_dict["truncate_dim"]
+                        )
                 else:
                     raise ValueError(
                         "Unsupported GConstruct transformation name: "

--- a/graphstorm-processing/tests/test_converter.py
+++ b/graphstorm-processing/tests/test_converter.py
@@ -368,6 +368,12 @@ def test_convert_gsprocessing(converter: GConstructConfigConverter):
             "node_id_col": "node_id",
             "features": [
                 {"feature_col": ["citation_time"], "feature_name": "feat"},
+                {"feature_col": ["str_vector"], "transform": {
+                        "name": "no-op",
+                        "separator": ";",
+                        "truncate_dim": 16
+                    }
+                },
                 {"feature_col": ["num_citations"], "transform": {"name": "max_min_norm"}},
                 {
                     "feature_col": ["num_citations"],
@@ -460,6 +466,14 @@ def test_convert_gsprocessing(converter: GConstructConfigConverter):
     assert nodes_output["column"] == "node_id"
     assert nodes_output["features"] == [
         {"column": "citation_time", "transformation": {"name": "no-op"}, "name": "feat"},
+        {"column": "str_vector", "transformation": {
+            "name": "no-op",
+            "kwargs": {
+                "separator": ";",
+                "truncate_dim": 16
+            }
+        }
+        },
         {
             "column": "num_citations",
             "transformation": {

--- a/graphstorm-processing/tests/test_converter.py
+++ b/graphstorm-processing/tests/test_converter.py
@@ -368,11 +368,9 @@ def test_convert_gsprocessing(converter: GConstructConfigConverter):
             "node_id_col": "node_id",
             "features": [
                 {"feature_col": ["citation_time"], "feature_name": "feat"},
-                {"feature_col": ["str_vector"], "transform": {
-                        "name": "no-op",
-                        "separator": ";",
-                        "truncate_dim": 16
-                    }
+                {
+                    "feature_col": ["str_vector"],
+                    "transform": {"name": "no-op", "separator": ";", "truncate_dim": 16},
                 },
                 {"feature_col": ["num_citations"], "transform": {"name": "max_min_norm"}},
                 {
@@ -466,13 +464,9 @@ def test_convert_gsprocessing(converter: GConstructConfigConverter):
     assert nodes_output["column"] == "node_id"
     assert nodes_output["features"] == [
         {"column": "citation_time", "transformation": {"name": "no-op"}, "name": "feat"},
-        {"column": "str_vector", "transformation": {
-            "name": "no-op",
-            "kwargs": {
-                "separator": ";",
-                "truncate_dim": 16
-            }
-        }
+        {
+            "column": "str_vector",
+            "transformation": {"name": "no-op", "kwargs": {"separator": ";", "truncate_dim": 16}},
         },
         {
             "column": "num_citations",

--- a/python/graphstorm/gconstruct/transform.py
+++ b/python/graphstorm/gconstruct/transform.py
@@ -1063,7 +1063,7 @@ class Noop(FeatTransform):
         When provided, will truncate the output float-vector feature to the specified dimension.
         This is useful when the feature is a multi-dimensional vector and we only need
         a subset of the dimensions, e.g. for Matryoshka Representation Learning embeddings.
-    separator: str , optional
+    separator: str, optional
         When provided will split every string in the input array along this separator
         to create an array of vectors.
 

--- a/python/graphstorm/gconstruct/utils.py
+++ b/python/graphstorm/gconstruct/utils.py
@@ -25,6 +25,7 @@ import copy
 import traceback
 import shutil
 import uuid
+from abc import ABC, abstractmethod
 
 
 import numpy as np
@@ -482,11 +483,12 @@ def _get_arrs_out_dtype(arrs):
     """
     return arrs[0][0].dtype
 
-class ExtMemArrayWrapper:
+class ExtMemArrayWrapper(ABC):
     """ An array wrapper for external-memory array.
     """
 
-    def to_numpy(self):
+    @abstractmethod
+    def to_numpy(self) -> np.ndarray:
         """ Convert the array to Numpy array.
         """
 

--- a/tests/unit-tests/gconstruct/test_construct_graph.py
+++ b/tests/unit-tests/gconstruct/test_construct_graph.py
@@ -229,6 +229,28 @@ def check_feat_ops_noop():
     assert res[0].feat_name == feat_op1[0]["feature_col"]
     assert isinstance(res[0], Noop)
 
+def test_noop_string():
+    text_vector_data = {
+        "test2": ["1;2;3", "4;5;6"]
+    }
+    text_vector_config = [{
+        "feature_col": "test2",
+        "feature_name": "test3",
+        "transform": {
+            "name": "no-op",
+            "separator": ";"
+        },
+    }]
+    (res, _, _, _) = parse_feat_ops(text_vector_config)
+    assert len(res) == 1
+    noop_transform = res[0]
+    assert isinstance(noop_transform, Noop)
+    assert noop_transform.separator == ";"
+
+    vector_data_processed = process_features(text_vector_data, res)
+
+    assert_equal(vector_data_processed["test3"], np.array([[1, 2, 3], [4, 5, 6]]))
+
 def check_feat_ops_tokenize():
     feat_op2 = [
         {

--- a/tests/unit-tests/gconstruct/test_transform.py
+++ b/tests/unit-tests/gconstruct/test_transform.py
@@ -20,6 +20,11 @@ import numpy as np
 from numpy.testing import assert_equal, assert_almost_equal, assert_raises
 from scipy.special import erfinv
 
+from graphstorm.gconstruct.transform import (
+    parse_feat_ops,
+    process_features,
+    preprocess_features
+)
 from graphstorm.gconstruct.transform import (_get_output_dtype,
                                              NumericalMinMaxTransform,
                                              NumericalStandardTransform,
@@ -582,6 +587,17 @@ def test_noop_truncate():
 
     assert trunc_feats["test"].shape[1] == 16
 
+def test_noop_str_vector():
+    """Test conversion of delimited string array to vectors"""
+
+    transform = Noop("test", "test", separator=";")
+    # Create a numpy array with ;-delimited vector strings
+    feats = np.array(["1;2;3", "4;5;6", "7;8;9"])
+    vector_feats = transform(feats)
+
+    expected_array = np.array([[1, 2, 3], [4, 5, 6], [7, 8, 9]])
+
+    assert_equal(vector_feats["test"], expected_array)
 
 @pytest.mark.parametrize("input_dtype", [np.cfloat, np.float32])
 @pytest.mark.parametrize("out_dtype", [None, np.float16])


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

* We add an explicit `no-op` transformation to GConstruct that can read delimited strings as vectors. 
* The previous no-op behavior when "transform" entry is not provided remains unchanged.
* Add docs and handling for conversion to GSProcessing.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
