### PR TITLE
[BugFix] Fix a bug in remapping node embeddings, when shared fs is not avaliable

### DIFF
--- a/python/graphstorm/gconstruct/remap_result.py
+++ b/python/graphstorm/gconstruct/remap_result.py
@@ -807,11 +807,11 @@ def main(args, gs_config_args):
             #     task_id1/
             #     ...
             # We need to exclude both emb_info.json, relation2id_map.json
-            # and task_id directories, when we are collecting node types
-            # with node embeddings.
+            # rel_emb.pt and task_id directories, when we are collecting 
+            # node types with node embeddings.
             emb_names = [e_name for e_name in emb_names \
                 if e_name not in task_emb_dirs + \
-                    ["emb_info.json", "relation2id_map.json"]]
+                    ["emb_info.json", "relation2id_map.json", "rel_emb.pt"]]
 
             emb_ntypes = emb_names
     else:

--- a/python/graphstorm/gconstruct/remap_result.py
+++ b/python/graphstorm/gconstruct/remap_result.py
@@ -806,12 +806,14 @@ def main(args, gs_config_args):
             #     task_id0/
             #     task_id1/
             #     ...
-            # We need to exclude both emb_info.json, relation2id_map.json
-            # rel_emb.pt and task_id directories, when we are collecting
+            # We need to exclude task_id directories, when we are collecting
             # node types with node embeddings.
             emb_names = [e_name for e_name in emb_names \
                 if e_name not in task_emb_dirs + \
                     ["emb_info.json", "relation2id_map.json", "rel_emb.pt"]]
+            # embeddings are under <node-type> directories, exclude other files
+            emb_names = [e_name for e_name in emb_names \
+                if os.path.isdir(os.path.join(node_emb_dir, e_name))]
 
             emb_ntypes = emb_names
     else:

--- a/python/graphstorm/gconstruct/remap_result.py
+++ b/python/graphstorm/gconstruct/remap_result.py
@@ -807,7 +807,7 @@ def main(args, gs_config_args):
             #     task_id1/
             #     ...
             # We need to exclude both emb_info.json, relation2id_map.json
-            # rel_emb.pt and task_id directories, when we are collecting 
+            # rel_emb.pt and task_id directories, when we are collecting
             # node types with node embeddings.
             emb_names = [e_name for e_name in emb_names \
                 if e_name not in task_emb_dirs + \

--- a/python/graphstorm/gconstruct/remap_result.py
+++ b/python/graphstorm/gconstruct/remap_result.py
@@ -806,10 +806,12 @@ def main(args, gs_config_args):
             #     task_id0/
             #     task_id1/
             #     ...
-            # We need to exclude both emb_info.json and task_id directories,
-            # when we are collecting node types with node embeddings.
+            # We need to exclude both emb_info.json, relation2id_map.json
+            # and task_id directories, when we are collecting node types 
+            # with node embeddings.
             emb_names = [e_name for e_name in emb_names \
-                if e_name not in task_emb_dirs + ["emb_info.json"]]
+                if e_name not in task_emb_dirs + \
+                    ["emb_info.json", "relation2id_map.json"]]
 
             emb_ntypes = emb_names
     else:

--- a/python/graphstorm/gconstruct/remap_result.py
+++ b/python/graphstorm/gconstruct/remap_result.py
@@ -807,7 +807,7 @@ def main(args, gs_config_args):
             #     task_id1/
             #     ...
             # We need to exclude both emb_info.json, relation2id_map.json
