### PR TITLE
[SageMaker] [breaking] Only upload latest epoch at the end of SageMaker training

### DIFF
--- a/python/graphstorm/sagemaker/sagemaker_train.py
+++ b/python/graphstorm/sagemaker/sagemaker_train.py
@@ -20,6 +20,8 @@ import json
 import logging
 import os
 import queue
+import re
+import shutil
 import socket
 import subprocess
 import sys
@@ -42,8 +44,9 @@ from .utils import (download_yaml_config,
                     barrier,
                     terminate_workers,
                     wait_for_exit,
-                    download_model,
-                    upload_model_artifacts)
+                    download_model,)
+
+SM_MODEL_OUTPUT = "/opt/ml/model"
 
 def launch_train_task(task_type, num_gpus, graph_config,
     save_model_path, ip_list, yaml_path,
@@ -166,14 +169,8 @@ def run_train(args, unknownargs):
     else:
         restore_model_path = None
 
-    if args.model_artifact_s3:
-        # If a user provides an S3 output destination as an input arg, the script itself
-        # will upload the model artifacts after training, so we save under /tmp.
-        output_path = "/tmp/gsgnn_model/"
-    else:
-        # If the user does not provide an output destination as an arg, we rely on SageMaker to
-        # do the model upload so we save the model to the pre-determined path /opt/ml/model
-        output_path = "/opt/ml/model"
+    # Models are saved to temporary output first
+    output_path = "/tmp/gsgnn_model"
 
     os.makedirs(output_path, exist_ok=True)
 
@@ -183,7 +180,7 @@ def run_train(args, unknownargs):
     logging.info("Known args %s", args)
     logging.info("Unknown args %s", unknownargs)
 
-    save_model_path = os.path.join(output_path, "model_checkpoint")
+    save_model_path = os.path.join(output_path, "model_checkpoints")
 
     train_env = json.loads(args.sm_dist_env)
     hosts = train_env['hosts']
@@ -241,19 +238,17 @@ def run_train(args, unknownargs):
     graph_data_s3 = args.graph_data_s3
     task_type = args.task_type
     train_yaml_s3 = args.train_yaml_s3
-    # If the user provided an output destination, trim any trailing '/'
-    if args.model_artifact_s3:
-        gs_model_artifact_s3 = args.model_artifact_s3.rstrip('/')
-    else:
-        gs_model_artifact_s3 = None
     custom_script = args.custom_script
 
     boto_session = boto3.session.Session(region_name=args.region)
     sagemaker_session = sagemaker.session.Session(boto_session=boto_session)
+
+    # Download yaml train config and graph data from S3
     yaml_path = download_yaml_config(train_yaml_s3,
         data_path, sagemaker_session)
     graph_config_path = download_graph(graph_data_s3, graph_name,
         host_rank, world_size, data_path, sagemaker_session)
+
     if model_checkpoint_s3 is not None:
         # Download Saved model checkpoint to resume
         download_model(model_checkpoint_s3, restore_model_path, sagemaker_session)
@@ -308,7 +303,97 @@ def run_train(args, unknownargs):
         logging.error("Task failed")
         sys.exit(-1)
 
-    # We upload models only when the user explicitly set the model_artifact_s3
-    # argument. Otherwise we can rely on the SageMaker service to do the upload.
-    if gs_model_artifact_s3 and os.path.exists(save_model_path):
-        upload_model_artifacts(gs_model_artifact_s3, save_model_path, sagemaker_session)
+    # Copy model+embeddings from last epoch into local SageMaker output directory
+    # TODO: Support packing the best epoch from the run
+    copy_best_model_to_sagemaker_output(save_model_path, best_epoch=None)
+
+
+def copy_best_model_to_sagemaker_output(save_model_path, best_epoch=None):
+    """Copy the best or latest epoch model and config files to SageMaker's
+       standard model output directory.
+
+    Parameters
+    ----------
+    save_model_path: str
+        Path to the directory containing existing model checkpoints
+    best_epoch: str, optional
+        Name of the best epoch directory (e.g., 'epoch-5'). If None, the latest epoch will be used.
+    """
+    # TODO: Do we want to be moving files instead for improved perf?
+    if not os.path.exists(save_model_path):
+        logging.warning("Model path %s does not exist, nothing to copy",
+                        save_model_path)
+        return
+
+    # If best_epoch is provided, try to use it directly
+    if best_epoch is not None:
+        best_epoch_dir = best_epoch
+        best_epoch_path = os.path.join(save_model_path, best_epoch_dir)
+        if not os.path.exists(best_epoch_path):
+            logging.warning(
+                "Best epoch directory %s does not exist, falling back to latest epoch",
+                best_epoch_path)
+            best_epoch = None
+
+    # If best_epoch aws not provided or not found, find the latest epoch
+    if best_epoch is None:
+        # Find the latest epoch directory
+        latest_epoch_dir = None
+        latest_epoch = None
+
+        for item in os.listdir(save_model_path):
+            item_path = os.path.join(save_model_path, item)
+            if os.path.isdir(item_path) and item.startswith('epoch-'):
+                # Extract epoch number from directory name
+                match = re.match(r'epoch-(\d+)(?:-iter-(\d+))?', item)
+                if match:
+                    epoch = int(match.group(1))
+                    iteration = int(match.group(2)) if match.group(2) else 0
+
+                    if (latest_epoch is None
+                        or epoch > latest_epoch[0]
+                        or (epoch == latest_epoch[0] and iteration > latest_epoch[1])
+                    ):
+                        latest_epoch = (epoch, iteration)
+                        latest_epoch_dir = item
+
+        if not latest_epoch_dir:
+            logging.warning("No epoch directory found, cannot copy model")
+            return
+
+        best_epoch_dir = latest_epoch_dir
+
+    # Source directory (best or latest epoch)
+    src_dir = os.path.join(save_model_path, best_epoch_dir)
+
+    # Create the destination directory if it doesn't exist
+    os.makedirs(SM_MODEL_OUTPUT, exist_ok=True)
+
+    # Copy all files from the selected epoch directory to /opt/ml/model
+    for item in os.listdir(src_dir):
+        src_path = os.path.join(src_dir, item)
+        dst_path = os.path.join(SM_MODEL_OUTPUT, item)
+
+        # Copy whole directory or individual file
+        if os.path.isdir(src_path):
+            if os.path.exists(dst_path):
+                logging.warning("Model destination path %s already exists, removing...", dst_path)
+                shutil.rmtree(dst_path)
+            shutil.copytree(src_path, dst_path)
+            logging.info("Copied directory %s to %s", item, SM_MODEL_OUTPUT)
+        else:
+            shutil.copy2(src_path, dst_path)
+            logging.info("Copied file %s to %s", item, SM_MODEL_OUTPUT)
+
+    # Also copy any YAML/JSON files from the root model save directory to /opt/ml/model
+    for file in os.listdir(save_model_path):
+        if (file.endswith(('.yaml', '.yml', '.json'))
+            and os.path.isfile(os.path.join(save_model_path, file))):
+            src_path = os.path.join(save_model_path, file)
+            dst_path = os.path.join(SM_MODEL_OUTPUT, file)
+            try:
+                shutil.copy2(src_path, dst_path)
+                logging.info("Copied config file %s to %s", file,
+                             SM_MODEL_OUTPUT)
+            except Exception as e: # pylint: disable=broad-exception-caught
+                logging.warning("Failed to copy %s: %s", file, str(e))

--- a/python/graphstorm/sagemaker/sagemaker_train.py
+++ b/python/graphstorm/sagemaker/sagemaker_train.py
@@ -335,7 +335,7 @@ def copy_best_model_to_sagemaker_output(save_model_path, best_epoch=None):
                 best_epoch_path)
             best_epoch = None
 
