### PR TITLE
[SageMaker] [breaking] Only upload latest epoch at the end of SageMaker training

### DIFF
--- a/tests/unit-tests/test_sagemaker_train_unit.py
+++ b/tests/unit-tests/test_sagemaker_train_unit.py
@@ -1,0 +1,137 @@
+"""Unit tests for sagemaker_train.py"""
+import os
+
+from unittest.mock import patch
+
+from graphstorm.sagemaker.sagemaker_train import copy_best_model_to_sagemaker_output
+
+def test_copy_best_model_to_sagemaker_output_basic(tmp_path):
+    """Test copying latest model checkpoint to SageMaker output directory.
+
+    This test verifies that:
+    1. The latest epoch directory is correctly identified
+    2. Model files are copied from the latest epoch directory
+    3. Config files from root directory are copied
+    """
+    # Create test directory structure
+    save_model_path = tmp_path / "model_save"
+    save_model_path.mkdir()
+
+    # Create epoch directories with dummy model files
+    epoch1 = save_model_path / "epoch-1"
+    epoch2 = save_model_path / "epoch-2"
+    epoch1.mkdir()
+    epoch2.mkdir()
+
+    # Create dummy files including nested directory structure
+    (epoch1 / "model.bin").write_text("model1 content")
+
+    # Create nested structure in epoch2
+    (epoch2 / "model.bin").write_text("model2 content")
+    nested_dir = epoch2 / "nested"
+    nested_dir.mkdir()
+    (nested_dir / "extra.pt").write_text("extra content")
+
+    (save_model_path / "config.yaml").write_text("config content")
+
+    # Mock SM_MODEL_OUTPUT and ensure directory exists
+    mock_output = str(tmp_path / "sm_output")
+    os.makedirs(mock_output, exist_ok=True)
+
+    with patch("graphstorm.sagemaker.sagemaker_train.SM_MODEL_OUTPUT", mock_output):
+        copy_best_model_to_sagemaker_output(str(save_model_path))
+
+        # Verify latest epoch files were copied
+        assert os.path.exists(os.path.join(mock_output, "model.bin"))
+        with open(os.path.join(mock_output, "model.bin"), 'r') as f:
+            assert f.read() == "model2 content"
+
+        # Verify nested directory was copied
+        nested_path = os.path.join(mock_output, "nested", "extra.pt")
+        assert os.path.exists(nested_path)
+        with open(nested_path, 'r') as f:
+            assert f.read() == "extra content"
+
+        # Verify config file was copied
+        assert os.path.exists(os.path.join(mock_output, "config.yaml"))
+        with open(os.path.join(mock_output, "config.yaml"), 'r') as f:
+            assert f.read() == "config content"
+
+def test_copy_best_model_to_sagemaker_output_with_iterations(tmp_path):
+    """Test copying latest model checkpoint when using iteration-specific epochs.
+
+    This test verifies that:
+    1. The latest epoch-iteration directory is correctly identified
+    2. Files from the latest epoch-iteration are copied correctly
+    """
+    # Create test directory structure
+    save_model_path = tmp_path / "model_save"
+    save_model_path.mkdir()
+
+    # Create epoch directories with iterations
+    epoch5_iter1 = save_model_path / "epoch-5-iter-100"
+    epoch5_iter2 = save_model_path / "epoch-5-iter-200"
+    epoch5_iter1.mkdir()
+    epoch5_iter2.mkdir()
+
+    # Create dummy files
+    (epoch5_iter1 / "model.bin").write_text("model5-100 content")
+    (epoch5_iter2 / "model.bin").write_text("model5-200 content")
+    (save_model_path / "config.yaml").write_text("config content")
+
+    # Mock SM_MODEL_OUTPUT and ensure directory exists
+    mock_output = str(tmp_path / "sm_output")
+    os.makedirs(mock_output, exist_ok=True)
+
+    with patch("graphstorm.sagemaker.sagemaker_train.SM_MODEL_OUTPUT", mock_output):
+        copy_best_model_to_sagemaker_output(str(save_model_path))
+
+        # Verify latest iteration files were copied
+        assert os.path.exists(os.path.join(mock_output, "model.bin"))
+        with open(os.path.join(mock_output, "model.bin"), 'r') as f:
+            assert f.read() == "model5-200 content"
+
+        # Verify config file was copied
+        assert os.path.exists(os.path.join(mock_output, "config.yaml"))
+        with open(os.path.join(mock_output, "config.yaml"), 'r') as f:
+            assert f.read() == "config content"
+
+def test_copy_best_model_to_sagemaker_output_specific_epoch(tmp_path):
+    """Test copying a specific epoch when best_epoch is provided.
+
+    This test verifies that:
+    1. The specified best_epoch is used instead of the latest
+    2. Files from the specified epoch are copied correctly
+    """
+    # Create test directory structure
+    save_model_path = tmp_path / "model_save"
+    save_model_path.mkdir()
+
+    # Create epoch directories with dummy model files
+    epoch1 = save_model_path / "epoch-0"
+    epoch2 = save_model_path / "epoch-1"
+    epoch1.mkdir()
+    epoch2.mkdir()
+
+    # Create dummy files
+    (epoch1 / "model.bin").write_text("model0 content")
+    (epoch2 / "model.bin").write_text("model1 content")
+    (save_model_path / "config.yaml").write_text("config content")
+
+    # Mock SM_MODEL_OUTPUT and ensure directory exists
+    mock_output = str(tmp_path / "sm_output")
+    os.makedirs(mock_output, exist_ok=True)
+
+    with patch("graphstorm.sagemaker.sagemaker_train.SM_MODEL_OUTPUT", mock_output):
+        # Specify epoch-0 as best epoch even though epoch-1 is latest
+        copy_best_model_to_sagemaker_output(str(save_model_path), best_epoch="epoch-0")
+
+        # Verify specified epoch files were copied
+        assert os.path.exists(os.path.join(mock_output, "model.bin"))
+        with open(os.path.join(mock_output, "model.bin"), 'r') as f:
+            assert f.read() == "model0 content"
+
+        # Verify config file was copied
+        assert os.path.exists(os.path.join(mock_output, "config.yaml"))
+        with open(os.path.join(mock_output, "config.yaml"), 'r') as f:
+            assert f.read() == "config content"


