### PR TITLE
Add infer-all-target-nodes argument to trigger inference on all nodes in target node types

### DIFF
--- a/docs/source/cli/model-training-inference/configuration-run.rst
+++ b/docs/source/cli/model-training-inference/configuration-run.rst
@@ -470,11 +470,12 @@ Node Classification/Regression Specific
     - Yaml: ``target_ntype: movie``
     - Argument: ``--target-ntype movie``
     - Default value: For heterogeneous input graph, this parameter must be provided by the user. If not provided, GraphStorm will assume the input graph is a homogeneous graph and set ``target_ntype`` to "_N".
-- **infer_all_target_nodes**: When set to true, run inference on all nodes in the target type(s), ignoring the test mask.
+- **infer_all_target_nodes**: When set to `True`, run inference on all nodes in the target type(s) as defined by **target_ntype**. **NEEDS TO RUN WITH no_validation=True**.
+  We require all-node inference to run without evaluation, to avoid biased evaluation that includes nodes in the train set.
 
-    - Yaml: ``infer_all_target_nodes: true``
-    - Argument: ``--infer-all-target-nodes true``
-    - Default value: False, inference will run only for the nodes in the test mask.
+    - Yaml: ``infer_all_target_nodes: True``
+    - Argument: ``--infer-all-target-nodes True``
+    - Default value: False, inference will run only on the node subset specified by the test mask.
 
 Edge Classification/Regression Specific
 `````````````````````````````````````````

--- a/docs/source/cli/model-training-inference/configuration-run.rst
+++ b/docs/source/cli/model-training-inference/configuration-run.rst
@@ -470,7 +470,7 @@ Node Classification/Regression Specific
     - Yaml: ``target_ntype: movie``
     - Argument: ``--target-ntype movie``
     - Default value: For heterogeneous input graph, this parameter must be provided by the user. If not provided, GraphStorm will assume the input graph is a homogeneous graph and set ``target_ntype`` to "_N".
-- **infer_all_target_nodes**: When set to `True`, run inference on all nodes in the target type(s) as defined by **target_ntype**. **NEEDS TO RUN WITH no_validation=True**.
+- **infer_all_target_nodes**: When set to `True`, run inference on all nodes in the target node type(s) as defined by **target_ntype**. **NEEDS TO RUN WITH no_validation=True**.
   We require all-node inference to run without evaluation, to avoid biased evaluation that includes nodes in the train set.
 
     - Yaml: ``infer_all_target_nodes: True``

--- a/docs/source/cli/model-training-inference/configuration-run.rst
+++ b/docs/source/cli/model-training-inference/configuration-run.rst
@@ -381,7 +381,7 @@ General Configurations
   choose the best trained model and for early stopping. Each learning task supports different evaluation metrics:
 
   - The supported evaluation metrics of classification tasks include ``accuracy``,
-    ``precision_recall``, ``roc_auc``, ``f1_score``, ``per_class_f1_score``, ``hit_at_k``, ``precision``, ``recall``, and ``fscore_at_beta``. 
+    ``precision_recall``, ``roc_auc``, ``f1_score``, ``per_class_f1_score``, ``hit_at_k``, ``precision``, ``recall``, and ``fscore_at_beta``.
 
     - The ``k`` of ``hit_at_k`` can be any positive integer, for example ``hit_at_10`` or
       ``hit_at_100``. The term ``hit_at_k`` refers to the number of true positives among the top ``k``
@@ -470,6 +470,11 @@ Node Classification/Regression Specific
     - Yaml: ``target_ntype: movie``
     - Argument: ``--target-ntype movie``
     - Default value: For heterogeneous input graph, this parameter must be provided by the user. If not provided, GraphStorm will assume the input graph is a homogeneous graph and set ``target_ntype`` to "_N".
+- **infer_all_target_nodes**: When set to true, run inference on all nodes in the target type(s), ignoring the test mask.
+
+    - Yaml: ``infer_all_target_nodes: true``
+    - Argument: ``--infer-all-target-nodes true``
+    - Default value: False, inference will run only for the nodes in the test mask.
 
 Edge Classification/Regression Specific
 `````````````````````````````````````````

