### PR TITLE
[GSProcessing] Handle `*` wildcards in filenames

### DIFF
--- a/docs/source/cli/graph-construction/distributed/gsprocessing/input-configuration.rst
+++ b/docs/source/cli/graph-construction/distributed/gsprocessing/input-configuration.rst
@@ -104,6 +104,10 @@ objects:
          -  e.g. ``"files": ['path/to/edge/type/']``
          -  This option allows for concise listing of entire types and
             would be preferred. All the files under the path will be loaded.
+         -  You can also provide a wildcard pattern, e.g.
+            ``"files": ['path/to/edge-type*.parquet']`` would match
+            all files that start with ``edge-type`` and end with
+            ``.parquet`` under ``<input_prefix>/path/to``.
 
       -  a multi-element list of **relative** file paths.
 

--- a/graphstorm-processing/graphstorm_processing/config/config_conversion/gconstruct_converter.py
+++ b/graphstorm-processing/graphstorm_processing/config/config_conversion/gconstruct_converter.py
@@ -274,9 +274,10 @@ class GConstructConfigConverter(ConfigConverter):
             # files
             node_files = n["files"] if isinstance(n["files"], list) else [n["files"]]
             for file_name in node_files:
-                if "*" in file_name or "?" in file_name:
+                if "?" in file_name:
                     raise ValueError(
-                        f"We do not currently support wildcards in node file names got: {file_name}"
+                        "We do not currently support '?' wildcards "
+                        f"in node file names got: {file_name}"
                     )
 
             # features

--- a/graphstorm-processing/graphstorm_processing/config/config_conversion/gconstruct_converter.py
+++ b/graphstorm-processing/graphstorm_processing/config/config_conversion/gconstruct_converter.py
@@ -277,7 +277,7 @@ class GConstructConfigConverter(ConfigConverter):
                 if "?" in file_name:
                     raise ValueError(
                         "We do not currently support '?' wildcards "
-                        f"in node file names got: {file_name}"
+                        f"in node file names, got: {file_name}"
                     )
 
             # features
@@ -311,8 +311,12 @@ class GConstructConfigConverter(ConfigConverter):
             # files
             edge_files = e["files"] if isinstance(e["files"], list) else [e["files"]]
             for file_name in edge_files:
-                if "*" in file_name or "?" in file_name:
-                    raise ValueError("Not Support for wildcard in edge file name")
+                for file_name in edge_files:
+                    if "?" in file_name:
+                        raise ValueError(
+                            "We do not currently support '?' wildcards "
+                            f"in edge file names, got: {file_name}"
+                        )
 
             # format
             edge_format = e["format"]["name"]

--- a/graphstorm-processing/graphstorm_processing/graph_loaders/dist_heterogeneous_loader.py
+++ b/graphstorm-processing/graphstorm_processing/graph_loaders/dist_heterogeneous_loader.py
@@ -1031,7 +1031,17 @@ class DistHeterogeneousGraphLoader(object):
         """
         expanded_files = []
 
-        def handle_wildcard(file_path, expanded_files):
+        def handle_wildcard(file_path: str, expanded_files: list[str]):
+            """Handles ``*`` wildcard in file path, matching files for local and S3 paths.
+            Appends new files to input list.
+
+            Parameters
+            ----------
+            file_path : str
+                File path that includes a ``*`` wildcard.
+            expanded_files : list[str]
+                List of file paths. Expanded files paths will appended to this list.
+            """
             # Handle wildcard pattern
             if self.filesystem_type == FilesystemType.S3:
                 # Extract the parent directory path and filename pattern
@@ -1100,10 +1110,9 @@ class DistHeterogeneousGraphLoader(object):
                 # No wildcard, use the file path as is
                 expanded_files.append(file_path)
 
-        # If no files were found after expansion, log a warning and fall back to original list
+        # If no files were found after expansion, error out
         if not expanded_files and any("*" in f for f in files):
-            logging.warning("No files found after expanding wildcards for %s", files)
-            expanded_files = files
+            raise ValueError(f"No files found after expanding wildcard for input {files=}")
 
         return [os.path.join(self.input_prefix, f) for f in expanded_files]
 

--- a/graphstorm-processing/tests/resources/small_heterogeneous_graph/gconstruct-config.json
+++ b/graphstorm-processing/tests/resources/small_heterogeneous_graph/gconstruct-config.json
@@ -21,7 +21,7 @@
         "relation": ["user", "rated", "movie"]
       },
       {
-        "files": "edges/director-directed-movie.csv",
+        "files": "edges/director-directed-*.csv",
         "format": {
             "name": "csv",
             "separator" : ","
@@ -42,7 +42,7 @@
         "node_id_col":  "~id",
         "node_type":    "movies",
         "format":       {"name": "csv", "separator": ","},
-        "files":        ["nodes/movie.csv"]
+        "files":        ["nodes/movie*"]
       },
       {
         "node_id_col":  "~id",

--- a/graphstorm-processing/tests/test_converter.py
+++ b/graphstorm-processing/tests/test_converter.py
@@ -41,11 +41,11 @@ def create_node_dict() -> dict:
     return text_input
 
 
-@pytest.mark.parametrize("wildcard", ["*", "?"])
+@pytest.mark.parametrize("wildcard", ["?"])
 def test_try_read_file_with_wildcard(
     converter: GConstructConfigConverter, node_dict: dict, wildcard
 ):
-    """We don't currently support wildcards in filenames, so should error out."""
+    """We don't currently support ? wildcards in filenames, so should error out."""
     node_dict["nodes"][0]["files"] = f"/tmp/acm_raw/nodes/author{wildcard}.parquet"
 
     with pytest.raises(ValueError):


### PR DESCRIPTION
*Issue #, if available:*

Fixes https://github.com/awslabs/graphstorm/issues/1107

*Description of changes:*

* Add handling for `*` in file paths, for local and S3 input in GSProcessing
* For local we glob files, for S3 we first list all files under prefix, then match file pattern


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