### PR DESCRIPTION

*Issue #, if available:*

*Description of changes:*
* Currently we upload the entire model output from local to S3 at the end of SM model training. For X epochs that includes X directories, each with its own version of the model
* SageMaker however assumes the model output should be a single, self-contained model that can be used to deploy a model directly
* In this PR we determine the latest epoch from the list of directories, copy over the model weights, any embeddings, and config files (json/yaml/yml) to the standard SageMaker output directory, and only output the latest epoch in the out location chosen from the launch_train.py script


## BREAKING CHANGE: SageMaker model output on S3 now only contains the latest epoch at the top level instead of all epochs

### PREVIOUS BEHAVIOR:

```
python launch_train.py --model-output-s3 s3://my-bucket/model-out --num-epochs 3

# Resulting output on S3
aws s3 ls s3://my-bucket/model-out
epoch-0/
epoch-1/
epoch-2/
GRAPHSTORM_RUNTIME_UPDATED_TRAINING_CONFIG.yaml

# Each epoch contained learnable embeddings and trained weights
aws s3 ls s3://my-bucket/model-out/epoch-0/
                           PRE author/
                           PRE paper/
                           PRE subject/
2025-07-23 18:24:37    4477911 model.bin
2025-07-23 18:24:38    8955170 optimizers.bin
```

### NEW BEHAVIOR

```
python launch_train.py --model-output-s3 s3://my-bucket/model-out --num-epochs 3

# Note that the job name is appended to the output path
aws s3 ls s3://my-bucket/model-out/graphstorm-thvasilo-2025-07-23-18-20-35-445/output/model/

# Learned model weights and learnable embeddings are all at the top level
                           PRE author/
                           PRE paper/
                           PRE subject/
2025-07-23 18:24:37        914 GRAPHSTORM_RUNTIME_UPDATED_TRAINING_CONFIG.yaml
2025-07-23 18:24:37    4477911 model.bin
2025-07-23 18:24:38    8955170 optimizers.bin
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

---------

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
