### PR TITLE
Change decoder output definition so that focal loss does not require setting num_classes to 1.

### DIFF
--- a/docs/source/advanced/imbalanced-labels.rst
+++ b/docs/source/advanced/imbalanced-labels.rst
@@ -34,7 +34,7 @@ in a binary classification. This function has two hyperparameters, :math:`\alpha
 corresponding to the ``alpha`` and ``gamma`` configuration in GraphStorm. Larger values of ``gamma`` will help
 update models on harder cases so as to detect more positive samples if the positive to negative ratio is small.
 There is no clear guideline for values of ``alpha``. You can use its default value(``0.25``) first, and then
-search for optimal values. Below is an example about how to set the `focal loss funciton` in a YAML configuration file.
+search for optimal values. Below is an example about how to set the `focal loss function` in a YAML configuration file.
 
   .. code-block:: yaml
 

--- a/docs/source/advanced/imbalanced-labels.rst
+++ b/docs/source/advanced/imbalanced-labels.rst
@@ -34,7 +34,9 @@ in a binary classification. This function has two hyperparameters, :math:`\alpha
 corresponding to the ``alpha`` and ``gamma`` configuration in GraphStorm. Larger values of ``gamma`` will help
 update models on harder cases so as to detect more positive samples if the positive to negative ratio is small.
 There is no clear guideline for values of ``alpha``. You can use its default value(``0.25``) first, and then
-search for optimal values. Below is an example about how to set the `focal loss function` in a YAML configuration file.
+search for optimal values. Focal loss only works for binary classification tasks, so ``num_classes`` should be set
+to 2.
+Below is an example about how to set the `focal loss function` in a YAML configuration file.
 
   .. code-block:: yaml
 

--- a/python/graphstorm/gsf.py
+++ b/python/graphstorm/gsf.py
@@ -483,6 +483,8 @@ def create_builtin_node_decoder(g, decoder_input_dim, config, train_task):
                                              config.multilabel_weights,
                                              config.imbalance_class_weights)
             elif config.class_loss_func == BUILTIN_CLASS_LOSS_FOCAL:
+                # For backward compatibility, we allow the num_classes to be 1.
+                # Users should set it to 2.
                 assert config.num_classes in [1, 2], \
                     "Focal loss only works with binary classification." \
                     "num_classes should be set to 2."
@@ -626,10 +628,13 @@ def create_builtin_edge_decoder(g, decoder_input_dim, config, train_task):
 
 
     if config.task_type == BUILTIN_TASK_EDGE_CLASSIFICATION:
+
         num_classes = config.num_classes
 
         # Focal loss expects 1-dimensional output
         if config.class_loss_func == BUILTIN_CLASS_LOSS_FOCAL:
+            # For backward compatibility, we allow the num_classes to be 1.
+            # Users should set it to 2.
             assert num_classes in [1, 2], (
                 "Focal loss only works with binary classification. "
                 "num_classes should be set to 2."

--- a/python/graphstorm/model/loss_func.py
+++ b/python/graphstorm/model/loss_func.py
@@ -101,7 +101,8 @@ class FocalLossFunc(GSLayer):
     See more details on https://pytorch.org/vision/main/_modules/torchvision/ops/focal_loss.html.
 
     To use focal loss, the classification task must be
-    a binary classification task.
+    a binary classification task, i.e. ``num_classes``
+    should be set to 2.
 
     Parameters
     ----------

--- a/tests/end2end-tests/graphstorm-ec/test.sh
+++ b/tests/end2end-tests/graphstorm-ec/test.sh
@@ -141,7 +141,7 @@ fi
 rm /tmp/exec.log
 
 echo "**************dataset: Test edge classification, RGCN layer: 1, node feat: fixed HF BERT, BERT nodes: movie, inference: mini-batch, focal loss"
-python3 -m graphstorm.run.gs_edge_classification --workspace $GS_HOME/training_scripts/gsgnn_ep/ --num-trainers $NUM_TRAINERS --num-servers 1 --num-samplers 0 --part-config /data/movielen_100k_ec_1p_4t/movie-lens-100k.json --ip-config ip_list.txt --ssh-port 2222 --cf ml_ec.yaml --num-epochs 1 --class-loss-func focal --num-classes 1
+python3 -m graphstorm.run.gs_edge_classification --workspace $GS_HOME/training_scripts/gsgnn_ep/ --num-trainers $NUM_TRAINERS --num-servers 1 --num-samplers 0 --part-config /data/movielen_100k_ec_1p_4t/movie-lens-100k.json --ip-config ip_list.txt --ssh-port 2222 --cf ml_ec.yaml --num-epochs 1 --class-loss-func focal --num-classes 2
 
 error_and_exit $?
 

--- a/tests/end2end-tests/graphstorm-nc/test.sh
+++ b/tests/end2end-tests/graphstorm-nc/test.sh
@@ -295,7 +295,7 @@ python3 -m graphstorm.run.gs_node_classification --workspace $GS_HOME/training_s
 error_and_exit $?
 
 echo "**************dataset: MovieLens, RGCN layer: 1, node feat: fixed HF BERT, BERT nodes: movie, inference: mini-batch, focal loss with tensorboard tracker but not tensorboard package installed"
-python3 -m graphstorm.run.gs_node_classification --workspace $GS_HOME/training_scripts/gsgnn_np/ --num-trainers $NUM_TRAINERS --num-servers 1 --num-samplers 0 --part-config /data/movielen_100k_train_val_1p_4t/movie-lens-100k.json --ip-config ip_list.txt --ssh-port 2222 --cf ml_nc.yaml --decoder-norm layer --class-loss-func focal --num-classes 1 --task-tracker tensorboard_task_tracker
+python3 -m graphstorm.run.gs_node_classification --workspace $GS_HOME/training_scripts/gsgnn_np/ --num-trainers $NUM_TRAINERS --num-servers 1 --num-samplers 0 --part-config /data/movielen_100k_train_val_1p_4t/movie-lens-100k.json --ip-config ip_list.txt --ssh-port 2222 --cf ml_nc.yaml --decoder-norm layer --class-loss-func focal --num-classes 2 --task-tracker tensorboard_task_tracker
 
 if test $? -eq 0
 then
@@ -308,7 +308,7 @@ fi
 python3 -m pip install tensorboard
 
 echo "**************dataset: MovieLens, RGCN layer: 1, node feat: fixed HF BERT, BERT nodes: movie, inference: mini-batch, focal loss with tensorboard tracker"
-python3 -m graphstorm.run.gs_node_classification --workspace $GS_HOME/training_scripts/gsgnn_np/ --num-trainers $NUM_TRAINERS --num-servers 1 --num-samplers 0 --part-config /data/movielen_100k_train_val_1p_4t/movie-lens-100k.json --ip-config ip_list.txt --ssh-port 2222 --cf ml_nc.yaml --decoder-norm layer --class-loss-func focal --num-classes 1 --task-tracker tensorboard_task_tracker
+python3 -m graphstorm.run.gs_node_classification --workspace $GS_HOME/training_scripts/gsgnn_np/ --num-trainers $NUM_TRAINERS --num-servers 1 --num-samplers 0 --part-config /data/movielen_100k_train_val_1p_4t/movie-lens-100k.json --ip-config ip_list.txt --ssh-port 2222 --cf ml_nc.yaml --decoder-norm layer --class-loss-func focal --num-classes 2 --task-tracker tensorboard_task_tracker
 
 error_and_exit $?
 
@@ -321,7 +321,7 @@ fi
 rm -fr $GS_HOME/training_scripts/gsgnn_np/runs/
 
 echo "**************dataset: MovieLens, RGCN layer: 1, node feat: fixed HF BERT, BERT nodes: movie, inference: mini-batch, focal loss with tensorboard tracker"
-python3 -m graphstorm.run.gs_node_classification --workspace $GS_HOME/training_scripts/gsgnn_np/ --num-trainers $NUM_TRAINERS --num-servers 1 --num-samplers 0 --part-config /data/movielen_100k_train_val_1p_4t/movie-lens-100k.json --ip-config ip_list.txt --ssh-port 2222 --cf ml_nc.yaml --decoder-norm layer --class-loss-func focal --num-classes 1 --task-tracker tensorboard_task_tracker:./logs/
+python3 -m graphstorm.run.gs_node_classification --workspace $GS_HOME/training_scripts/gsgnn_np/ --num-trainers $NUM_TRAINERS --num-servers 1 --num-samplers 0 --part-config /data/movielen_100k_train_val_1p_4t/movie-lens-100k.json --ip-config ip_list.txt --ssh-port 2222 --cf ml_nc.yaml --decoder-norm layer --class-loss-func focal --num-classes 2 --task-tracker tensorboard_task_tracker:./logs/
 
 error_and_exit $?
 

--- a/tests/unit-tests/test_gsf.py
+++ b/tests/unit-tests/test_gsf.py
@@ -97,7 +97,7 @@ def test_create_builtin_node_decoder():
     config = GSTestConfig(
         {
             "task_type": BUILTIN_TASK_NODE_CLASSIFICATION,
-            "num_classes": 1,
+            "num_classes": 2,
             "multilabel": False,
             "class_loss_func": BUILTIN_CLASS_LOSS_FOCAL,
             "multilabel_weights": None,
@@ -155,8 +155,8 @@ def test_create_builtin_node_decoder():
             "target_ntype": ["n0", "n1"],
             "task_type": BUILTIN_TASK_NODE_CLASSIFICATION,
             "num_classes": {
-                "n0": 1,
-                "n1": 1
+                "n0": 2,
+                "n1": 2
             },
             "multilabel":  {
                 "n0": False,
@@ -243,7 +243,7 @@ def test_create_builtin_edge_decoder():
         {
             "task_type": BUILTIN_TASK_EDGE_CLASSIFICATION,
             "target_etype": [("n0", "r0", "n1")],
-            "num_classes": 1,
+            "num_classes": 2,
             "decoder_type": "DenseBiDecoder",
             "num_decoder_basis": 2,
             "multilabel": False,
@@ -266,7 +266,7 @@ def test_create_builtin_edge_decoder():
         {
             "task_type": BUILTIN_TASK_EDGE_CLASSIFICATION,
             "target_etype": [("n0", "r0", "n1")],
-            "num_classes": 1,
+            "num_classes": 2,
             "decoder_type": "MLPDecoder",
             "multilabel": False,
             "class_loss_func": BUILTIN_CLASS_LOSS_FOCAL,


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

* We use a condition to only set the decoder output dimension to 1 for focal loss, using num_classes for other cases.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