--- a/python/graphstorm/__init__.py
+++ b/python/graphstorm/__init__.py
@@ -26,6 +26,11 @@ warnings.filterwarnings(
 warnings.filterwarnings(
     "ignore",
     category=UserWarning, module="torchdata.datapipes")
+warnings.filterwarnings(
+    "ignore",
+    message=".*torch.utils._pytree._register_pytree_node is deprecated.*",
+    category=UserWarning,
+    module="transformers.utils.generic")
 
 from . import gsf
 from . import utils

--- a/python/graphstorm/__init__.py
+++ b/python/graphstorm/__init__.py
@@ -26,11 +26,6 @@ warnings.filterwarnings(
 warnings.filterwarnings(
     "ignore",
     category=UserWarning, module="torchdata.datapipes")
-warnings.filterwarnings(
-    "ignore",
-    message=".*torch.utils._pytree._register_pytree_node is deprecated.*",
-    category=UserWarning,
-    module="transformers.utils.generic")
 
 from . import gsf
 from . import utils

--- a/python/graphstorm/config/argument.py
+++ b/python/graphstorm/config/argument.py
@@ -887,7 +887,7 @@ class GSConfig:
             _ = self.lp_embed_normalizer
 
         # For inference tasks in particular
-        if self.task_type == [
+        if self.task_type in [
             BUILTIN_TASK_NODE_CLASSIFICATION,
             BUILTIN_TASK_NODE_REGRESSION,
         ]:

--- a/python/graphstorm/config/argument.py
+++ b/python/graphstorm/config/argument.py
@@ -886,6 +886,15 @@ class GSConfig:
             _ = self.model_select_etype
             _ = self.lp_embed_normalizer
 
+        # For inference tasks in particular
+        if self.task_type == [
+            BUILTIN_TASK_EDGE_CLASSIFICATION,
+            BUILTIN_TASK_EDGE_REGRESSION,
+            BUILTIN_TASK_NODE_CLASSIFICATION,
+            BUILTIN_TASK_NODE_REGRESSION,
+        ]:
+            _ = self.infer_all_targets
+
     def _turn_off_gradient_checkpoint(self, reason):
         """Turn off `gradient_checkpoint` flags in `node_lm_configs`
         """
@@ -2353,6 +2362,19 @@ class GSConfig:
         # use save_embed_path
         return self.save_embed_path
 
+    @property
+    def infer_all_targets(self):
+        """ Whether to force inference to run on all the nodes/edges in the graph. Default is False.
+        """
+        # pylint: disable=no-member
+        if hasattr(self, "_infer_all_targets"):
+            assert self._infer_all_targets in [True, False], \
+                "infer_all_target_nodes/infer_all_target_edges should be in [True, False]"
+            return self._infer_all_targets
+
+        # By default, do not force inference on all nodes/edges
+        return False
+
     ### Node related task variables ###
     @property
     def target_ntype(self):
@@ -3677,16 +3699,28 @@ def _add_task_general_args(parser):
                 "the evaluation metric used. Supported metrics are accuracy,"
                 "precision_recall, or roc_auc multiple metrics"
                 "can be specified e.g. --eval-metric accuracy precision_recall")
-    group.add_argument('--report-eval-per-type', type=bool, default=argparse.SUPPRESS,
-            help="Whether report evaluation metrics per node type or edge type."
-                 "If True, report evaluation results for each node type/edge type."
-                 "If False, report an average evaluation result.")
+    group.add_argument(
+        '--report-eval-per-type', type=lambda x: (str(x).lower() in ['true', '1']),
+        default=argparse.SUPPRESS,
+        help=(
+            "Whether to report evaluation metrics per node type or edge type. "
+            "If set to 'True', report evaluation results for each node type/edge type. "
+            "Otherwise, report an average evaluation result."
+        )
+    )
     return parser
 
-def _add_inference_args(parser):
+def _add_inference_args(parser: argparse.ArgumentParser):
     group = parser.add_argument_group(title="infer")
     group.add_argument("--save-prediction-path", type=str, default=argparse.SUPPRESS,
                        help="Where to save the prediction results.")
+    # Both infer-all-target-nodes and infer-all-target-edges passed
+    # will set the value infer_all_targets
+    group.add_argument(
+        "--infer-all-target-nodes", "--infer-all-target-edges",
+        type=lambda x: (str(x).lower() in ['true', '1']),
+        default=argparse.SUPPRESS, dest="infer_all_targets",
+        help="When set to 'true', will force inference to run on all target node/edge types.")
     return parser
 
 def _add_distill_args(parser):

--- a/python/graphstorm/config/argument.py
+++ b/python/graphstorm/config/argument.py
@@ -2368,7 +2368,7 @@ class GSConfig:
         # pylint: disable=no-member
         if hasattr(self, "_infer_all_target_nodes"):
             assert self._infer_all_target_nodes in [True, False], \
-                "infer_all_target_nodes/infer_all_target_edges should be in [True, False] (bool)"
+                "infer_all_target_nodes should be in [True, False] (bool)"
             return self._infer_all_target_nodes
 
         # By default, do not force inference on all nodes/edges

--- a/python/graphstorm/config/argument.py
+++ b/python/graphstorm/config/argument.py
@@ -888,12 +888,10 @@ class GSConfig:
 
         # For inference tasks in particular
         if self.task_type == [
-            BUILTIN_TASK_EDGE_CLASSIFICATION,
-            BUILTIN_TASK_EDGE_REGRESSION,
             BUILTIN_TASK_NODE_CLASSIFICATION,
             BUILTIN_TASK_NODE_REGRESSION,
         ]:
-            _ = self.infer_all_targets
+            _ = self.infer_all_target_nodes
 
     def _turn_off_gradient_checkpoint(self, reason):
         """Turn off `gradient_checkpoint` flags in `node_lm_configs`
@@ -2363,14 +2361,15 @@ class GSConfig:
         return self.save_embed_path
 
     @property
-    def infer_all_targets(self):
-        """ Whether to force inference to run on all the nodes/edges in the graph. Default is False.
+    def infer_all_target_nodes(self):
+        """ Whether to force inference to run on all nodes for types specified
+        by target-ntypes, ignoring any mask. Default is False.
         """
         # pylint: disable=no-member
-        if hasattr(self, "_infer_all_targets"):
-            assert self._infer_all_targets in [True, False], \
-                "infer_all_target_nodes/infer_all_target_edges should be in [True, False]"
-            return self._infer_all_targets
+        if hasattr(self, "_infer_all_target_nodes"):
+            assert self._infer_all_target_nodes in [True, False], \
+                "infer_all_target_nodes/infer_all_target_edges should be in [True, False] (bool)"
+            return self._infer_all_target_nodes
 
         # By default, do not force inference on all nodes/edges
         return False
@@ -3714,13 +3713,11 @@ def _add_inference_args(parser: argparse.ArgumentParser):
     group = parser.add_argument_group(title="infer")
     group.add_argument("--save-prediction-path", type=str, default=argparse.SUPPRESS,
                        help="Where to save the prediction results.")
-    # Both infer-all-target-nodes and infer-all-target-edges passed
-    # will set the value infer_all_targets
     group.add_argument(
-        "--infer-all-target-nodes", "--infer-all-target-edges",
+        "--infer-all-target-nodes",
         type=lambda x: (str(x).lower() in ['true', '1']),
-        default=argparse.SUPPRESS, dest="infer_all_targets",
-        help="When set to 'true', will force inference to run on all target node/edge types.")
+        default=argparse.SUPPRESS,
+        help="When set to 'true', will force inference to run on all target node types.")
     return parser
 
 def _add_distill_args(parser):

--- a/python/graphstorm/run/gsgnn_np/np_infer_gnn.py
+++ b/python/graphstorm/run/gsgnn_np/np_infer_gnn.py
@@ -60,19 +60,30 @@ def main(config_args):
                         model_layer_to_load=config.restore_model_layers)
     infer = GSgnnNodePredictionInferrer(model)
     infer.setup_device(device=get_device())
