### PR TITLE
Save combined training config file with saved model artifacts

### DIFF
--- a/python/graphstorm/config/argument.py
+++ b/python/graphstorm/config/argument.py
@@ -334,8 +334,12 @@ class GSConfig:
                             section[key] = attr_value
                             break
                     else:
-                        # If not found in any section, add to the first section
-                        next(iter(yaml_config['gsf'].values()))[key] = attr_value
+                        # If not found in any section, add to its own `runtime` section
+                        if 'runtime' not in yaml_config['gsf']:
+                            yaml_config['gsf']['runtime'] = {}
+                        yaml_config['gsf']['runtime'].update({key: attr_value})
+                else:
+                    raise ValueError("GraphStorm configuration needs a 'gsf' section")
 
         # Try to save to model output location
         try:

--- a/python/graphstorm/config/argument.py
+++ b/python/graphstorm/config/argument.py
@@ -334,7 +334,7 @@ class GSConfig:
                             section[key] = attr_value
                             break
                     else:
-                        # If not found in any section, add to its own `runtime` section
+                        # If not found in any section, add to the `runtime` section
                         if 'runtime' not in yaml_config['gsf']:
                             yaml_config['gsf']['runtime'] = {}
                         yaml_config['gsf']['runtime'].update({key: attr_value})

--- a/python/graphstorm/config/config.py
+++ b/python/graphstorm/config/config.py
@@ -102,6 +102,9 @@ SUPPORTED_LP_DECODER = [BUILTIN_LP_DOT_DECODER,
                         BUILTIN_LP_TRANSE_L1_DECODER,
                         BUILTIN_LP_TRANSE_L2_DECODER]
 
+# Filename constants
+COMBINED_CONFIG_FILENAME = "GRAPHSTORM_COMBINED_TRAINING_CONFIG.yaml"
+
 ################ Task info data classes ############################
 def get_mttask_id(task_type, ntype=None, etype=None, label=None):
     """ Generate task ID for multi-task learning tasks.

--- a/python/graphstorm/config/config.py
+++ b/python/graphstorm/config/config.py
@@ -105,7 +105,7 @@ SUPPORTED_LP_DECODER = [BUILTIN_LP_DOT_DECODER,
 # Filename constants
 
 # Filename for output yaml, updated with runtime args
-COMBINED_CONFIG_FILENAME = "GRAPHSTORM_RUNTIME_UPDATE_TRAINING_CONFIG.yaml"
+COMBINED_CONFIG_FILENAME = "GRAPHSTORM_RUNTIME_UPDATED_TRAINING_CONFIG.yaml"
 
 ################ Task info data classes ############################
 def get_mttask_id(task_type, ntype=None, etype=None, label=None):

--- a/python/graphstorm/config/config.py
+++ b/python/graphstorm/config/config.py
@@ -103,7 +103,9 @@ SUPPORTED_LP_DECODER = [BUILTIN_LP_DOT_DECODER,
                         BUILTIN_LP_TRANSE_L2_DECODER]
 
 # Filename constants
-COMBINED_CONFIG_FILENAME = "GRAPHSTORM_COMBINED_TRAINING_CONFIG.yaml"
+
+# Filename for output yaml, updated with runtime args
+COMBINED_CONFIG_FILENAME = "GRAPHSTORM_RUNTIME_UPDATE_TRAINING_CONFIG.yaml"
 
 ################ Task info data classes ############################
 def get_mttask_id(task_type, ntype=None, etype=None, label=None):

--- a/tests/end2end-tests/graphstorm-nc/test.sh
+++ b/tests/end2end-tests/graphstorm-nc/test.sh
@@ -95,6 +95,12 @@ error_and_exit $?
 echo "**************dataset: MovieLens, RGCN layer: 1, node feat: fixed HF BERT, BERT nodes: movie, inference: full-graph, mlp layer between GNN layer: 1"
 python3 -m graphstorm.run.gs_node_classification --workspace $GS_HOME/training_scripts/gsgnn_np --num-trainers $NUM_TRAINERS --num-servers 1 --num-samplers 0 --part-config /data/movielen_100k_train_val_1p_4t/movie-lens-100k.json --ip-config ip_list.txt --ssh-port 2222 --cf ml_nc.yaml --use-mini-batch-infer false --num-ffn-layers-in-gnn 1 --save-model-path ./models/movielen_100k/train_val/movielen_100k_ngnn_model
 
+# Ensure a file named GRAPHSTORM_RUNTIME_UPDATED_TRAINING_CONFIG.yaml was created under --save-model-path
+if [ ! -f ./models/movielen_100k/train_val/movielen_100k_ngnn_model/GRAPHSTORM_RUNTIME_UPDATED_TRAINING_CONFIG.yaml ]; then
+    echo "GRAPHSTORM_RUNTIME_UPDATED_TRAINING_CONFIG.yaml was not created"
+    exit 1
+fi
+
 error_and_exit $?
 
 python3 -m graphstorm.run.gs_node_classification --inference --workspace $GS_HOME/training_scripts/gsgnn_np --num-trainers $NUM_TRAINERS --num-servers 1 --num-samplers 0 --part-config /data/movielen_100k_train_val_1p_4t/movie-lens-100k.json --ip-config ip_list.txt --ssh-port 2222 --cf ml_nc.yaml --restore-model-path ./models/movielen_100k/train_val/movielen_100k_ngnn_model/epoch-1/

--- a/tests/unit-tests/test_config.py
+++ b/tests/unit-tests/test_config.py
@@ -13,18 +13,18 @@
     See the License for the specific language governing permissions and
     limitations under the License.
 """
