### PR TITLE
Only log a warning if we instantiate a GSConfig object that references a missing part_config

### DIFF
--- a/python/graphstorm/config/argument.py
+++ b/python/graphstorm/config/argument.py
@@ -244,9 +244,6 @@ class GSConfig:
         """
         # Copy data configuration file if available
         if get_rank() == 0:
-            assert isinstance(self.part_config, str), (
-                "Need to provide a value for part_config"
-            )
             try:
                 part_config_dir = os.path.dirname(self.part_config)
                 input_data_config = os.path.join(part_config_dir, GS_RUNTIME_GCONSTRUCT_FILENAME)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

* Previously, while trying to copy the GConstruct config from data source to model output, which happens during instantiation of the GSConfig object, we were assuming the part_config file will exist.
* However during real-time inference we also need to instantiate a GSConfig object, however there the part_config file might be missing.
* By ensuring any reference to gs_config.part_config is within a try/except clause we are guaranteeing we will at most log a warning instead of raising an assertion if we instantiate a GSConfig object from a YAML file that lists a part_config file that's not available.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