-            # and task_id directories, when we are collecting node types 
+            # and task_id directories, when we are collecting node types
             # with node embeddings.
             emb_names = [e_name for e_name in emb_names \
                 if e_name not in task_emb_dirs + \

--- a/tests/end2end-tests/data_process/test.sh
+++ b/tests/end2end-tests/data_process/test.sh
@@ -353,6 +353,10 @@ rm -fr /tmp/np_remap/
 echo "********* Test the remap node emb/partial emb *********"
 python3 $GS_HOME/tests/end2end-tests/data_process/gen_emb_predict_remap_test.py --output /tmp/em_remap/
 
+# Add relation2id_map.json into /tmp/em_remap/partial-emb/
+# remap_result should ignore this file
+echo 'Dummy' > /tmp/em_remap/partial-emb/relation2id_map.json
+
 # Test remap emb results
 python3 -m graphstorm.gconstruct.remap_result --num-processes 16 --node-id-mapping /tmp/em_remap/id_mapping/ --logging-level debug --node-emb-dir /tmp/em_remap/partial-emb/  --preserve-input True --rank 1 --world-size 2
 error_and_exit $?
@@ -446,6 +450,11 @@ cp -r /tmp/em_remap/partial-emb/n0/*0.pt /tmp/em_remap/partial-emb/0/n0/
 cp -r /tmp/em_remap/partial-emb/n0/*1.pt /tmp/em_remap/partial-emb/1/n0/
 cp -r /tmp/em_remap/partial-emb/n1/*0.pt /tmp/em_remap/partial-emb/0/n1/
 cp -r /tmp/em_remap/partial-emb/n1/*1.pt /tmp/em_remap/partial-emb/1/n1/
+
+# Add relation2id_map.json into /tmp/em_remap/partial-emb/
+# remap_result should ignore this file
+echo 'Dummy' > /tmp/em_remap/partial-emb/0/relation2id_map.json
+echo 'Dummy' > /tmp/em_remap/partial-emb/1/relation2id_map.json
 
 # Test remap emb results
 python3 -m graphstorm.gconstruct.remap_result --num-processes 16 --node-id-mapping /tmp/em_remap/id_mapping/ --logging-level debug --node-emb-dir /tmp/em_remap/partial-emb/1/  --preserve-input True --rank 1 --world-size 2 --with-shared-fs False

--- a/tests/end2end-tests/data_process/test.sh
+++ b/tests/end2end-tests/data_process/test.sh
@@ -355,8 +355,8 @@ python3 $GS_HOME/tests/end2end-tests/data_process/gen_emb_predict_remap_test.py 
 
 # Add relation2id_map.json and rel_emb.pt into /tmp/em_remap/partial-emb/
 # remap_result should ignore this file
-echo 'Dummy' > /tmp/em_remap/partial-emb/relation2id_map.json
-echo 'Dummy' > /tmp/em_remap/partial-emb/rel_emb.pt
+touch /tmp/em_remap/partial-emb/relation2id_map.json
+touch /tmp/em_remap/partial-emb/rel_emb.pt
 
 # Test remap emb results
 python3 -m graphstorm.gconstruct.remap_result --num-processes 16 --node-id-mapping /tmp/em_remap/id_mapping/ --logging-level debug --node-emb-dir /tmp/em_remap/partial-emb/  --preserve-input True --rank 1 --world-size 2
@@ -452,12 +452,12 @@ cp -r /tmp/em_remap/partial-emb/n0/*1.pt /tmp/em_remap/partial-emb/1/n0/
 cp -r /tmp/em_remap/partial-emb/n1/*0.pt /tmp/em_remap/partial-emb/0/n1/
 cp -r /tmp/em_remap/partial-emb/n1/*1.pt /tmp/em_remap/partial-emb/1/n1/
 
-# Add relation2id_map.json and into /tmp/em_remap/partial-emb/
+# Add relation2id_map.json and rel_emb.pt into /tmp/em_remap/partial-emb/
 # remap_result should ignore this file
-echo 'Dummy' > /tmp/em_remap/partial-emb/0/rel_emb.pt
-echo 'Dummy' > /tmp/em_remap/partial-emb/1/rel_emb.pt
-echo 'Dummy' > /tmp/em_remap/partial-emb/0/rel_emb.pt
-echo 'Dummy' > /tmp/em_remap/partial-emb/1/rel_emb.pt
+for i in 0 1; do
+  touch /tmp/em_remap/partial-emb/$i/rel_emb.pt
+  touch /tmp/em_remap/partial-emb/$i/relation2id_map.json
+done
 
 # Test remap emb results
 python3 -m graphstorm.gconstruct.remap_result --num-processes 16 --node-id-mapping /tmp/em_remap/id_mapping/ --logging-level debug --node-emb-dir /tmp/em_remap/partial-emb/1/  --preserve-input True --rank 1 --world-size 2 --with-shared-fs False

--- a/tests/end2end-tests/data_process/test.sh
+++ b/tests/end2end-tests/data_process/test.sh
@@ -353,9 +353,10 @@ rm -fr /tmp/np_remap/
 echo "********* Test the remap node emb/partial emb *********"
 python3 $GS_HOME/tests/end2end-tests/data_process/gen_emb_predict_remap_test.py --output /tmp/em_remap/
 
-# Add relation2id_map.json into /tmp/em_remap/partial-emb/
+# Add relation2id_map.json and rel_emb.pt into /tmp/em_remap/partial-emb/
 # remap_result should ignore this file
 echo 'Dummy' > /tmp/em_remap/partial-emb/relation2id_map.json
+echo 'Dummy' > /tmp/em_remap/partial-emb/rel_emb.pt
 
 # Test remap emb results
 python3 -m graphstorm.gconstruct.remap_result --num-processes 16 --node-id-mapping /tmp/em_remap/id_mapping/ --logging-level debug --node-emb-dir /tmp/em_remap/partial-emb/  --preserve-input True --rank 1 --world-size 2
@@ -451,10 +452,12 @@ cp -r /tmp/em_remap/partial-emb/n0/*1.pt /tmp/em_remap/partial-emb/1/n0/
 cp -r /tmp/em_remap/partial-emb/n1/*0.pt /tmp/em_remap/partial-emb/0/n1/
 cp -r /tmp/em_remap/partial-emb/n1/*1.pt /tmp/em_remap/partial-emb/1/n1/
 
-# Add relation2id_map.json into /tmp/em_remap/partial-emb/
+# Add relation2id_map.json and into /tmp/em_remap/partial-emb/
 # remap_result should ignore this file
-echo 'Dummy' > /tmp/em_remap/partial-emb/0/relation2id_map.json
-echo 'Dummy' > /tmp/em_remap/partial-emb/1/relation2id_map.json
+echo 'Dummy' > /tmp/em_remap/partial-emb/0/rel_emb.pt
+echo 'Dummy' > /tmp/em_remap/partial-emb/1/rel_emb.pt
+echo 'Dummy' > /tmp/em_remap/partial-emb/0/rel_emb.pt
+echo 'Dummy' > /tmp/em_remap/partial-emb/1/rel_emb.pt
 
 # Test remap emb results
 python3 -m graphstorm.gconstruct.remap_result --num-processes 16 --node-id-mapping /tmp/em_remap/id_mapping/ --logging-level debug --node-emb-dir /tmp/em_remap/partial-emb/1/  --preserve-input True --rank 1 --world-size 2 --with-shared-fs False


### PR DESCRIPTION
*Issue #, if available:*
The bug was introduced in https://github.com/awslabs/graphstorm/pull/1163, where it saves relation2id_map.json into the emb output path. The remap script will mistakenly load the .json file.

*Description of changes:*
Fix the bug





By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
