### PR TITLE
[GSProcessing] Support `:` in label column names

### DIFF
--- a/graphstorm-processing/tests/test_dist_label_loader.py
+++ b/graphstorm-processing/tests/test_dist_label_loader.py
@@ -27,9 +27,9 @@ from graphstorm_processing.constants import NODE_MAPPING_INT
 
 def test_dist_classification_label(spark: SparkSession, check_df_schema):
     """Test classification label generation"""
-    label_col = "name"
+    label_col = "name:Int"
     classification_config = {
-        "column": "name",
+        "column": label_col,
         "type": "classification",
         "split_rate": {"train": 0.8, "val": 0.2, "test": 0.0},
     }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

* Previously, label column names that included colons in their name like `label:String`, which is how Neptune Analytics exports CSV columns, would trigger an SQL syntax error because of the way we defined the label DataFrame schema using an SQL string. 
 
For example with a column like `isFraud:Int`

```
[PARSE_SYNTAX_ERROR] Syntax error at or near ':'.(line 1, pos 3)
== SQL ==
idx: int, isFraud:Int: string
---^^^
```

* This PR programmatically defines the schema to avoid this issue.
* Modify a test to match the corner case.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