-    # If best_epoch aws not provided or not found, find the latest epoch
+    # If best_epoch was not provided or not found, find the latest epoch
     if best_epoch is None:
         # Find the latest epoch directory
         latest_epoch_dir = None
@@ -380,10 +380,10 @@ def copy_best_model_to_sagemaker_output(save_model_path, best_epoch=None):
                 logging.warning("Model destination path %s already exists, removing...", dst_path)
                 shutil.rmtree(dst_path)
             shutil.copytree(src_path, dst_path)
-            logging.info("Copied directory %s to %s", item, SM_MODEL_OUTPUT)
+            logging.info("Copied directory %s to %s", src_path, dst_path)
         else:
             shutil.copy2(src_path, dst_path)
-            logging.info("Copied file %s to %s", item, SM_MODEL_OUTPUT)
+            logging.info("Copied file %s to %s", src_path, dst_path)
 
     # Also copy any YAML/JSON files from the root model save directory to /opt/ml/model
     for file in os.listdir(save_model_path):

--- a/python/graphstorm/sagemaker/sagemaker_train.py
+++ b/python/graphstorm/sagemaker/sagemaker_train.py
@@ -44,7 +44,7 @@ from .utils import (download_yaml_config,
                     barrier,
                     terminate_workers,
                     wait_for_exit,
-                    download_model,)
+                    download_model)
 
 SM_MODEL_OUTPUT = "/opt/ml/model"
 