-import os, sys
-from pathlib import Path
-from tempfile import tempdir
 import json
-import yaml
 import math
+import os
+import sys
 import tempfile
+import yaml
 from argparse import Namespace
-from dgl.distributed.constants import DEFAULT_NTYPE, DEFAULT_ETYPE
+from pathlib import Path
 
 import dgl
 import torch as th
+from dgl.distributed.constants import DEFAULT_NTYPE, DEFAULT_ETYPE
 
 from graphstorm.config import GSConfig
 from graphstorm.config.config import (BUILTIN_CLASS_LOSS_CROSS_ENTROPY,
@@ -2263,19 +2263,34 @@ def test_multi_task_config():
         assert efr_config.eval_metric[0] == "rmse"
         assert efr_config.batch_size == 64
 
-if __name__ == '__main__':
-    test_multi_task_config()
-    test_id_mapping_file()
-    test_load_basic_info()
-    test_gnn_info()
-    test_load_io_info()
-    test_train_info()
-    test_rgcn_info()
-    test_rgat_info()
-    test_node_class_info()
-    test_node_regress_info()
-    test_edge_class_info()
-    test_lp_info()
 
-    test_lm()
-    test_check_node_lm_config()
+def test_save_combined_config():
+    with tempfile.TemporaryDirectory() as tmpdirname:
+        # Create a basic config file
+        create_basic_config(Path(tmpdirname), 'combined_test')
+
+        # Create args with an override
+        args = Namespace(
+            yaml_config_file=os.path.join(Path(tmpdirname), 'combined_test.yaml'),
+            local_rank=0,
+            # Set save_model_path to trigger combined config saving
+            save_model_path=os.path.join(tmpdirname, "model"),
+            lr=0.02  # Override the lr value from the yaml
+        )
+
+        # Create config
+        config = GSConfig(args)
+
+        # Call save_combined_config
+        output_path = os.path.join(tmpdirname, "combined_config.yaml")
+        config._save_combined_config(output_path)
+
+        # Verify the file exists
+        assert os.path.exists(output_path)
+
+        # Load the saved config and verify it contains the overridden value
+        with open(output_path, 'r') as f:
+            saved_config = yaml.safe_load(f)
+
+        # Check that the lr value was updated
+        assert saved_config['gsf']['hyperparam']['lr'] == 0.02

--- a/tests/unit-tests/test_config.py
+++ b/tests/unit-tests/test_config.py
@@ -2314,7 +2314,9 @@ def test_save_combined_new_argument():
         )
 
         # Create GSConfig, this will also create the updated yaml file
-        _ = GSConfig(args)
+        gs_config = GSConfig(args)
+        # Ensure the new runtime value was added to the config
+        assert gs_config.wd_l2norm == 0.0001
 
         # Updated config should exist under the save model path
         updated_yaml = os.path.join(save_model_path, COMBINED_CONFIG_FILENAME)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

* We now save the training config file modified with runtime arguments in the model output

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
