### PR TITLE
[Bug Fix] Save transformed config before repartition

### DIFF
--- a/graphstorm-processing/graphstorm_processing/distributed_executor.py
+++ b/graphstorm-processing/graphstorm_processing/distributed_executor.py
@@ -322,6 +322,27 @@ class DistributedExecutor:
             streaming_repartitioning=False,
         )
 
+        # If pre-computed representations exist, merge them with the input dict and save to disk
+        with open(
+            os.path.join(
+                self.local_metadata_output_path,
+                f"{os.path.splitext(self.config_filename)[0]}_with_transformations.json",
+            ),
+            "w",
+            encoding="utf-8",
+        ) as f:
+            input_dict_with_transforms = self._merge_config_with_transformations(
+                self.gsp_config_dict, processed_representations.transformation_representations
+            )
+            json.dump(input_dict_with_transforms, f, indent=4)
+
+        # This is used to upload the output output JSON files to S3 on non-SageMaker runs,
+        # since we can't rely on SageMaker to do it
+        if self.filesystem_type == FilesystemType.S3:
+            self._upload_output_files(
+                self.loader, force=(not self.execution_env == ExecutionEnv.SAGEMAKER)
+            )
+
         repartition_start = time.perf_counter()
         updated_metadata = {}
         if all_match:
@@ -380,27 +401,6 @@ class DistributedExecutor:
                 sorted(processed_representations.timers.items(), key=lambda x: x[1], reverse=True)
             )
             json.dump(sorted_timers, f, indent=4)
-
-        # If pre-computed representations exist, merge them with the input dict and save to disk
-        with open(
-            os.path.join(
-                self.local_metadata_output_path,
-                f"{os.path.splitext(self.config_filename)[0]}_with_transformations.json",
-            ),
-            "w",
-            encoding="utf-8",
-        ) as f:
-            input_dict_with_transforms = self._merge_config_with_transformations(
-                self.gsp_config_dict, processed_representations.transformation_representations
-            )
-            json.dump(input_dict_with_transforms, f, indent=4)
-
-        # This is used to upload the output output JSON files to S3 on non-SageMaker runs,
-        # since we can't rely on SageMaker to do it
-        if self.filesystem_type == FilesystemType.S3:
-            self._upload_output_files(
-                self.loader, force=(not self.execution_env == ExecutionEnv.SAGEMAKER)
-            )
 
     def _merge_config_with_transformations(
         self,

--- a/graphstorm-processing/graphstorm_processing/distributed_executor.py
+++ b/graphstorm-processing/graphstorm_processing/distributed_executor.py
@@ -336,13 +336,6 @@ class DistributedExecutor:
             )
             json.dump(input_dict_with_transforms, f, indent=4)
 
-        # This is used to upload the output output JSON files to S3 on non-SageMaker runs,
-        # since we can't rely on SageMaker to do it
-        if self.filesystem_type == FilesystemType.S3:
-            self._upload_output_files(
-                self.loader, force=(not self.execution_env == ExecutionEnv.SAGEMAKER)
-            )
-
         repartition_start = time.perf_counter()
         updated_metadata = {}
         if all_match:
@@ -401,6 +394,13 @@ class DistributedExecutor:
                 sorted(processed_representations.timers.items(), key=lambda x: x[1], reverse=True)
             )
             json.dump(sorted_timers, f, indent=4)
+
+        # This is used to upload the output output JSON files to S3 on non-SageMaker runs,
+        # since we can't rely on SageMaker to do it
+        if self.filesystem_type == FilesystemType.S3:
+            self._upload_output_files(
+                self.loader, force=(not self.execution_env == ExecutionEnv.SAGEMAKER)
+            )
 
     def _merge_config_with_transformations(
         self,


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

When repartition failed on AWS infra, it will not save the transformed GSProcessing config. If users do repartition on SageMaker later, it will miss the tranformed GSProcessing config.

Resolve Issue: https://github.com/awslabs/graphstorm/issues/1300

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