--- a/python/graphstorm/sagemaker/sagemaker_train.py
+++ b/python/graphstorm/sagemaker/sagemaker_train.py
@@ -328,20 +328,22 @@ def copy_best_model_to_sagemaker_output(save_model_path, best_epoch=None):
     # If best_epoch is provided, try to use it directly
     epoch_to_save = None
     if best_epoch is not None:
-        epoch_to_save = best_epoch
-        epoch_to_save_path = os.path.join(save_model_path, epoch_to_save)
-        if not os.path.exists(epoch_to_save_path):
+        best_epoch_path = os.path.join(save_model_path, best_epoch)
+        if not os.path.exists(best_epoch_path):
             logging.warning(
                 "Best epoch directory %s does not exist, falling back to latest epoch",
-                epoch_to_save_path)
-            best_epoch = None
+                best_epoch_path)
+            epoch_to_save = None
+        else:
+            epoch_to_save = best_epoch
 
-    # If best_epoch aws not provided or not found, find the latest epoch
+    # If best_epoch was not provided or not found, find the latest epoch
     if epoch_to_save is None:
         # Find the latest epoch directory
         latest_epoch_dir = None
         latest_epoch = None
 
+        # Iterate over every epoch/saved iteration directory
         for item in os.listdir(save_model_path):
             item_path = os.path.join(save_model_path, item)
             if os.path.isdir(item_path) and item.startswith('epoch-'):
@@ -351,6 +353,7 @@ def copy_best_model_to_sagemaker_output(save_model_path, best_epoch=None):
                     epoch = int(match.group(1))
                     iteration = int(match.group(2)) if match.group(2) else 0
 
