### PR TITLE
[Ehancement] Refactor `return_proba` warning message and document

### DIFF
--- a/docs/source/cli/model-training-inference/configuration-run.rst
+++ b/docs/source/cli/model-training-inference/configuration-run.rst
@@ -433,7 +433,7 @@ Classification and Regression Task
     - Yaml: ``imbalance_class_weights: 0.1,0.2,0.3``
     - Argument: ``--imbalance-class-weights 0.1,0.2,0.3``
     - Default value: ``None``
-- **return_proba**: In classification inference, this configuration determines whether to return probability estimates for each class or the maximum probable class in the output predicitons. Set true to return probability estimates and false to return the maximum probable class.
+- **return_proba**: In classification inference, this parameter determines whether the output files will contain probability estimates for each class or the maximum probable class in the output predicitons. Set true to return probability estimates and false to return the maximum probable class.
 
     - Yaml: ``return_proba: true``
     - Argument: ``--return-proba true``

--- a/docs/source/cli/model-training-inference/configuration-run.rst
+++ b/docs/source/cli/model-training-inference/configuration-run.rst
@@ -433,7 +433,7 @@ Classification and Regression Task
     - Yaml: ``imbalance_class_weights: 0.1,0.2,0.3``
     - Argument: ``--imbalance-class-weights 0.1,0.2,0.3``
     - Default value: ``None``
-- **return_proba**: For classification task, this configuration determines whether to return probability estimates for each class or the maximum probable class. Set true to return probability estimates and false to return the maximum probable class.
+- **return_proba**: In classification inference, this configuration determines whether to return probability estimates for each class or the maximum probable class in the output predicitons. Set true to return probability estimates and false to return the maximum probable class.
 
     - Yaml: ``return_proba: true``
     - Argument: ``--return-proba true``

--- a/python/graphstorm/trainer/ep_trainer.py
+++ b/python/graphstorm/trainer/ep_trainer.py
@@ -360,9 +360,6 @@ class GSgnnEdgePredictionTrainer(GSgnnTrainer):
                          but {need_label_pred} requires return_proba==False."
         if len(need_proba) > 0 and return_proba is False:
             return_proba = True
-            logging.warning("%s requires return_proba==True. \
-                Set return_proba to True.", need_proba)
-
 
         model.eval()
         if use_mini_batch_infer:

--- a/python/graphstorm/trainer/np_trainer.py
+++ b/python/graphstorm/trainer/np_trainer.py
@@ -338,8 +338,6 @@ class GSgnnNodePredictionTrainer(GSgnnTrainer):
                          but {need_label_pred} requires return_proba==False."
         if len(need_proba) > 0 and return_proba is False:
             return_proba = True
-            logging.warning("%s requires return_proba==True. \
-                Set return_proba to True.", need_proba)
 
         if use_mini_batch_infer:
             val_pred, _, val_label = node_mini_batch_gnn_predict(model, val_loader, return_proba,


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This PR comment out the warning message of `set return_proba to be true`, which is confusing during training pipeline. And revise the document of `return_proba` configuration to explain this configuration only works on inference output.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