-    if not config.no_validation:
-        infer_idxs = infer_data.get_node_test_set(config.target_ntype)
+    # If the user requested no evaluation, ensure there's no test mask
+    if config.no_validation:
+        infer_idxs = infer_data.get_node_infer_set(config.target_ntype)
+        assert len(infer_idxs) > 0, \
+            f"To do inference on '{config.target_ntype}' without doing evaluation, " \
+            "you should not define test_mask as a node feature. " \
+            "GraphStorm will do inference on the whole node set. "
+    else:
+        if config.infer_all_targets:
+            # Set the mask name to the empty string, this ensures
+            # the mask doesn't exist, and get_node_infer_set
+            # will return the entire node set
+            requested_mask = ""
+        else:
+            requested_mask = "test_mask"
+        infer_idxs = infer_data.get_node_infer_set(
+            config.target_ntype,
+            mask=requested_mask
+        )
         evaluator = get_evaluator(config)
         infer.setup_evaluator(evaluator)
         assert len(infer_idxs) > 0, \
             "There is not test data for evaluation. " \
             "You can use --no-validation true to avoid do testing"
-    else:
-        infer_idxs = infer_data.get_node_infer_set(config.target_ntype)
-        assert len(infer_idxs) > 0, \
-            f"To do inference on {config.target_ntype} without doing evaluation, " \
-            "you should not define test_mask as its node feature. " \
-            "GraphStorm will do inference on the whole node set. "
     tracker = gs.create_builtin_task_tracker(config)
     infer.setup_task_tracker(tracker)
     fanout = config.eval_fanout if config.use_mini_batch_infer else []
@@ -84,6 +95,7 @@ def main(config_args):
                                      label_field=config.label_field,
                                      construct_feat_ntype=config.construct_feat_ntype,
                                      construct_feat_fanout=config.construct_feat_fanout)
+    logging.info("Start inference for node type(s) '%s'", config.target_ntype)
     infer.infer(dataloader, save_embed_path=config.save_embed_path,
                 save_prediction_path=config.save_prediction_path,
                 use_mini_batch_infer=config.use_mini_batch_infer,

--- a/python/graphstorm/run/gsgnn_np/np_infer_gnn.py
+++ b/python/graphstorm/run/gsgnn_np/np_infer_gnn.py
@@ -73,7 +73,7 @@ def main(config_args):
                 ("Cannot run evaluation during all-nodes inference as that would "
                 "include training data. To run evaluation, ensure you have a 'test_mask' set up "
                 "and run with  infer_all_target_nodes=False. For all-nodes predictions, "
-                "'--no-validation' to skip evaluation and only produce embeddings/predictions.")
+                "use '--no-validation' to skip evaluation and only produce embeddings/predictions.")
             )
         # Set the mask name to an empty string, this implicitly ensures
         # the mask will be ignored, and get_node_infer_set

--- a/python/graphstorm/run/gsgnn_np/np_infer_gnn.py
+++ b/python/graphstorm/run/gsgnn_np/np_infer_gnn.py
@@ -60,30 +60,41 @@ def main(config_args):
                         model_layer_to_load=config.restore_model_layers)
     infer = GSgnnNodePredictionInferrer(model)
     infer.setup_device(device=get_device())
-    # If the user requested no evaluation, ensure there's no test mask
-    if config.no_validation:
-        infer_idxs = infer_data.get_node_infer_set(config.target_ntype)
-        assert len(infer_idxs) > 0, \
-            f"To do inference on '{config.target_ntype}' without doing evaluation, " \
-            "you should not define test_mask as a node feature. " \
-            "GraphStorm will do inference on the whole node set. "
-    else:
-        if config.infer_all_targets:
-            # Set the mask name to the empty string, this ensures
-            # the mask doesn't exist, and get_node_infer_set
-            # will return the entire node set
-            requested_mask = ""
-        else:
-            requested_mask = "test_mask"
-        infer_idxs = infer_data.get_node_infer_set(
-            config.target_ntype,
-            mask=requested_mask
-        )
+
+
+    # Only set up evaluator when the user has not explicitly set no_validation=True
+    if not config.no_validation:
         evaluator = get_evaluator(config)
         infer.setup_evaluator(evaluator)
-        assert len(infer_idxs) > 0, \
-            "There is not test data for evaluation. " \
-            "You can use --no-validation true to avoid do testing"
+
+    if config.infer_all_target_nodes:
+        if not config.no_validation:
+            raise RuntimeError(
+                ("Cannot run evaluation during all-nodes inference as that would "
+                "include training data. To run evaluation, ensure you have a 'test_mask' set up "
+                "and run with  infer_all_target_nodes=False. For all-nodes predictions, "
+                "'--no-validation' to skip evaluation and only produce embeddings/predictions.")
+            )
+        # Set the mask name to an empty string, this implicitly ensures
+        # the mask will be ignored, and get_node_infer_set
+        # will return the entire node set
+        requested_mask = ""
+    else:
+        requested_mask = "test_mask"
+
+
+    infer_idxs = infer_data.get_node_infer_set(
+        config.target_ntype,
+        mask=requested_mask
+    )
+
+    # In the case where we want eval to run, ensure there exist test data
+    if not config.no_validation:
+        assert len(infer_idxs) > 0, (
+            "There is no test data for evaluation. "
+            "You can use --no-validation true to avoid running evaluation."
+        )
+
     tracker = gs.create_builtin_task_tracker(config)
     infer.setup_task_tracker(tracker)
     fanout = config.eval_fanout if config.use_mini_batch_infer else []
