### PR TITLE
[Bugfix] Fix the case when the subtask name is too long in multi-task learning

### DIFF
--- a/python/graphstorm/config/config.py
+++ b/python/graphstorm/config/config.py
@@ -136,7 +136,15 @@ def get_mttask_id(task_type, ntype=None, etype=None, label=None):
         elif isinstance(etype, tuple):
             task_id.append("_".join(etype))
         elif isinstance(etype, list): # a list of etypes
-            task_id.append("__".join(["_".join(et) for et in etype]))
+            etype_info = "__".join(["_".join(et) for et in etype])
+            # In case the task id is too long, trim it
+            # Set the max etype information into 64
+            # Add a hash information to avoid task id naming conflict
+            if len(etype_info) > 64:
+                id_hash = str(hash(etype_info))
+                etype_info = etype_info[:64] + id_hash[:8]
+
+            task_id.append(etype_info)
         else:
             raise TypeError(f"Unknown etype format: {etype}. Must be a string " \
                             "or a tuple of strings or a list of tuples of strings.")

--- a/python/graphstorm/config/config.py
+++ b/python/graphstorm/config/config.py
@@ -17,6 +17,7 @@
 """
 import dataclasses
 import typing
+import hashlib
 from typing import List
 
 BUILTIN_GNN_ENCODER = ["gat", "rgat", "rgcn", "sage", "hgt", "gatv2"]
@@ -141,7 +142,9 @@ def get_mttask_id(task_type, ntype=None, etype=None, label=None):
             # Set the max etype information into 64
             # Add a hash information to avoid task id naming conflict
             if len(etype_info) > 64:
-                id_hash = str(hash(etype_info))
+                hasher = hashlib.sha256()
+                hasher.update(etype_info.encode('utf-8'))
+                id_hash = hasher.hexdigest()
                 etype_info = etype_info[:64] + id_hash[:8]
 
             task_id.append(etype_info)

--- a/tests/unit-tests/test_config.py
+++ b/tests/unit-tests/test_config.py
@@ -54,6 +54,50 @@ from graphstorm.config import (BUILTIN_LP_DOT_DECODER,
                                BUILTIN_LP_TRANSE_L1_DECODER,
                                BUILTIN_LP_TRANSE_L2_DECODER)
 from graphstorm.config.config import LINK_PREDICTION_MAJOR_EVAL_ETYPE_ALL
+from graphstorm.config.config import get_mttask_id
+
+def test_get_mttask_id():
+    # node classification task
+    task_type = "node_classification"
+    ntype = "type0"
+    etype = None
+    label = "label"
+
+    task_id = get_mttask_id(task_type, ntype=ntype, etype=etype, label=label)
+    assert task_id == "-".join([task_type, ntype, label])
+
+    # edge classification task
+    task_type = "edge_classification"
+    ntype = None
+    etype = ("type0", "r0", "type1")
+    label = "label"
+    task_id = get_mttask_id(task_type, ntype=ntype, etype=etype, label=label)
+    assert task_id == "-".join([task_type, "_".join(etype), label])
+
+    # link prediction task
+    task_type = "link_prediction"
+    ntype = None
+    etype = [("type0", "r0", "type1")]
+    label = None
+    task_id = get_mttask_id(task_type, ntype=ntype, etype=etype, label=label)
+    etype_info = "__".join(["_".join(et) for et in etype])
+    assert task_id == "-".join([task_type, etype_info])
+
+    task_type = "link_prediction"
+    ntype = None
+    etype = [("type0", "r0", "type1"), ("type0", "r0", "type2")]
+    task_id = get_mttask_id(task_type, ntype=ntype, etype=etype, label=label)
+    etype_info = "__".join(["_".join(et) for et in etype])
+    assert task_id == "-".join([task_type, etype_info])
+
+    # the etypes are too long
+    task_type = "link_prediction"
+    ntype = None
+    etype = [("type0", "r0", "type1"), ("type0", "1"*64, "type2")]
+    task_id = get_mttask_id(task_type, ntype=ntype, etype=etype, label=label)
+    etype_info = "__".join(["_".join(et) for et in etype])
+    etype_info = etype_info[:64] + str(hash(etype_info))[:8]
+    assert task_id == "-".join([task_type, etype_info])
 
 def check_failure(config, field):
     has_error = False

--- a/tests/unit-tests/test_config.py
+++ b/tests/unit-tests/test_config.py
@@ -21,6 +21,7 @@ import yaml
 import math
 import tempfile
 import pytest
+import hashlib
 from argparse import Namespace
 from dgl.distributed.constants import DEFAULT_NTYPE, DEFAULT_ETYPE
 
@@ -94,9 +95,11 @@ def test_get_mttask_id():
     task_type = "link_prediction"
     ntype = None
     etype = [("type0", "r0", "type1"), ("type0", "1"*64, "type2")]
-    task_id = get_mttask_id(task_type, ntype=ntype, etype=etype, label=label)
+    hasher = hashlib.sha256()
     etype_info = "__".join(["_".join(et) for et in etype])
-    etype_info = etype_info[:64] + str(hash(etype_info))[:8]
+    hasher.update(etype_info.encode('utf-8'))
+    task_id = get_mttask_id(task_type, ntype=ntype, etype=etype, label=label)
+    etype_info = etype_info[:64] + hasher.hexdigest()[:8]
     assert task_id == "-".join([task_type, etype_info])
 
 def check_failure(config, field):


### PR DESCRIPTION
The task id of link prediction subtask in multi-task learning setting may be too long when there are multiple edge types.

This led to errors when trying to save the embedding files, as the file names exceeded the maximum file name limit for file systems like ext4/XFS
See `Max filename length` in https://en.wikipedia.org/wiki/Ext4

Solution: trim the edge type information to keep the task id short.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
