### PR TITLE
[Bug] Set logging default level in real-time launch script

### DIFF
--- a/sagemaker/launch/launch_realtime_endpoint.py
+++ b/sagemaker/launch/launch_realtime_endpoint.py
@@ -107,10 +107,10 @@ def run_job(input_args):
         SageMaker's naming format, which is ^[a-zA-Z0-9]([\-a-zA-Z0-9]*[a-zA-Z0-9])$. The default
         value is \"GSF-Model4Realtime\".
     logging_level: str
-        The level of logging. Optional values are 'debug', 'info', 'warning', 'error'.
-        Default is'info'."
+        The level of logging. Optional values are 'debug', 'info', 'warning', and 'error'.
+        Default is 'info'."
     """
-    # set logging levels
+    # set the logging level
     log_level = get_log_level(input_args.logging_level) \
                 if hasattr(input_args, "logging_level") else logging.INFO
     logging.basicConfig(level=log_level, force=True)

--- a/sagemaker/launch/launch_utils.py
+++ b/sagemaker/launch/launch_utils.py
@@ -238,3 +238,19 @@ def check_name_format(name_str):
                                 'expression pattern: ' + \
                                 r'^[a-zA-Z0-9]([\-a-zA-Z0-9]*[a-zA-Z0-9])$.')
     return name_str
+
+
+def get_log_level(log_level):
+    """ Map the logging level.
+    """
+    if log_level == "debug":
+        return logging.DEBUG
+    elif log_level == "info":
+        return logging.INFO
+    elif log_level == "warning":
+        return logging.WARNING
+    elif log_level == "error":
+        return logging.ERROR
+    else:
+        raise ValueError(f"Unknown logging level {log_level}. " + \
+                "The possible values are: debug, info, warning, error.")

--- a/tests/sagemaker-tests/test_sagemaker_args.py
+++ b/tests/sagemaker-tests/test_sagemaker_args.py
@@ -102,7 +102,8 @@ def test_get_realtime_infer_argparser():
     default_args = {'--instance-type': 'ml.c6i.xlarge',
                     '--instance-count': 1,
                     '--async-execution': 'true',
-                    '--model-name': 'GSF-Model4Realtime'}
+                    '--model-name': 'GSF-Model4Realtime',
+                    '--logging-level': 'info'}
 
     # Test case 1: normal cases
     #       1.1: for the three required arguments


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This PR fix the error of no log output information in the launch script. By this PR, we set the default logging level to INFO, which will output both endpoint ARN and name.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