@@ -95,7 +106,7 @@ def main(config_args):
                                      label_field=config.label_field,
                                      construct_feat_ntype=config.construct_feat_ntype,
                                      construct_feat_fanout=config.construct_feat_fanout)
-    logging.info("Start inference for node type(s) '%s'", config.target_ntype)
+    logging.debug("Start inference for node type(s) '%s'", config.target_ntype)
     infer.infer(dataloader, save_embed_path=config.save_embed_path,
                 save_prediction_path=config.save_prediction_path,
                 use_mini_batch_infer=config.use_mini_batch_infer,

--- a/python/graphstorm/sagemaker/sagemaker_infer.py
+++ b/python/graphstorm/sagemaker/sagemaker_infer.py
@@ -93,7 +93,7 @@ def launch_infer_task(task_type, num_gpus, graph_config,
     elif task_type == BUILTIN_TASK_NODE_CLASSIFICATION:
         cmd = "graphstorm.run.gs_node_classification"
     elif task_type == BUILTIN_TASK_NODE_REGRESSION:
-        cmd = "graphstorm.run.gs_node_classification"
+        cmd = "graphstorm.run.gs_node_regression"
     elif task_type == BUILTIN_TASK_EDGE_CLASSIFICATION:
         cmd = "graphstorm.run.gs_edge_classification"
     elif task_type == BUILTIN_TASK_EDGE_REGRESSION:

--- a/tests/end2end-tests/graphstorm-nc/check_emb.py
+++ b/tests/end2end-tests/graphstorm-nc/check_emb.py
@@ -13,40 +13,76 @@
     See the License for the specific language governing permissions and
     limitations under the License.
 """
-
-import os, argparse
-import torch as th
+import argparse
 import json
+import logging
+import os
+
+import numpy as np
+import torch as th
 
 if __name__ == '__main__':
-    argparser = argparse.ArgumentParser("Check emb")
+    argparser = argparse.ArgumentParser("Check embedding file correctness")
     argparser.add_argument("--emb-path", type=str, required=True,
         help="Path to node embedings to load")
     argparser.add_argument("--graph-config", type=str, required=True,
         help="Config file of the graph")
-    argparser.add_argument("--ntypes", type=str, required=True,
+    argparser.add_argument("--ntypes", type=str, nargs='+', required=True,
         help="Node types to check. The format is 'ntype1 ntype2")
     argparser.add_argument("--emb-size", type=int, required=True,
         help="Output emb dim")
+    argparser.add_argument("--expected-row-count", type=int, required=False,
+        default=None, help="Expected number of rows in the embedding file")
+    argparser.add_argument("--file-format", type=str, default="pytorch",
+        choices=["parquet", "torch"],
+        help=("File format of the embedding files, can be 'parquet' or 'pytorch', "
+              "default: pytorch"))
     args = argparser.parse_args()
-    with open(args.graph_config, 'r') as f:
+
+    with open(args.graph_config, 'r', encoding="utf-8") as f:
         graph_config = json.load(f)
 
         # Get all ntypes
-        ntypes = args.ntypes.strip().split(' ')
+        ntypes = args.ntypes
         node_map = {}
-        for ntype, range in graph_config['node_map'].items():
+        for ntype, nrange in graph_config['node_map'].items():
             node_map[ntype] = 0
-            for r in range:
+            for r in nrange:
                 node_map[ntype] += r[1] - r[0]
 
     # multiple node types
     for ntype, num_nodes in node_map.items():
+        if ntype not in ntypes:
+            continue
         ntype_files = os.listdir(os.path.join(args.emb_path, ntype))
 
-        # Only work with torch 1.13+
-        feats = [th.load(os.path.join(os.path.join(args.emb_path, ntype), nfile),
-                         weights_only=True) for nfile in ntype_files]
-        feats = th.cat(feats, dim=0)
-        assert feats.shape[0] == num_nodes
-        assert feats.shape[1] == args.emb_size
+        if args.file_format == "parquet":
+            import pyarrow.parquet as pq
+            feats = pq.read_table(
+                [
+                    os.path.join(
+                        os.path.join(args.emb_path, ntype), nfile)
+                    for nfile in ntype_files if nfile.startswith("embed")
+                ]
+            )
+            feats = th.tensor(np.array(feats["emb"].to_pylist())).squeeze()
+        else:
+            # Only work with torch 1.13+
+            feats = [th.load(os.path.join(os.path.join(args.emb_path, ntype), nfile),
+                            weights_only=True) for nfile in ntype_files]
+            feats = th.cat(feats, dim=0)
+
+        # If the caller asks for a specific row count check that,
+        # otherwise assume all nodes should have embeddings
+        if args.expected_row_count is not None:
+            assert feats.shape[0] == args.expected_row_count, \
+                f"Expected {args.expected_row_count} rows, got {feats.shape[0]} rows"
+        else:
+            assert feats.shape[0] == num_nodes, \
+                f"Expected {num_nodes} rows, got {feats.shape[0]} rows"
+
+        # Ensure embeddings have correct number of dims
+        assert feats.shape[1] == args.emb_size, \
+            f"Expected {args.emb_size} columns, got {feats.shape[1]} columns"
+
+        logging.info("Checks for '%s' embeddings passed", ntype)

--- a/tests/end2end-tests/graphstorm-nc/check_emb.py
+++ b/tests/end2end-tests/graphstorm-nc/check_emb.py
@@ -19,6 +19,7 @@ import logging
 import os
 
 import numpy as np
+import pyarrow.parquet as pq
 import torch as th
 
 if __name__ == '__main__':
@@ -57,7 +58,6 @@ if __name__ == '__main__':
         ntype_files = os.listdir(os.path.join(args.emb_path, ntype))
 
         if args.file_format == "parquet":
-            import pyarrow.parquet as pq
             feats = pq.read_table(
                 [
                     os.path.join(

--- a/tests/end2end-tests/graphstorm-nc/test.sh
+++ b/tests/end2end-tests/graphstorm-nc/test.sh
@@ -2,11 +2,10 @@
 
 service ssh restart
 
-DGL_HOME=/root/dgl
 GS_HOME=$(pwd)
 NUM_TRAINERS=1
 export PYTHONPATH=$GS_HOME/python/
-cd $GS_HOME/training_scripts/gsgnn_np
+cd $GS_HOME/training_scripts/gsgnn_np || exit
 
 echo "127.0.0.1" > ip_list.txt
 
@@ -97,7 +96,59 @@ python3 -m graphstorm.run.gs_node_classification --workspace $GS_HOME/training_s
 
 error_and_exit $?
 
-python3 -m graphstorm.run.gs_node_classification --inference --workspace $GS_HOME/training_scripts/gsgnn_np --num-trainers $NUM_TRAINERS --num-servers 1 --num-samplers 0 --part-config /data/movielen_100k_train_val_1p_4t/movie-lens-100k.json --ip-config ip_list.txt --ssh-port 2222 --cf ml_nc.yaml --restore-model-path ./models/movielen_100k/train_val/movielen_100k_ngnn_model/epoch-1/
+echo "**************dataset: MovieLens, Check test-set-only inference"
+# Create a temp dir for embedding output
+EMBED_CHECK_DIR=$(mktemp -d)
+# Set up tmpdir cleanup trap
+trap 'rm -rf "$EMBED_CHECK_DIR"; echo "Cleaned up temp directories"' EXIT
+
+# Only infer test set
+python3 -m graphstorm.run.gs_node_classification \
+    --inference \
+    --workspace $GS_HOME/training_scripts/gsgnn_np \
+    --num-trainers $NUM_TRAINERS --num-servers 1 --num-samplers 0 \
+    --part-config /data/movielen_100k_train_val_1p_4t/movie-lens-100k.json \
+    --ip-config ip_list.txt --ssh-port 2222 --cf ml_nc.yaml \
+    --restore-model-path ./models/movielen_100k/train_val/movielen_100k_ngnn_model/epoch-1/ \
+    --save-embed-path "$EMBED_CHECK_DIR/only-test-embeddings/"
+
+error_and_exit $?
+
+# Ensure ohly test nodes have embeddings
+# test set is 10% of 1682 nodes, so we expect 168 nodes
+python3 $GS_HOME/tests/end2end-tests/graphstorm-nc/check_emb.py \
+    --emb-path "$EMBED_CHECK_DIR/only-test-embeddings/" \
+    --graph-config /data/movielen_100k_train_val_1p_4t/movie-lens-100k.json \
+    --ntypes "movie" \
+    --expected-row-count 168 \
+    --emb-size 128 \
+    --file-format "parquet"
+
+error_and_exit $?
+
+echo "**************dataset: MovieLens, Check all-nodes inference"
+# Infer all nodes
+python3 -m graphstorm.run.gs_node_classification \
+    --inference \
+    --infer-all-target-nodes true \
+    --no-validation true \
+    --workspace $GS_HOME/training_scripts/gsgnn_np \
+    --num-trainers $NUM_TRAINERS --num-servers 1 --num-samplers 0 \
+    --part-config /data/movielen_100k_train_val_1p_4t/movie-lens-100k.json \
+    --ip-config ip_list.txt --ssh-port 2222 \
+    --cf ml_nc.yaml \
+    --restore-model-path ./models/movielen_100k/train_val/movielen_100k_ngnn_model/epoch-1/ \
+    --save-embed-path "$EMBED_CHECK_DIR/all-node-embeddings/"
+
+error_and_exit $?
+
+# Ensure all nodes have embeddings
+python3 $GS_HOME/tests/end2end-tests/graphstorm-nc/check_emb.py \
+    --emb-path "$EMBED_CHECK_DIR/all-node-embeddings/" \
+    --graph-config /data/movielen_100k_train_val_1p_4t/movie-lens-100k.json \
+    --ntypes "movie" \
+    --emb-size 128 \
+    --file-format "parquet"
 
 error_and_exit $?
 

--- a/tests/end2end-tests/graphstorm-nc/test.sh
+++ b/tests/end2end-tests/graphstorm-nc/test.sh
@@ -5,7 +5,7 @@ service ssh restart
 GS_HOME=$(pwd)
 NUM_TRAINERS=1
 export PYTHONPATH=$GS_HOME/python/
-cd $GS_HOME/training_scripts/gsgnn_np || exit
+cd $GS_HOME/training_scripts/gsgnn_np || exit 1
 
 echo "127.0.0.1" > ip_list.txt
 

--- a/tests/end2end-tests/graphstorm-nc/test.sh
+++ b/tests/end2end-tests/graphstorm-nc/test.sh
@@ -114,7 +114,7 @@ python3 -m graphstorm.run.gs_node_classification \
 
 error_and_exit $?
 
-# Ensure ohly test nodes have embeddings
+# Ensure only test nodes have embeddings
 # test set is 10% of 1682 nodes, so we expect 168 nodes
 python3 $GS_HOME/tests/end2end-tests/graphstorm-nc/check_emb.py \
     --emb-path "$EMBED_CHECK_DIR/only-test-embeddings/" \

--- a/tests/unit-tests/test_np_infer_gnn.py
+++ b/tests/unit-tests/test_np_infer_gnn.py
@@ -1,0 +1,167 @@
+"""
+    Copyright 2023 Contributors
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+"""
+
+import os
+import json
+import tempfile
+import yaml
+from argparse import Namespace
+from unittest.mock import patch, MagicMock, call
+
+import dgl
+import torch as th
+
+from graphstorm.run.gsgnn_np.np_infer_gnn import main
+
+def create_nc_config(tmp_path, file_name, infer_all=False, no_validation=False):
+    """Create a node classification config file for testing."""
+    # Create a dummy part.json file
+    part_config_path = os.path.join(tmp_path, "part.json")
+    with open(part_config_path, "w") as f:
+        json.dump({"graph_name": "test"}, f)
+
+    # Create a dummy ip.txt file
+    ip_config_path = os.path.join(tmp_path, "ip.txt")
+    with open(ip_config_path, "w") as f:
+        f.write("127.0.0.1\n")
+
+    conf_object = {
+        "version": 1.0,
+        "gsf": {
+            "basic": {
+                "node_feat_name": ["feat"],
+                "model_encoder_type": "rgat",
+                "no_validation": no_validation,
+                "part_config": part_config_path,
+                "ip_config": ip_config_path,
+                "backend": "gloo",
+                "task_type": "node_classification",
+            },
+            "gnn": {
+                "num_layers": 1,
+                "hidden_size": 4,
+                "lr": 0.001,
+                "norm": "layer"
+            },
+            "input": {
+                "restore_model_path": os.path.join(tmp_path, "model")
+            },
+            "output": {},
+            "node_classification": {
+                "num_classes": 2,
+                "target_ntype": "n0",
+                "label_field": "label",
+            },
+        }
+    }
+
+    # Only add infer_all_targets if it's True
+    if infer_all:
+        conf_object["gsf"]["basic"]["infer_all_targets"] = True
+
+    with open(os.path.join(tmp_path, file_name), "w") as f:
+        yaml.dump(conf_object, f)
+
+    # Create dummy model directory
+    os.makedirs(os.path.join(tmp_path, "model"), exist_ok=True)
+
+    return part_config_path, ip_config_path
+
+def test_np_infer_gnn_infer_all_targets():
+    """Test the infer_all_targets option in np_infer_gnn.py."""
+    # Initialize the torch distributed environment
+    th.distributed.init_process_group(backend='gloo',
+                                      init_method='tcp://127.0.0.1:23456',
+                                      rank=0,
+                                      world_size=1)
+
+    with tempfile.TemporaryDirectory() as tmpdirname:
+        # Create config files with different settings
+        create_nc_config(tmpdirname, 'gnn_nc_default.yaml')
+        create_nc_config(tmpdirname, 'gnn_nc_infer_all.yaml', infer_all=True)
+        create_nc_config(tmpdirname, 'gnn_nc_no_validation.yaml', no_validation=True)
+
+        # Mock the necessary functions and classes
+        with patch('graphstorm.run.gsgnn_np.np_infer_gnn.GSgnnData') as mock_data, \
+             patch('graphstorm.run.gsgnn_np.np_infer_gnn.gs') as mock_gs, \
+             patch('graphstorm.run.gsgnn_np.np_infer_gnn.GSgnnNodeDataLoader') as _, \
+             patch('graphstorm.run.gsgnn_np.np_infer_gnn.GSgnnNodePredictionInferrer') as mock_inferrer, \
+             patch('graphstorm.run.gsgnn_np.np_infer_gnn.get_evaluator') as mock_get_evaluator, \
+             patch('graphstorm.run.gsgnn_np.np_infer_gnn.get_device') as mock_get_device, \
+             patch('graphstorm.run.gsgnn_np.np_infer_gnn.get_lm_ntypes') as mock_get_lm_ntypes, \
+             patch('graphstorm.run.gsgnn_np.np_infer_gnn.use_wholegraph') as mock_use_wholegraph:
+
+            # Setup mocks
+            mock_model = MagicMock()
+            mock_gs.create_builtin_node_gnn_model.return_value = mock_model
+            mock_gs.create_builtin_task_tracker.return_value = MagicMock()
+            mock_get_device.return_value = 'cpu'
+            mock_get_lm_ntypes.return_value = None
+            mock_use_wholegraph.return_value = False
+
+            mock_data_instance = MagicMock()
+            mock_data.return_value = mock_data_instance
+            mock_data_instance.g = MagicMock()
+
+            # Make get_node_infer_set return a non-empty dictionary
+            mock_data_instance.get_node_infer_set.return_value = {'n0': th.tensor([0, 1, 2])}
+
+            mock_inferrer_instance = MagicMock()
+            mock_inferrer.return_value = mock_inferrer_instance
+
+            mock_evaluator = MagicMock()
+            mock_get_evaluator.return_value = mock_evaluator
+
+            # Run all three tests
+            # Test Case 1: Default behavior (infer_all_targets=False)
+            args = Namespace(yaml_config_file=os.path.join(tmpdirname, 'gnn_nc_default.yaml'),
+                            local_rank=0)
+            main(args)
+
+            # Test Case 2: infer_all_targets=True
+            args = Namespace(yaml_config_file=os.path.join(tmpdirname, 'gnn_nc_infer_all.yaml'),
+                            local_rank=0)
+            main(args)
+
+            # Test Case 3: no_validation=True
+            args = Namespace(yaml_config_file=os.path.join(tmpdirname, 'gnn_nc_no_validation.yaml'),
+                            local_rank=0)
+            main(args)
+
+            # Now check all the calls to get_node_infer_set
+            calls = mock_data_instance.get_node_infer_set.call_args_list
+
+            # There should be 3 calls
+            assert len(calls) == 3, f"Expected 3 calls to get_node_infer_set, got {len(calls)}"
+
+            # First call should be with test_mask
+            assert calls[0] == call('n0', mask='test_mask'), \
+                f"First call should be with test_mask, got {calls[0]}"
+
+            # Second call should be with empty string mask
+            assert calls[1] == call('n0', mask=''), \
+                f"Second call should be with empty string mask, got {calls[1]}"
+
+            # Third call should be without mask parameter
+            assert calls[2] == call('n0'), \
+                f"Third call should be without mask parameter, got {calls[2]}"
+
+    # Clean up
+    th.distributed.destroy_process_group()
+    dgl.distributed.kvstore.close_kvstore()
+
+if __name__ == '__main__':
+    test_np_infer_gnn_infer_all_targets()

--- a/tests/unit-tests/test_np_infer_gnn.py
+++ b/tests/unit-tests/test_np_infer_gnn.py
@@ -1,17 +1,17 @@
 """
-    Copyright 2023 Contributors
+Copyright Contributors
 
-    Licensed under the Apache License, Version 2.0 (the "License");
-    you may not use this file except in compliance with the License.
-    You may obtain a copy of the License at
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
 
-       http://www.apache.org/licenses/LICENSE-2.0
+   http://www.apache.org/licenses/LICENSE-2.0
 
-    Unless required by applicable law or agreed to in writing, software
-    distributed under the License is distributed on an "AS IS" BASIS,
-    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-    See the License for the specific language governing permissions and
-    limitations under the License.
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
 """
 
 import os
@@ -20,11 +20,14 @@ import tempfile
 import yaml
 from argparse import Namespace
 from unittest.mock import patch, MagicMock, call
+from pprint import pp
 
 import dgl
+import pytest
 import torch as th
 
 from graphstorm.run.gsgnn_np.np_infer_gnn import main
+
 
 def create_nc_config(tmp_path, file_name, infer_all=False, no_validation=False):
     """Create a node classification config file for testing."""
@@ -50,27 +53,20 @@ def create_nc_config(tmp_path, file_name, infer_all=False, no_validation=False):
                 "backend": "gloo",
                 "task_type": "node_classification",
             },
-            "gnn": {
-                "num_layers": 1,
-                "hidden_size": 4,
-                "lr": 0.001,
-                "norm": "layer"
-            },
-            "input": {
-                "restore_model_path": os.path.join(tmp_path, "model")
-            },
+            "gnn": {"num_layers": 1, "hidden_size": 4, "lr": 0.001, "norm": "layer"},
+            "input": {"restore_model_path": os.path.join(tmp_path, "model")},
             "output": {},
             "node_classification": {
                 "num_classes": 2,
                 "target_ntype": "n0",
                 "label_field": "label",
             },
-        }
+        },
     }
 
-    # Only add infer_all_targets if it's True
+    # Only add infer_all_target_nodes if it's True
     if infer_all:
-        conf_object["gsf"]["basic"]["infer_all_targets"] = True
+        conf_object["gsf"]["basic"]["infer_all_target_nodes"] = True
 
     with open(os.path.join(tmp_path, file_name), "w") as f:
         yaml.dump(conf_object, f)
@@ -80,35 +76,56 @@ def create_nc_config(tmp_path, file_name, infer_all=False, no_validation=False):
 
     return part_config_path, ip_config_path
 
+
 def test_np_infer_gnn_infer_all_targets():
     """Test the infer_all_targets option in np_infer_gnn.py."""
     # Initialize the torch distributed environment
-    th.distributed.init_process_group(backend='gloo',
-                                      init_method='tcp://127.0.0.1:23456',
-                                      rank=0,
-                                      world_size=1)
+    th.distributed.init_process_group(
+        backend="gloo", init_method="tcp://127.0.0.1:23456", rank=0, world_size=1
+    )
 
     with tempfile.TemporaryDirectory() as tmpdirname:
         # Create config files with different settings
-        create_nc_config(tmpdirname, 'gnn_nc_default.yaml')
-        create_nc_config(tmpdirname, 'gnn_nc_infer_all.yaml', infer_all=True)
-        create_nc_config(tmpdirname, 'gnn_nc_no_validation.yaml', no_validation=True)
+        create_nc_config(
+            tmpdirname, "gnn_nc_default.yaml", no_validation=False, infer_all=False
+        )
+        create_nc_config(
+            tmpdirname,
+            "gnn_nc_infer_all_without_evaluation.yaml",
+            no_validation=True,
+            infer_all=True,
+        )
+        create_nc_config(
+            tmpdirname,
+            "gnn_nc_infer_all_with_evalation.yaml",
+            no_validation=False,
+            infer_all=True,
+        )
 
         # Mock the necessary functions and classes
-        with patch('graphstorm.run.gsgnn_np.np_infer_gnn.GSgnnData') as mock_data, \
-             patch('graphstorm.run.gsgnn_np.np_infer_gnn.gs') as mock_gs, \
-             patch('graphstorm.run.gsgnn_np.np_infer_gnn.GSgnnNodeDataLoader') as _, \
-             patch('graphstorm.run.gsgnn_np.np_infer_gnn.GSgnnNodePredictionInferrer') as mock_inferrer, \
-             patch('graphstorm.run.gsgnn_np.np_infer_gnn.get_evaluator') as mock_get_evaluator, \
-             patch('graphstorm.run.gsgnn_np.np_infer_gnn.get_device') as mock_get_device, \
-             patch('graphstorm.run.gsgnn_np.np_infer_gnn.get_lm_ntypes') as mock_get_lm_ntypes, \
-             patch('graphstorm.run.gsgnn_np.np_infer_gnn.use_wholegraph') as mock_use_wholegraph:
-
+        with (
+            patch("graphstorm.run.gsgnn_np.np_infer_gnn.GSgnnData") as mock_data,
+            patch("graphstorm.run.gsgnn_np.np_infer_gnn.gs") as mock_gs,
+            patch("graphstorm.run.gsgnn_np.np_infer_gnn.GSgnnNodeDataLoader") as _,
+            patch(
+                "graphstorm.run.gsgnn_np.np_infer_gnn.GSgnnNodePredictionInferrer"
+            ) as mock_inferrer,
+            patch(
+                "graphstorm.run.gsgnn_np.np_infer_gnn.get_evaluator"
+            ) as mock_get_evaluator,
+            patch("graphstorm.run.gsgnn_np.np_infer_gnn.get_device") as mock_get_device,
+            patch(
+                "graphstorm.run.gsgnn_np.np_infer_gnn.get_lm_ntypes"
+            ) as mock_get_lm_ntypes,
+            patch(
+                "graphstorm.run.gsgnn_np.np_infer_gnn.use_wholegraph"
+            ) as mock_use_wholegraph,
+        ):
             # Setup mocks
             mock_model = MagicMock()
             mock_gs.create_builtin_node_gnn_model.return_value = mock_model
             mock_gs.create_builtin_task_tracker.return_value = MagicMock()
-            mock_get_device.return_value = 'cpu'
+            mock_get_device.return_value = "cpu"
             mock_get_lm_ntypes.return_value = None
             mock_use_wholegraph.return_value = False
 
@@ -117,7 +134,9 @@ def test_np_infer_gnn_infer_all_targets():
             mock_data_instance.g = MagicMock()
 
             # Make get_node_infer_set return a non-empty dictionary
-            mock_data_instance.get_node_infer_set.return_value = {'n0': th.tensor([0, 1, 2])}
+            mock_data_instance.get_node_infer_set.return_value = {
+                "n0": th.tensor([0, 1, 2])
+            }
 
             mock_inferrer_instance = MagicMock()
             mock_inferrer.return_value = mock_inferrer_instance
@@ -126,42 +145,57 @@ def test_np_infer_gnn_infer_all_targets():
             mock_get_evaluator.return_value = mock_evaluator
 
             # Run all three tests
-            # Test Case 1: Default behavior (infer_all_targets=False)
-            args = Namespace(yaml_config_file=os.path.join(tmpdirname, 'gnn_nc_default.yaml'),
-                            local_rank=0)
+            # Test Case 1: Default behavior (infer_all_targets=False, no_validation=False)
+            args = Namespace(
+                yaml_config_file=os.path.join(tmpdirname, "gnn_nc_default.yaml"),
+                local_rank=0,
+            )
             main(args)
 
-            # Test Case 2: infer_all_targets=True
-            args = Namespace(yaml_config_file=os.path.join(tmpdirname, 'gnn_nc_infer_all.yaml'),
-                            local_rank=0)
+            # Test Case 2: no_validation=True, infer_all_target_nodes=True
+            args = Namespace(
+                yaml_config_file=os.path.join(
+                    tmpdirname, "gnn_nc_infer_all_without_evaluation.yaml"
+                ),
+                local_rank=0,
+            )
             main(args)
 
-            # Test Case 3: no_validation=True
-            args = Namespace(yaml_config_file=os.path.join(tmpdirname, 'gnn_nc_no_validation.yaml'),
-                            local_rank=0)
-            main(args)
+            # Test Case 3: failure case, infer_all_target_nodes=True, no_validation=False
+            args = Namespace(
+                yaml_config_file=os.path.join(
+                    tmpdirname, "gnn_nc_infer_all_with_evalation.yaml"
+                ),
+                local_rank=0,
+            )
+            with pytest.raises(
+                RuntimeError,
+                match="Cannot run evaluation during all-nodes inference .*",
+            ):
+                main(args)
 
             # Now check all the calls to get_node_infer_set
             calls = mock_data_instance.get_node_infer_set.call_args_list
 
-            # There should be 3 calls
-            assert len(calls) == 3, f"Expected 3 calls to get_node_infer_set, got {len(calls)}"
+            # There should be 2 calls, the third test raised before calling get_node_infer_set
+            assert len(calls) == 2, (
+                f"Expected 2 calls to get_node_infer_set, got {len(calls)}"
+            )
 
-            # First call should be with test_mask
-            assert calls[0] == call('n0', mask='test_mask'), \
+            # First call should be with test_mask, because no_validation was False
+            assert calls[0] == call("n0", mask="test_mask"), (
                 f"First call should be with test_mask, got {calls[0]}"
+            )
 
-            # Second call should be with empty string mask
-            assert calls[1] == call('n0', mask=''), \
-                f"Second call should be with empty string mask, got {calls[1]}"
-
-            # Third call should be without mask parameter
-            assert calls[2] == call('n0'), \
-                f"Third call should be without mask parameter, got {calls[2]}"
+            # Second call should be with empty string mask parameter, because infer_all_target_nodes was True
+            assert calls[1] == call("n0", mask=""), (
+                f"Second call should be without mask parameter, got {calls[1]}"
+            )
 
     # Clean up
     th.distributed.destroy_process_group()
     dgl.distributed.kvstore.close_kvstore()
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     test_np_infer_gnn_infer_all_targets()


### PR DESCRIPTION
*Issue #, if available:*

Fixes #1240 

*Description of changes:*

* Add a top-level string input argument to the parser, `--infer-all-target-nodes`.
* When the user provides `--infer-all-target-nodes true` the set of nodes to run inference on returned from `get_node_infer_set` will be all the nodes for the target type.
* For now this is implemented only for `run/np_infer_gnn.py`.
* Used GenAI to create a unit test that mocks the main function because np_infer_gnn.py can only be executed as a script, there's no individual function we could test without refactoring. 
* Added e2e test scripts that check size of embeddings for test-only, and all-node embedding generation.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
