### PR TITLE
[docker] [sagemaker] Fix order of installation to ensure torhc is not pulled twice

### DIFF
--- a/docker/sagemaker/Dockerfile.endpoint
+++ b/docker/sagemaker/Dockerfile.endpoint
@@ -12,17 +12,17 @@ ARG DGL_VERSION
 # Uninstall preset Pytorch packages
 RUN pip3 uninstall -y torchdata torch torchvision torchaudio
 
+RUN pip3 install \
+    torch==2.3 \
+    --index-url https://download.pytorch.org/whl/cu121 \
+    && rm -rf /root/.cache
+
 # Install Dependencies to fit DGL GraphBolt requirements
 RUN pip3 install \
         torchdata==0.9.0 \
         pydantic==2.7.1 \
         transformers==4.47.1 \
         ogb==1.3.6 \
-    && rm -rf /root/.cache
-
-RUN pip3 install \
-    torch==2.3 \
-    --index-url https://download.pytorch.org/whl/cu121 \
     && rm -rf /root/.cache
 
 # Install DGL GPU version
@@ -36,17 +36,17 @@ ARG DGL_VERSION
 # Uninstall preset Pytorch packages
 RUN pip3 uninstall -y torchdata torch torchvision torchaudio
 
+RUN pip3 install \
+    torch==2.3 \
+    --index-url https://download.pytorch.org/whl/cpu \
+    && rm -rf /root/.cache
+
 # Install Dependencies to fit DGL GraphBolt requirements
 RUN pip3 install \
         torchdata==0.9.0 \
         pydantic==2.7.1 \
         transformers==4.47.1 \
         ogb==1.3.6 \
-    && rm -rf /root/.cache
-
-RUN pip3 install \
-    torch==2.3 \
-    --index-url https://download.pytorch.org/whl/cpu \
     && rm -rf /root/.cache
 
 # Install DGL CPU version


### PR DESCRIPTION

*Issue #, if available:*

*Description of changes:*

* Previously we'd try to install torchdata and trasformers _before_ installing torch. These both depend on torch, leading to the GPU version + all cuda dependencies being pulled into the image.
* We move the torch installation first, avoiding the double-pulling and significantly reducing image size for CPU.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
