### PR TITLE
Don't print torchdata deprecation warnings

### DIFF
--- a/python/graphstorm/__init__.py
+++ b/python/graphstorm/__init__.py
@@ -16,6 +16,15 @@
     Graphstorm package.
 """
 __version__ = "0.4.1"
+import warnings
+
+# Don't print torchdata warnings
+warnings.filterwarnings(
+    "ignore",
+    message=".*The 'datapipes', 'dataloader2' modules are deprecated.*")
+warnings.filterwarnings(
+    "ignore",
+    category=UserWarning, module="torchdata.datapipes")
 
 from . import gsf
 from . import utils


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

* Currently every time DGL is imported the torchdata deprecation warnings are printed. For logs with multiple workers and trainers we can have the same message repeated tens of times (once per DGL process), polluting the logs. 
* This PR filters out the warning since we are aware of the deprecation notice and it come from DGL and not graphstorm

Old behavior:

```
root@3ef2b8d262b3:/opt/ml/code# python
>>> import graphstorm
/opt/conda/lib/python3.11/site-packages/torchdata/datapipes/__init__.py:18: UserWarning:
################################################################################
WARNING!
The 'datapipes', 'dataloader2' modules are deprecated and will be removed in a
future torchdata release! Please see https://github.com/pytorch/data/issues/1196
to learn more and leave feedback.
################################################################################

  deprecation_warning()
>>>
```

new behavior:

```
root@88e89a8ea077:/opt/ml/code# python
>>> import graphstorm
>>>
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