+                    # If current epoch is latest, use that
                     if (latest_epoch is None
                         or epoch > latest_epoch[0]
                         or (epoch == latest_epoch[0] and iteration > latest_epoch[1])

--- a/python/graphstorm/sagemaker/sagemaker_train.py
+++ b/python/graphstorm/sagemaker/sagemaker_train.py
@@ -319,7 +319,6 @@ def copy_best_model_to_sagemaker_output(save_model_path, best_epoch=None):
     best_epoch: str, optional
         Name of the best epoch directory (e.g., 'epoch-5'). If None, the latest epoch will be used.
     """
-    # TODO: Do we want to be moving files instead for improved perf?
     if not os.path.exists(save_model_path):
         logging.warning("Model path %s does not exist, nothing to copy",
                         save_model_path)
@@ -374,6 +373,7 @@ def copy_best_model_to_sagemaker_output(save_model_path, best_epoch=None):
     os.makedirs(SM_MODEL_OUTPUT, exist_ok=True)
 
     # Copy all files from the selected epoch directory to /opt/ml/model
+    # TODO: Moving instead of copying will be more performant, let's reconsider after v0.5 feedback
     for item in os.listdir(src_dir):
         src_path = os.path.join(src_dir, item)
         dst_path = os.path.join(SM_MODEL_OUTPUT, item)

--- a/sagemaker/launch/launch_train.py
+++ b/sagemaker/launch/launch_train.py
@@ -85,8 +85,10 @@ def run_job(input_args, image, unknowargs):
     estimator_kwargs = parse_estimator_kwargs(input_args.sm_estimator_parameters)
 
     est = PyTorch(
+        # Disable SM profiler
         debugger_hook_config=False,
         disable_profiler=True,
+        # Disable output compression to maintain b/w compat with GS < 0.5
         disable_output_compression=True,
         entry_point=os.path.basename(entry_point),
         hyperparameters=params,

--- a/sagemaker/launch/launch_train.py
+++ b/sagemaker/launch/launch_train.py
@@ -66,10 +66,10 @@ def run_job(input_args, image, unknowargs):
         "graph-data-s3": graph_data_s3,
         "graph-name": graph_name,
         "log-level": log_level,
-        "model-artifact-s3": model_artifact_s3,
         "task-type": task_type,
         "train-yaml-s3": train_yaml_s3,
     }
+
     if custom_script is not None:
         params["custom-script"] = custom_script
     if model_checkpoint_to_load is not None:
@@ -85,6 +85,9 @@ def run_job(input_args, image, unknowargs):
     estimator_kwargs = parse_estimator_kwargs(input_args.sm_estimator_parameters)
 
     est = PyTorch(
+        debugger_hook_config=False,
+        disable_profiler=True,
+        disable_output_compression=True,
         entry_point=os.path.basename(entry_point),
         hyperparameters=params,
         image_uri=container_image_uri,
@@ -100,6 +103,7 @@ def run_job(input_args, image, unknowargs):
         **estimator_kwargs
     )
 
+    # TODO: Decide whether we'll provide the yaml as input here, or download ourselves in sagemaker_train.py
     est.fit({"train": train_yaml_s3}, job_name=sm_task_name, wait=not input_args.async_execution)
 
 def get_train_parser():

--- a/tests/unit-tests/test_sagemaker_train_unit.py
+++ b/tests/unit-tests/test_sagemaker_train_unit.py
@@ -1,0 +1,137 @@
+"""Unit tests for sagemaker_train.py"""
+import os
+
+from unittest.mock import patch
+
+from graphstorm.sagemaker.sagemaker_train import copy_best_model_to_sagemaker_output
+
+def test_copy_best_model_to_sagemaker_output_basic(tmp_path):
+    """Test copying latest model checkpoint to SageMaker output directory.
+
+    This test verifies that:
+    1. The latest epoch directory is correctly identified
+    2. Model files are copied from the latest epoch directory
+    3. Config files from root directory are copied
+    """
+    # Create test directory structure
+    save_model_path = tmp_path / "model_save"
+    save_model_path.mkdir()
+
+    # Create epoch directories with dummy model files
+    epoch1 = save_model_path / "epoch-1"
+    epoch2 = save_model_path / "epoch-2"
+    epoch1.mkdir()
+    epoch2.mkdir()
+
+    # Create dummy files including nested directory structure
+    (epoch1 / "model.bin").write_text("model1 content")
+
+    # Create nested structure in epoch2
+    (epoch2 / "model.bin").write_text("model2 content")
+    nested_dir = epoch2 / "nested"
+    nested_dir.mkdir()
+    (nested_dir / "extra.pt").write_text("extra content")
+
+    (save_model_path / "config.yaml").write_text("config content")
+
+    # Mock SM_MODEL_OUTPUT and ensure directory exists
+    mock_output = str(tmp_path / "sm_output")
+    os.makedirs(mock_output, exist_ok=True)
+
+    with patch("graphstorm.sagemaker.sagemaker_train.SM_MODEL_OUTPUT", mock_output):
+        copy_best_model_to_sagemaker_output(str(save_model_path))
+
+        # Verify latest epoch files were copied
+        assert os.path.exists(os.path.join(mock_output, "model.bin"))
+        with open(os.path.join(mock_output, "model.bin"), 'r') as f:
+            assert f.read() == "model2 content"
+
+        # Verify nested directory was copied
+        nested_path = os.path.join(mock_output, "nested", "extra.pt")
+        assert os.path.exists(nested_path)
+        with open(nested_path, 'r') as f:
+            assert f.read() == "extra content"
+
+        # Verify config file was copied
+        assert os.path.exists(os.path.join(mock_output, "config.yaml"))
+        with open(os.path.join(mock_output, "config.yaml"), 'r') as f:
+            assert f.read() == "config content"
+
+def test_copy_best_model_to_sagemaker_output_with_iterations(tmp_path):
+    """Test copying latest model checkpoint when using iteration-specific epochs.
+
+    This test verifies that:
+    1. The latest epoch-iteration directory is correctly identified
+    2. Files from the latest epoch-iteration are copied correctly
+    """
+    # Create test directory structure
+    save_model_path = tmp_path / "model_save"
+    save_model_path.mkdir()
+
+    # Create epoch directories with iterations
+    epoch5_iter1 = save_model_path / "epoch-5-iter-100"
+    epoch5_iter2 = save_model_path / "epoch-5-iter-200"
+    epoch5_iter1.mkdir()
+    epoch5_iter2.mkdir()
+
+    # Create dummy files
+    (epoch5_iter1 / "model.bin").write_text("model5-100 content")
+    (epoch5_iter2 / "model.bin").write_text("model5-200 content")
+    (save_model_path / "config.yaml").write_text("config content")
+
+    # Mock SM_MODEL_OUTPUT and ensure directory exists
+    mock_output = str(tmp_path / "sm_output")
+    os.makedirs(mock_output, exist_ok=True)
+
+    with patch("graphstorm.sagemaker.sagemaker_train.SM_MODEL_OUTPUT", mock_output):
+        copy_best_model_to_sagemaker_output(str(save_model_path))
+
+        # Verify latest iteration files were copied
+        assert os.path.exists(os.path.join(mock_output, "model.bin"))
+        with open(os.path.join(mock_output, "model.bin"), 'r') as f:
+            assert f.read() == "model5-200 content"
+
+        # Verify config file was copied
+        assert os.path.exists(os.path.join(mock_output, "config.yaml"))
+        with open(os.path.join(mock_output, "config.yaml"), 'r') as f:
+            assert f.read() == "config content"
+
+def test_copy_best_model_to_sagemaker_output_specific_epoch(tmp_path):
+    """Test copying a specific epoch when best_epoch is provided.
+
+    This test verifies that:
+    1. The specified best_epoch is used instead of the latest
+    2. Files from the specified epoch are copied correctly
+    """
+    # Create test directory structure
+    save_model_path = tmp_path / "model_save"
+    save_model_path.mkdir()
+
+    # Create epoch directories with dummy model files
+    epoch1 = save_model_path / "epoch-0"
+    epoch2 = save_model_path / "epoch-1"
+    epoch1.mkdir()
+    epoch2.mkdir()
+
+    # Create dummy files
+    (epoch1 / "model.bin").write_text("model0 content")
+    (epoch2 / "model.bin").write_text("model1 content")
+    (save_model_path / "config.yaml").write_text("config content")
+
+    # Mock SM_MODEL_OUTPUT and ensure directory exists
+    mock_output = str(tmp_path / "sm_output")
+    os.makedirs(mock_output, exist_ok=True)
+
+    with patch("graphstorm.sagemaker.sagemaker_train.SM_MODEL_OUTPUT", mock_output):
+        # Specify epoch-0 as best epoch even though epoch-1 is latest
+        copy_best_model_to_sagemaker_output(str(save_model_path), best_epoch="epoch-0")
+
+        # Verify specified epoch files were copied
+        assert os.path.exists(os.path.join(mock_output, "model.bin"))
+        with open(os.path.join(mock_output, "model.bin"), 'r') as f:
+            assert f.read() == "model0 content"
+
+        # Verify config file was copied
+        assert os.path.exists(os.path.join(mock_output, "config.yaml"))
+        with open(os.path.join(mock_output, "config.yaml"), 'r') as f:
+            assert f.read() == "config content"


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
* Currently we upload the entire model output from local to S3 at the end of SM model training. For X epochs that includes X directories, each with its own version of the model
* SageMaker however assumes the model output should be a single, self-contained model that can be used to deploy a model directly
* In this PR we determine the latest epoch from the list of directories, copy over the model weights, any embeddings, and config files (json/yaml/yml) to the standard SageMaker output directory, and only output the latest epoch in the out location chosen from the launch_train.py script


## BREAKING CHANGE: SageMaker model output on S3 now only contains the latest epoch at the top level instead of all epochs

### PREVIOUS BEHAVIOR:

```
python launch_train.py --model-output-s3 s3://my-bucket/model-out --num-epochs 3

# Resulting output on S3
aws s3 ls s3://my-bucket/model-out
epoch-0/
epoch-1/
epoch-2/
GRAPHSTORM_RUNTIME_UPDATED_TRAINING_CONFIG.yaml

# Each epoch contained learnable embeddings and trained weights
aws s3 ls s3://my-bucket/model-out/epoch-0/
                           PRE author/
                           PRE paper/
                           PRE subject/
2025-07-23 18:24:37    4477911 model.bin
2025-07-23 18:24:38    8955170 optimizers.bin
```

### NEW BEHAVIOR

```
python launch_train.py --model-output-s3 s3://my-bucket/model-out --num-epochs 3

# Note that the job name is appended to the output path
aws s3 ls s3://my-bucket/model-out/graphstorm-thvasilo-2025-07-23-18-20-35-445/output/model/

# Learned model weights and learnable embeddings are all at the top level
                           PRE author/
                           PRE paper/
                           PRE subject/
2025-07-23 18:24:37        914 GRAPHSTORM_RUNTIME_UPDATED_TRAINING_CONFIG.yaml
2025-07-23 18:24:37    4477911 model.bin
2025-07-23 18:24:38    8955170 optimizers.bin
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
