### PR TITLE
[Bug] Fix real-time inference workflow when adding reverse edges

### DIFF
--- a/graphstorm-processing/graphstorm_processing/config/config_parser.py
+++ b/graphstorm-processing/graphstorm_processing/config/config_parser.py
@@ -360,7 +360,7 @@ class NodeConfig(StructureConfig):
         return self._node_col
 
 
-def update_gsprocessing_config(graph_config: Dict[str, Any], add_reverse_edge: bool = False):
+def update_gsprocessing_config(graph_config: Dict[str, Any], add_reverse_edges: bool = False):
     """Parses a GSProcessing JSON configuration dictionary and save flag.
     Automatically adjusting the node/edge type configurations for homogeneous graphs
     to ensure they are compatible with DGL requirements.
@@ -369,7 +369,7 @@ def update_gsprocessing_config(graph_config: Dict[str, Any], add_reverse_edge: b
     ----------
     graph_config : Dict[str, Any]
         A GSProcessing configuration dict, describing stored graph data.
-    add_reverse_edge: Bool
+    add_reverse_edges: Bool
         If add reverse edge
     """
     if "nodes" in graph_config and graph_config["nodes"] != [{}]:
@@ -398,7 +398,7 @@ def update_gsprocessing_config(graph_config: Dict[str, Any], add_reverse_edge: b
     else:
         graph_config["is_homogeneous"] = False
 
-    graph_config["add_reverse_edge"] = add_reverse_edge
+    graph_config["add_reverse_edges"] = add_reverse_edges
 
 
 def create_config_objects(graph_config: Dict[str, Any]) -> Dict[str, Sequence[StructureConfig]]:

--- a/graphstorm-processing/graphstorm_processing/config/config_parser.py
+++ b/graphstorm-processing/graphstorm_processing/config/config_parser.py
@@ -362,7 +362,7 @@ class NodeConfig(StructureConfig):
 
 def update_gsprocessing_config(graph_config: Dict[str, Any], add_reverse_edges: bool = False):
     """Updates input GSProcessing dictionary with runtime parameters to allow graph reconstruction.
-    
+
     Will update the edge and node type names to match DGL expecations when the graph is homogeneous,
     and adds an `add_reverse_edges` boolean value to indicate whether reverse edges were created
     during graph construction.

--- a/graphstorm-processing/graphstorm_processing/config/config_parser.py
+++ b/graphstorm-processing/graphstorm_processing/config/config_parser.py
@@ -360,7 +360,7 @@ class NodeConfig(StructureConfig):
         return self._node_col
 
 
-def update_gsprocessing_config(graph_config: Dict[str, Any], add_reverse_edge):
+def update_gsprocessing_config(graph_config: Dict[str, Any], add_reverse_edge=False):
     """Parses a GSProcessing JSON configuration dictionary and adjust the node/edge type
     if it is a homogeneous graph to fit the DGL requirement.
 

--- a/graphstorm-processing/graphstorm_processing/config/config_parser.py
+++ b/graphstorm-processing/graphstorm_processing/config/config_parser.py
@@ -360,7 +360,7 @@ class NodeConfig(StructureConfig):
         return self._node_col
 
 
-def update_dict_if_homogeneous(graph_config: Dict[str, Any]):
+def update_gsprocessing_config(graph_config: Dict[str, Any], add_reverse_edge):
     """Parses a GSProcessing JSON configuration dictionary and adjust the node/edge type
     if it is a homogeneous graph to fit the DGL requirement.
 
@@ -368,6 +368,8 @@ def update_dict_if_homogeneous(graph_config: Dict[str, Any]):
     ----------
     graph_config : Dict[str, Any]
         A GSProcessing configuration dict, describing stored graph data.
+    add_reverse_edge: Bool
+        If add reverse edge
     """
     if "nodes" in graph_config and graph_config["nodes"] != [{}]:
         ntype = {n["type"] for n in graph_config["nodes"]}
@@ -394,6 +396,8 @@ def update_dict_if_homogeneous(graph_config: Dict[str, Any]):
             e_config["relation"]["type"] = "_E"
     else:
         graph_config["is_homogeneous"] = False
+
+    graph_config["add_reverse_edge"] = add_reverse_edge
 
 
 def create_config_objects(graph_config: Dict[str, Any]) -> Dict[str, Sequence[StructureConfig]]:

--- a/graphstorm-processing/graphstorm_processing/config/config_parser.py
+++ b/graphstorm-processing/graphstorm_processing/config/config_parser.py
@@ -360,9 +360,10 @@ class NodeConfig(StructureConfig):
         return self._node_col
 
 
-def update_gsprocessing_config(graph_config: Dict[str, Any], add_reverse_edge=False):
-    """Parses a GSProcessing JSON configuration dictionary and adjust the node/edge type
-    if it is a homogeneous graph to fit the DGL requirement.
+def update_gsprocessing_config(graph_config: Dict[str, Any], add_reverse_edge: bool = False):
+    """Parses a GSProcessing JSON configuration dictionary and save flag.
+    Automatically adjusting the node/edge type configurations for homogeneous graphs
+    to ensure they are compatible with DGL requirements.
 
     Parameters
     ----------

--- a/graphstorm-processing/graphstorm_processing/config/config_parser.py
+++ b/graphstorm-processing/graphstorm_processing/config/config_parser.py
@@ -372,7 +372,8 @@ def update_gsprocessing_config(graph_config: Dict[str, Any], add_reverse_edges: 
     graph_config : Dict[str, Any]
         A GSProcessing configuration dict, describing stored graph data.
     add_reverse_edges: Bool
-        Indicates whether reverse edges were added during processing. Used to recreate graph downstream.
+        Indicates whether reverse edges were added during processing.
+        Used to recreate graph downstream.
     """
     if "nodes" in graph_config and graph_config["nodes"] != [{}]:
         ntype = {n["type"] for n in graph_config["nodes"]}

--- a/graphstorm-processing/graphstorm_processing/config/config_parser.py
+++ b/graphstorm-processing/graphstorm_processing/config/config_parser.py
@@ -361,16 +361,18 @@ class NodeConfig(StructureConfig):
 
 
 def update_gsprocessing_config(graph_config: Dict[str, Any], add_reverse_edges: bool = False):
-    """Parses a GSProcessing JSON configuration dictionary and save flag.
-    Automatically adjusting the node/edge type configurations for homogeneous graphs
-    to ensure they are compatible with DGL requirements.
+    """Updates input GSProcessing dictionary with runtime parameters to allow graph reconstruction.
+    
+    Will update the edge and node type names to match DGL expecations when the graph is homogeneous,
+    and adds an `add_reverse_edges` boolean value to indicate whether reverse edges were created
+    during graph construction.
 
     Parameters
     ----------
     graph_config : Dict[str, Any]
         A GSProcessing configuration dict, describing stored graph data.
     add_reverse_edges: Bool
-        If add reverse edge
+        Indicates whether reverse edges were added during processing. Used to recreate graph downstream.
     """
     if "nodes" in graph_config and graph_config["nodes"] != [{}]:
         ntype = {n["type"] for n in graph_config["nodes"]}

--- a/graphstorm-processing/graphstorm_processing/distributed_executor.py
+++ b/graphstorm-processing/graphstorm_processing/distributed_executor.py
@@ -566,7 +566,7 @@ class DistributedExecutor:
 
         gsp_top_level_dict = {
             "graph": gsp_config_dict_copy,
-            "version": "gsprocessing-v1.0",
+            "version": "gsprocessing-runtime-v1.0",
         }
 
         return gsp_top_level_dict

--- a/graphstorm-processing/graphstorm_processing/distributed_executor.py
+++ b/graphstorm-processing/graphstorm_processing/distributed_executor.py
@@ -71,7 +71,7 @@ from graphstorm_processing.graph_loaders.dist_heterogeneous_loader import (
 )
 from graphstorm_processing.config.config_parser import (
     create_config_objects,
-    update_dict_if_homogeneous,
+    update_gsprocessing_config,
 )
 from graphstorm_processing.config.config_conversion import GConstructConfigConverter
 from graphstorm_processing.constants import TRANSFORMATIONS_FILENAME
@@ -254,7 +254,7 @@ class DistributedExecutor:
         self.spark = spark_utils.create_spark_session(self.execution_env, self.filesystem_type)
 
         # Initialize the graph loader
-        update_dict_if_homogeneous(self.gsp_config_dict)
+        update_gsprocessing_config(self.gsp_config_dict, self.add_reverse_edges)
         data_configs = create_config_objects(self.gsp_config_dict)
         loader_config = HeterogeneousLoaderConfig(
             is_homogeneous=self.gsp_config_dict[HOMOGENEOUS_FLAG],

--- a/graphstorm-processing/tests/test_gsprocessing_config.py
+++ b/graphstorm-processing/tests/test_gsprocessing_config.py
@@ -21,7 +21,7 @@ from graphstorm_processing.config.config_parser import (
     EdgeConfig,
     create_config_objects,
     parse_feat_config,
-    update_dict_if_homogeneous,
+    update_gsprocessing_config,
 )
 from graphstorm_processing.config.numerical_configs import (
     NumericalFeatureConfig,
@@ -182,7 +182,7 @@ def test_update_dict_if_homogeneous():
             }
         ],
     }
-    update_dict_if_homogeneous(graph_config)
+    update_gsprocessing_config(graph_config)
     assert graph_config["nodes"][0]["type"] == "_N"
     assert graph_config["edges"][0]["source"]["type"] == "_N"
     assert graph_config["edges"][0]["dest"]["type"] == "_N"
@@ -199,7 +199,7 @@ def test_update_dict_if_homogeneous():
             }
         ]
     }
-    update_dict_if_homogeneous(graph_config)
+    update_gsprocessing_config(graph_config)
     assert graph_config["edges"][0]["source"]["type"] == "_N"
     assert graph_config["edges"][0]["dest"]["type"] == "_N"
     assert graph_config["edges"][0]["relation"]["type"] == "_E"
@@ -216,7 +216,7 @@ def test_update_dict_if_homogeneous():
         ],
         "nodes": [{}],
     }
-    update_dict_if_homogeneous(graph_config)
+    update_gsprocessing_config(graph_config)
     assert graph_config["edges"][0]["source"]["type"] == "movie"
     assert graph_config["edges"][0]["dest"]["type"] == "genre"
     assert graph_config["edges"][0]["relation"]["type"] == "relation"

--- a/graphstorm-processing/tests/test_gsprocessing_config.py
+++ b/graphstorm-processing/tests/test_gsprocessing_config.py
@@ -236,8 +236,8 @@ def test_update_dict_reverse_edge():
 
     # Without reverse edge case
     update_gsprocessing_config(graph_config)
-    assert not graph_config["add_reverse_edge"]
+    assert not graph_config["add_reverse_edges"]
 
     # With reverse edge case
-    update_gsprocessing_config(graph_config, add_reverse_edge=True)
-    assert graph_config["add_reverse_edge"]
+    update_gsprocessing_config(graph_config, add_reverse_edges=True)
+    assert graph_config["add_reverse_edges"]

--- a/graphstorm-processing/tests/test_gsprocessing_config.py
+++ b/graphstorm-processing/tests/test_gsprocessing_config.py
@@ -220,3 +220,24 @@ def test_update_dict_if_homogeneous():
     assert graph_config["edges"][0]["source"]["type"] == "movie"
     assert graph_config["edges"][0]["dest"]["type"] == "genre"
     assert graph_config["edges"][0]["relation"]["type"] == "relation"
+
+
+def test_update_dict_reverse_edge():
+    graph_config = {
+        "edges": [
+            {
+                "source": {"column": "~from", "type": "movie"},
+                "relation": {"type": "relation"},
+                "dest": {"column": "~to", "type": "genre"},
+            }
+        ],
+        "nodes": [{}],
+    }
+
+    # Without reverse edge case
+    update_gsprocessing_config(graph_config)
+    assert not graph_config["add_reverse_edge"]
+
+    # With reverse edge case
+    update_gsprocessing_config(graph_config, add_reverse_edge=True)
+    assert graph_config["add_reverse_edge"]

--- a/python/graphstorm/dataloading/metadata.py
+++ b/python/graphstorm/dataloading/metadata.py
@@ -1053,7 +1053,7 @@ def load_metadata_from_json(config_json):
         # parse edge types
         etypes = []
         efeat_dims = {}
-        add_reverse_edges = graph_obj['add_reverse_edge'] in ['True', 'true']
+        add_reverse_edges = graph_obj['add_reverse_edge'] in ['True', 'true', True]
         for edge_obj in graph_obj['edges']:
             src_ntype = edge_obj['source']['type']
             dst_ntype = edge_obj['dest']['type']

--- a/python/graphstorm/dataloading/metadata.py
+++ b/python/graphstorm/dataloading/metadata.py
@@ -680,7 +680,7 @@ def config_json_sanity_check(config_json):
 
     JSON from GS gconstruct:
         {
-            "version": "gconstruct-v0.1",
+            "version": "gconstruct-runtime-v0.1",
             "is_homogeneous": bool,
             "add_reverse_edges": bool,
             "nodes":[
@@ -713,7 +713,7 @@ def config_json_sanity_check(config_json):
         }
     JSON from GSProcessing:
         {
-            "version": "gsprocessing-v0.4.1",
+            "version": "gsprocessing-runtime-v0.4.1",
             "graph": {
                 "is_homogeneous": bool,
                 "add_reverse_edges": bool,
@@ -764,6 +764,8 @@ def config_json_sanity_check(config_json):
     assert 'version' in config_json, (
         'A "version" field must be defined in the configuration JSON object.')
     config_version = config_json['version']
+    assert 'runtime' in config_version, (
+        'The "version" field must contain a "runtime" field to identify the runtime version.')
 
     if config_version.startswith('gconstruct'):
         assert 'is_homogeneous' in config_json, (

--- a/python/graphstorm/dataloading/metadata.py
+++ b/python/graphstorm/dataloading/metadata.py
@@ -1024,7 +1024,7 @@ def load_metadata_from_json(config_json):
                 for feat_obj in edge_obj['features']:
                     feat_dims[feat_obj['feature_name']] = feat_obj['feature_dim']
                 efeat_dims[tuple(edge_obj['relation'])] = feat_dims
-            if add_reverse_edges:
+            if add_reverse_edges and not is_homo:
                 reverse_relation = [edge_obj['relation'][2],
                                     edge_obj['relation'][1] + "-rev",
                                     edge_obj['relation'][0]]
@@ -1065,13 +1065,13 @@ def load_metadata_from_json(config_json):
                 for feat_obj in edge_obj['features']:
                     feat_dims[feat_obj['name']] = feat_obj['dim']
                 efeat_dims[(src_ntype, etype, dst_ntype)] = feat_dims
-            if add_reverse_edges:
+            if add_reverse_edges and not is_homo:
                 etypes.append((dst_ntype, etype + "-rev", src_ntype))
                 if 'features' in edge_obj:
                     feat_dims = {}
                     for feat_obj in edge_obj['features']:
                         feat_dims[feat_obj['name']] = feat_obj['dim']
-                    efeat_dims[(src_ntype, etype + "-rev", dst_ntype)] = feat_dims
+                    efeat_dims[(dst_ntype, etype + "-rev", src_ntype)] = feat_dims
 
     # create the metadata instance
     if is_homo:

--- a/python/graphstorm/dataloading/metadata.py
+++ b/python/graphstorm/dataloading/metadata.py
@@ -906,9 +906,9 @@ def load_metadata_from_json(config_json):
 
     JSON from GS gconstruct:
         {
-            "version": "gconstruct-v0.1",
+            "version": "gconstruct-runtime-v0.1",
             "is_homogeneous": bool,
-            "add_reverse_edge": bool,
+            "add_reverse_edges": bool,
             "nodes":[
                 {
                     "node_id_col": str,
@@ -939,9 +939,10 @@ def load_metadata_from_json(config_json):
         }
     JSON from GSProcessing:
         {
-            "version": "gsprocessing-v0.4.1",
+            "version": "gsprocessing-runtime-v0.4.1",
             "graph": {
                 "is_homogeneous": bool,
+                "add_reverse_edges": bool,
                 "nodes": [
                     {
                         "type": str,
@@ -1015,7 +1016,7 @@ def load_metadata_from_json(config_json):
         # parse edge types
         etypes = []
         efeat_dims = {}
-        add_reverse_edges = config_json['add_reverse_edge'] in ['True', 'true', True]
+        add_reverse_edges = config_json['add_reverse_edges'] in ['True', 'true', True]
         for edge_obj in config_json['edges']:
             etypes.append(tuple(edge_obj['relation']))  # convert a list to tuple as can_etype
             # extract feature name and dimensions if have
@@ -1053,7 +1054,7 @@ def load_metadata_from_json(config_json):
         # parse edge types
         etypes = []
         efeat_dims = {}
-        add_reverse_edges = graph_obj['add_reverse_edge'] in ['True', 'true', True]
+        add_reverse_edges = graph_obj['add_reverse_edges'] in ['True', 'true', True]
         for edge_obj in graph_obj['edges']:
             src_ntype = edge_obj['source']['type']
             dst_ntype = edge_obj['dest']['type']
@@ -1084,5 +1085,4 @@ def load_metadata_from_json(config_json):
                                      etypes=etypes,
                                      nfeat_dims=nfeat_dims,
                                      efeat_dims=efeat_dims)
-
     return graph_metadata

--- a/python/graphstorm/dataloading/metadata.py
+++ b/python/graphstorm/dataloading/metadata.py
@@ -765,13 +765,14 @@ def config_json_sanity_check(config_json):
         'A "version" field must be defined in the configuration JSON object.')
     config_version = config_json['version']
     assert 'runtime' in config_version, (
-        'The value of the "version" field must contain "runtime" to identify it is a runtime version.')
+        'The value of the "version" field must contain "runtime" to identify '
+        'it is a runtime version.')
 
     if config_version.startswith('gconstruct'):
         assert 'is_homogeneous' in config_json, (
             'A "is_homogeneous" field must be defined in the configuration JSON object.')
         is_homo = config_json['is_homogeneous']
-        assert is_homo in [True, 'true', False, 'false'], (
+        assert is_homo in [True, "True", 'true', False, "False", 'false'], (
             'The value of "is_homogeneous" can only be "True", "true", "False", or '
             f'"false", but got {is_homo}.')
 
@@ -779,7 +780,7 @@ def config_json_sanity_check(config_json):
             'An "add_reverse_edges" field must be defined in the configuration JSON object.'
         )
         add_reverse_edges = config_json["add_reverse_edges"]
-        assert add_reverse_edges in [True, 'true', False, 'false'], (
+        assert add_reverse_edges in [True, "True", 'true', False, "False", 'false'], (
             'The value of "add_reverse_edges" can only be "True", "true", "False", or '
             f'"false", but got {add_reverse_edges}.')
 
@@ -834,14 +835,14 @@ def config_json_sanity_check(config_json):
         assert 'is_homogeneous' in graph_obj, (
             'An "is_homogeneous" field must be defined in the configuration JSON object.')
         is_homo = graph_obj['is_homogeneous']
-        assert is_homo in [True, 'true', False, 'false'], (
+        assert is_homo in [True, "True", 'true', False, "False", 'false'], (
             'The value of "is_homogeneous" can only be "True", "true", "False", or '
             f'"false", but got {is_homo}.')
 
         assert 'add_reverse_edges' in graph_obj, (
             'An "add_reverse_edges" field must be defined in the configuration JSON object.')
         add_reverse_edges = graph_obj['add_reverse_edges']
-        assert add_reverse_edges in [True, 'true', False, 'false'], (
+        assert add_reverse_edges in [True, "True", 'true', False, "False", 'false'], (
             'The value of "add_reverse_edges" can only be "True", "true", "False", or '
             f'"false", but got {add_reverse_edges}.')
 

--- a/python/graphstorm/dataloading/metadata.py
+++ b/python/graphstorm/dataloading/metadata.py
@@ -682,6 +682,7 @@ def config_json_sanity_check(config_json):
         {
             "version": "gconstruct-v0.1",
             "is_homogeneous": bool,
+            "add_reverse_edges": bool,
             "nodes":[
                 {
                     "node_id_col": str,
@@ -715,6 +716,7 @@ def config_json_sanity_check(config_json):
             "version": "gsprocessing-v0.4.1",
             "graph": {
                 "is_homogeneous": bool,
+                "add_reverse_edges": bool,
                 "nodes": [
                     {
                         "type": str,
@@ -771,6 +773,14 @@ def config_json_sanity_check(config_json):
             'The value of "is_homogeneous" can only be "True", "true", "False", or '
             f'"false", but got {is_homo}.')
 
+        assert "add_reverse_edges" in config_json, (
+            'A "add_reverse_edges" field must be defined in the configuration JSON object.'
+        )
+        add_reverse_edges = config_json["add_reverse_edges"]
+        assert add_reverse_edges in [True, 'true', False, 'false'], (
+            'The value of "add_reverse_edges" can only be "True", "true", "False", or '
+            f'"false", but got {add_reverse_edges}.')
+
         assert 'nodes' in config_json, (
             'A "nodes" field must be defined in the configuration JSON object.')
         assert len(config_json['nodes']) > 0, 'Need at least one node in the \"nodes\" object.'
@@ -822,9 +832,16 @@ def config_json_sanity_check(config_json):
         assert 'is_homogeneous' in graph_obj, (
             'An "is_homogeneous" field must be defined in the configuration JSON object.')
         is_homo = graph_obj['is_homogeneous']
-        assert is_homo in ['True', 'true', 'False', 'false'], (
+        assert is_homo in [True, 'true', False, 'false'], (
             'The value of "is_homogeneous" can only be "True", "true", "False", or '
             f'"false", but got {is_homo}.')
+
+        assert 'add_reverse_edges' in graph_obj, (
+            'An "add_reverse_edges" field must be defined in the configuration JSON object.')
+        add_reverse_edges = graph_obj['add_reverse_edges']
+        assert add_reverse_edges in [True, 'true', False, 'false'], (
+            'The value of "add_reverse_edges" can only be "True", "true", "False", or '
+            f'"false", but got {add_reverse_edges}.')
 
         assert 'nodes' in graph_obj, (
             'A "nodes" field must be defined in the graph object.')

--- a/python/graphstorm/dataloading/metadata.py
+++ b/python/graphstorm/dataloading/metadata.py
@@ -908,6 +908,7 @@ def load_metadata_from_json(config_json):
         {
             "version": "gconstruct-v0.1",
             "is_homogeneous": bool,
+            "add_reverse_edge": bool,
             "nodes":[
                 {
                     "node_id_col": str,
@@ -997,7 +998,7 @@ def load_metadata_from_json(config_json):
     config_version = config_json['version']
 
     if config_version.startswith('gconstruct'):
-        is_homo = config_json['is_homogeneous'] in ['True', 'true']
+        is_homo = config_json['is_homogeneous'] in ['True', 'true', True]
 
         # parse node types
         ntypes = []
@@ -1014,7 +1015,7 @@ def load_metadata_from_json(config_json):
         # parse edge types
         etypes = []
         efeat_dims = {}
-        add_reverse_edges = config_json['add_reverse_edge'] in ['True', 'true']
+        add_reverse_edges = config_json['add_reverse_edge'] in ['True', 'true', True]
         for edge_obj in config_json['edges']:
             etypes.append(tuple(edge_obj['relation']))  # convert a list to tuple as can_etype
             # extract feature name and dimensions if have
@@ -1024,9 +1025,10 @@ def load_metadata_from_json(config_json):
                     feat_dims[feat_obj['feature_name']] = feat_obj['feature_dim']
                 efeat_dims[tuple(edge_obj['relation'])] = feat_dims
             if add_reverse_edges:
-                reverse_relation = [edge_obj['relation'][0],
+                reverse_relation = [edge_obj['relation'][2],
                                     edge_obj['relation'][1] + "-rev",
-                                    edge_obj['relation'][2]]
+                                    edge_obj['relation'][0]]
+                etypes.append(tuple(reverse_relation))
                 if 'features' in edge_obj:
                     feat_dims = {}
                     for feat_obj in edge_obj['features']:
@@ -1034,7 +1036,7 @@ def load_metadata_from_json(config_json):
                     efeat_dims[tuple(reverse_relation)] = feat_dims
     else:
         graph_obj = config_json['graph']
-        is_homo = graph_obj['is_homogeneous'] in ['True', 'true']
+        is_homo = graph_obj['is_homogeneous'] in ['True', 'true', True]
 
         # parse node types
         ntypes = []
@@ -1051,7 +1053,7 @@ def load_metadata_from_json(config_json):
         # parse edge types
         etypes = []
         efeat_dims = {}
-        add_reverse_edges = config_json['add_reverse_edge'] in ['True', 'true']
+        add_reverse_edges = graph_obj['add_reverse_edge'] in ['True', 'true']
         for edge_obj in graph_obj['edges']:
             src_ntype = edge_obj['source']['type']
             dst_ntype = edge_obj['dest']['type']
@@ -1064,7 +1066,7 @@ def load_metadata_from_json(config_json):
                     feat_dims[feat_obj['name']] = feat_obj['dim']
                 efeat_dims[(src_ntype, etype, dst_ntype)] = feat_dims
             if add_reverse_edges:
-                etypes.append((src_ntype, etype + "-rev", dst_ntype))
+                etypes.append((dst_ntype, etype + "-rev", src_ntype))
                 if 'features' in edge_obj:
                     feat_dims = {}
                     for feat_obj in edge_obj['features']:
@@ -1082,4 +1084,5 @@ def load_metadata_from_json(config_json):
                                      etypes=etypes,
                                      nfeat_dims=nfeat_dims,
                                      efeat_dims=efeat_dims)
+
     return graph_metadata

--- a/python/graphstorm/dataloading/metadata.py
+++ b/python/graphstorm/dataloading/metadata.py
@@ -1014,6 +1014,7 @@ def load_metadata_from_json(config_json):
         # parse edge types
         etypes = []
         efeat_dims = {}
+        add_reverse_edges = config_json['add_reverse_edge'] in ['True', 'true']
         for edge_obj in config_json['edges']:
             etypes.append(tuple(edge_obj['relation']))  # convert a list to tuple as can_etype
             # extract feature name and dimensions if have
@@ -1022,6 +1023,15 @@ def load_metadata_from_json(config_json):
                 for feat_obj in edge_obj['features']:
                     feat_dims[feat_obj['feature_name']] = feat_obj['feature_dim']
                 efeat_dims[tuple(edge_obj['relation'])] = feat_dims
+            if add_reverse_edges:
+                reverse_relation = [edge_obj['relation'][0],
+                                    edge_obj['relation'][1] + "-rev",
+                                    edge_obj['relation'][2]]
+                if 'features' in edge_obj:
+                    feat_dims = {}
+                    for feat_obj in edge_obj['features']:
+                        feat_dims[feat_obj['feature_name']] = feat_obj['feature_dim']
+                    efeat_dims[tuple(reverse_relation)] = feat_dims
     else:
         graph_obj = config_json['graph']
         is_homo = graph_obj['is_homogeneous'] in ['True', 'true']
@@ -1041,6 +1051,7 @@ def load_metadata_from_json(config_json):
         # parse edge types
         etypes = []
         efeat_dims = {}
+        add_reverse_edges = config_json['add_reverse_edge'] in ['True', 'true']
         for edge_obj in graph_obj['edges']:
             src_ntype = edge_obj['source']['type']
             dst_ntype = edge_obj['dest']['type']
@@ -1052,6 +1063,13 @@ def load_metadata_from_json(config_json):
                 for feat_obj in edge_obj['features']:
                     feat_dims[feat_obj['name']] = feat_obj['dim']
                 efeat_dims[(src_ntype, etype, dst_ntype)] = feat_dims
+            if add_reverse_edges:
+                etypes.append((src_ntype, etype + "-rev", dst_ntype))
+                if 'features' in edge_obj:
+                    feat_dims = {}
+                    for feat_obj in edge_obj['features']:
+                        feat_dims[feat_obj['name']] = feat_obj['dim']
+                    efeat_dims[(src_ntype, etype + "-rev", dst_ntype)] = feat_dims
 
     # create the metadata instance
     if is_homo:

--- a/python/graphstorm/dataloading/metadata.py
+++ b/python/graphstorm/dataloading/metadata.py
@@ -765,7 +765,7 @@ def config_json_sanity_check(config_json):
         'A "version" field must be defined in the configuration JSON object.')
     config_version = config_json['version']
     assert 'runtime' in config_version, (
-        'The "version" field must contain a "runtime" field to identify the runtime version.')
+        'The value of the "version" field must contain "runtime" to identify it is a runtime version.')
 
     if config_version.startswith('gconstruct'):
         assert 'is_homogeneous' in config_json, (
@@ -776,7 +776,7 @@ def config_json_sanity_check(config_json):
             f'"false", but got {is_homo}.')
 
         assert "add_reverse_edges" in config_json, (
-            'A "add_reverse_edges" field must be defined in the configuration JSON object.'
+            'An "add_reverse_edges" field must be defined in the configuration JSON object.'
         )
         add_reverse_edges = config_json["add_reverse_edges"]
         assert add_reverse_edges in [True, 'true', False, 'false'], (

--- a/python/graphstorm/gconstruct/construct_graph.py
+++ b/python/graphstorm/gconstruct/construct_graph.py
@@ -1053,7 +1053,7 @@ def print_graph_info(g, node_data, edge_data, node_label_stats, edge_label_stats
 def write_transformed_config(output_conf_file, output_dir, process_confs):
     """
     Write the transformed configuration file. If not specified by output_conf_file,
-    will write to the constructed graph directory.
+    will write to the output graph directory.
 
     Parameters:
     ---------
@@ -1148,7 +1148,7 @@ def process_graph(args):
 
     os.makedirs(args.output_dir, exist_ok=True)
 
-    if args.add_reverse_edges or process_confs.get("add_reverse_edge", False):
+    if args.add_reverse_edges:
         edges1 = {}
         if is_homogeneous(process_confs):
             logging.warning("For homogeneous graph, the generated reverse edge will "
@@ -1183,11 +1183,10 @@ def process_graph(args):
                 assert isinstance(etype, tuple) and len(etype) == 3
                 edges1[etype] = e
                 edges1[etype[2], etype[1] + "-rev", etype[0]] = (e[1], e[0])
-        process_confs["add_reverse_edge"] = True
         edges = edges1
         sys_tracker.check('Add reverse edges')
-    else:
-        process_confs["add_reverse_edge"] = False
+    process_confs["add_reverse_edge"] = args.add_reverse_edge
+
     write_transformed_config(args.output_conf_file, args.output_dir, process_confs)
     g = dgl.heterograph(edges, num_nodes_dict=num_nodes)
     print_graph_info(g, node_data, edge_data, node_label_stats, edge_label_stats,

--- a/python/graphstorm/gconstruct/construct_graph.py
+++ b/python/graphstorm/gconstruct/construct_graph.py
@@ -1107,6 +1107,8 @@ def process_graph(args):
     else:
         logging.warning("Unrecognized configuration file version name: %s",
                         process_confs["version"])
+    # Update version to runtime
+    process_confs["version"] = "gconstruct-runtime-v0.1"
 
     sys_tracker.set_rank(0)
     num_processes_for_nodes = args.num_processes_for_nodes \
@@ -1185,7 +1187,7 @@ def process_graph(args):
                 edges1[etype[2], etype[1] + "-rev", etype[0]] = (e[1], e[0])
         edges = edges1
         sys_tracker.check('Add reverse edges')
-    process_confs["add_reverse_edge"] = args.add_reverse_edge
+    process_confs["add_reverse_edges"] = args.add_reverse_edges
 
     write_transformed_config(args.output_conf_file, args.output_dir, process_confs)
     g = dgl.heterograph(edges, num_nodes_dict=num_nodes)

--- a/python/graphstorm/gconstruct/construct_graph.py
+++ b/python/graphstorm/gconstruct/construct_graph.py
@@ -1132,7 +1132,7 @@ def process_graph(args):
     with open(outfile_path, "w", encoding="utf8") as outfile:
         json.dump(process_confs, outfile, indent=4)
 
-    if args.add_reverse_edges:
+    if args.add_reverse_edges or process_confs.get("add_reverse_edge", False):
         edges1 = {}
         if is_homogeneous(process_confs):
             logging.warning("For homogeneous graph, the generated reverse edge will "
@@ -1167,8 +1167,11 @@ def process_graph(args):
                 assert isinstance(etype, tuple) and len(etype) == 3
                 edges1[etype] = e
                 edges1[etype[2], etype[1] + "-rev", etype[0]] = (e[1], e[0])
+        process_confs["add_reverse_edge"] = True
         edges = edges1
         sys_tracker.check('Add reverse edges')
+    else:
+        process_confs["add_reverse_edge"] = False
     g = dgl.heterograph(edges, num_nodes_dict=num_nodes)
     print_graph_info(g, node_data, edge_data, node_label_stats, edge_label_stats,
                      node_label_masks, edge_label_masks)

--- a/python/graphstorm/gconstruct/construct_graph.py
+++ b/python/graphstorm/gconstruct/construct_graph.py
@@ -1189,7 +1189,7 @@ def process_graph(args):
         sys_tracker.check('Add reverse edges')
     process_confs["add_reverse_edges"] = args.add_reverse_edges
 
-    write_transformed_config(args.output_conf_file, args.output_dir, process_confs)
+    write_transformed_config(args.output_dir, process_confs, args.output_conf_file)
     g = dgl.heterograph(edges, num_nodes_dict=num_nodes)
     print_graph_info(g, node_data, edge_data, node_label_stats, edge_label_stats,
                      node_label_masks, edge_label_masks)

--- a/python/graphstorm/gconstruct/construct_graph.py
+++ b/python/graphstorm/gconstruct/construct_graph.py
@@ -1050,19 +1050,19 @@ def print_graph_info(g, node_data, edge_data, node_label_stats, edge_label_stats
             print_edge_label_stats(etype, label_name, stats)
 
 
-def write_transformed_config(output_conf_file, output_dir, process_confs):
+def write_transformed_config(output_dir, process_confs, output_conf_file=None):
     """
     Write the transformed configuration file. If not specified by output_conf_file,
     will write to the output graph directory.
 
     Parameters:
     ---------
-    output_conf_file: str
-        Path to the output configuration file, default: None
     output_dir: str
         Path to the constructed graph
     process_confs: dict
         GConstruct Transformed Config
+    output_conf_file: str
+        Path to the output configuration file, default: None
     """
     if output_conf_file is not None:
         outfile_path = output_conf_file

--- a/python/graphstorm/gconstruct/construct_graph.py
+++ b/python/graphstorm/gconstruct/construct_graph.py
@@ -1049,6 +1049,39 @@ def print_graph_info(g, node_data, edge_data, node_label_stats, edge_label_stats
         for label_name, stats in edge_label_stats[etype].items():
             print_edge_label_stats(etype, label_name, stats)
 
+
+def write_transformed_config(output_conf_file, output_dir, process_confs):
+    """
+    Write the transformed configuration file. If not specified by output_conf_file,
+    will write to the constructed graph directory.
+
+    Parameters:
+    ---------
+    output_conf_file: str
+        Path to the output configuration file, default: None
+    output_dir: str
+        Path to the constructed graph
+    process_confs: dict
+        GConstruct Transformed Config
+    """
+    if output_conf_file is not None:
+        outfile_path = output_conf_file
+    else:
+        new_file_name = GS_RUNTIME_GCONSTRUCT_FILENAME
+        outfile_path = os.path.join(output_dir, new_file_name)
+
+    # check if the output configuration file exists. Overwrite it with a warning.
+    if os.path.exists(outfile_path):
+        logging.warning('Overwrote the existing %s file, which was generated in ' + \
+                        'the previous graph construction command. Use the --output-conf-file ' + \
+                        'argument to specify a different location if not want to overwrite the ' + \
+                        'existing configuration file.', outfile_path)
+
+    # Save the new config file.
+    with open(outfile_path, "w", encoding="utf8") as outfile:
+        json.dump(process_confs, outfile, indent=4)
+
+
 def process_graph(args):
     """ Process the graph.
     """
@@ -1115,23 +1148,6 @@ def process_graph(args):
 
     os.makedirs(args.output_dir, exist_ok=True)
 
-    if args.output_conf_file is not None:
-        outfile_path = args.output_conf_file
-    else:
-        new_file_name = GS_RUNTIME_GCONSTRUCT_FILENAME
-        outfile_path = os.path.join(args.output_dir, new_file_name)
-
-    # check if the output configuration file exists. Overwrite it with a warning.
-    if os.path.exists(outfile_path):
-        logging.warning('Overwrote the existing %s file, which was generated in ' + \
-                        'the previous graph construction command. Use the --output-conf-file ' + \
-                        'argument to specify a different location if not want to overwrite the ' + \
-                        'existing configuration file.', outfile_path)
-
-    # Save the new config file.
-    with open(outfile_path, "w", encoding="utf8") as outfile:
-        json.dump(process_confs, outfile, indent=4)
-
     if args.add_reverse_edges or process_confs.get("add_reverse_edge", False):
         edges1 = {}
         if is_homogeneous(process_confs):
@@ -1172,6 +1188,7 @@ def process_graph(args):
         sys_tracker.check('Add reverse edges')
     else:
         process_confs["add_reverse_edge"] = False
+    write_transformed_config(args.output_conf_file, args.output_dir, process_confs)
     g = dgl.heterograph(edges, num_nodes_dict=num_nodes)
     print_graph_info(g, node_data, edge_data, node_label_stats, edge_label_stats,
                      node_label_masks, edge_label_masks)

--- a/tests/sagemaker-tests/test_sagemaker_entry.py
+++ b/tests/sagemaker-tests/test_sagemaker_entry.py
@@ -144,7 +144,7 @@ def create_realtime_yaml_object(tmpdirname):
 
     return gs_config
 
-def create_realtime_json_oject(tmpdirname):
+def create_realtime_json_object(tmpdirname):
     """ Create a graph construction json file to build GraphFromMetadata
     """
     json_object = \
@@ -224,7 +224,8 @@ def create_realtime_json_oject(tmpdirname):
                         "files":        "/data/ml-100k/edges_rev.parquet",
                 }
         ],
-        "is_homogeneous": "false"
+        "is_homogeneous": "false",
+        "add_reverse_edge": "true"
     }
     with open(os.path.join(tmpdirname, "ml.json"), "w") as f:
         json.dump(json_object, f, indent=4)
@@ -239,7 +240,7 @@ def create_realtime_np_model(tmpdirname, model_error=False):
 
     This basic configuration is a subset of the `training_scripts/gsgnn_np/ml_nc.yaml`.
     """
-    gs_json = create_realtime_json_oject(tmpdirname)
+    gs_json = create_realtime_json_object(tmpdirname)
     gs_config = create_realtime_yaml_object(tmpdirname)
 
     gs_metadata = load_metadata_from_json(gs_json)

--- a/tests/sagemaker-tests/test_sagemaker_entry.py
+++ b/tests/sagemaker-tests/test_sagemaker_entry.py
@@ -225,7 +225,7 @@ def create_realtime_json_object(tmpdirname):
                 }
         ],
         "is_homogeneous": "false",
-        "add_reverse_edge": "true"
+        "add_reverse_edges": "true"
     }
     with open(os.path.join(tmpdirname, "ml.json"), "w") as f:
         json.dump(json_object, f, indent=4)

--- a/tests/sagemaker-tests/test_sagemaker_entry.py
+++ b/tests/sagemaker-tests/test_sagemaker_entry.py
@@ -149,7 +149,7 @@ def create_realtime_json_object(tmpdirname):
     """
     json_object = \
     {
-        "version": "gconstruct-v0.1",
+        "version": "gconstruct-runtime-v0.1",
         "nodes": [
                 {
                         "node_id_col":  "id",

--- a/tests/unit-tests/data_utils.py
+++ b/tests/unit-tests/data_utils.py
@@ -57,7 +57,7 @@ def convert_tensor_to_list_arrays(tensor):
 
     return list_array
 
-def create_dummy_hetero_graph_config(tmp_dir, graph, save_data=False, add_reverse_edge=False):
+def create_dummy_hetero_graph_config(tmp_dir, graph, save_data=False):
     """ Build the new JSON file from a gcontruct for tests
     """
     # generate node dataframe: we use the graph node ids and node name as node_type
@@ -243,7 +243,7 @@ def create_dummy_hetero_graph_config(tmp_dir, graph, save_data=False, add_revers
         data_json['is_homogeneous'] = True
     else:
         data_json['is_homogeneous'] = False
-    data_json['add_reverse_edge'] = add_reverse_edge
+    data_json["add_reverse_edges"] = False
     data_json['nodes'] = node_jsons
     data_json['edges'] = edge_jsons
         

--- a/tests/unit-tests/data_utils.py
+++ b/tests/unit-tests/data_utils.py
@@ -57,7 +57,7 @@ def convert_tensor_to_list_arrays(tensor):
 
     return list_array
 
-def create_dummy_hetero_graph_config(tmp_dir, graph, save_data=False):
+def create_dummy_hetero_graph_config(tmp_dir, graph, save_data=False, add_reverse_edge=False):
     """ Build the new JSON file from a gcontruct for tests
     """
     # generate node dataframe: we use the graph node ids and node name as node_type
@@ -235,7 +235,7 @@ def create_dummy_hetero_graph_config(tmp_dir, graph, save_data=False):
             edge_dict['labels'] = labels_list
         
         edge_jsons.append(edge_dict)
-        
+
     # generate the configuration JSON file
     data_json = {}
     data_json['version'] = 'gconstruct-v0.1'
@@ -243,6 +243,7 @@ def create_dummy_hetero_graph_config(tmp_dir, graph, save_data=False):
         data_json['is_homogeneous'] = True
     else:
         data_json['is_homogeneous'] = False
+    data_json['add_reverse_edge'] = add_reverse_edge
     data_json['nodes'] = node_jsons
     data_json['edges'] = edge_jsons
         

--- a/tests/unit-tests/data_utils.py
+++ b/tests/unit-tests/data_utils.py
@@ -238,7 +238,7 @@ def create_dummy_hetero_graph_config(tmp_dir, graph, save_data=False):
 
     # generate the configuration JSON file
     data_json = {}
-    data_json['version'] = 'gconstruct-v0.1'
+    data_json['version'] = 'gconstruct-runtime-v0.1'
     if len(node_list) == 1 and len(edge_list) == 1:
         data_json['is_homogeneous'] = True
     else:
@@ -754,6 +754,92 @@ def generate_dummy_homogeneous_failure_graph(size='tiny', gen_mask=True, type='n
     return hetero_graph
 
 
+def generate_dummy_hetero_graph_hete_rev_edge(size='tiny', gen_mask=True):
+    """
+    Generate a dummy heterogeneous graph with reverse edges. GraphStorm output graph will
+    save the reverse edge type as <orig-edge-type>-rev.
+    """
+    size_dict = SIZE_DICT
+    data_size = int(size_dict[size])
+
+    num_nodes_dict = {
+        "n0": data_size,
+        "n1": data_size,
+    }
+
+    edges = {
+        ("n0", "r0", "n1"): (th.randint(data_size, (data_size,)),
+                             th.randint(data_size, (data_size,))),
+        ("n0", "r1", "n1"): (th.randint(data_size, (2 * data_size,)),
+                             th.randint(data_size, (2 * data_size,))),
+    }
+    edges[("n1", "r0-rev", "n0")] = (edges[("n0", "r0", "n1")][1], edges[("n0", "r0", "n1")][0])
+    edges[("n1", "r1-rev", "n0")] = (edges[("n0", "r1", "n1")][1], edges[("n0", "r1", "n1")][0])
+
+    hetero_graph = dgl.heterograph(edges, num_nodes_dict=num_nodes_dict)
+
+    # set node and edge features
+    node_feat = {'n0': th.randn(data_size, 2),
+                 'n1': th.randn(data_size, 2)}
+    node_feat1 = {'n0': th.randn(data_size, 4),
+                 'n1': th.randn(data_size, 4)}
+
+    edge_feat = {'r0': th.randn(data_size, 2),
+                 'r1': th.randn(2 * data_size, 2)}
+    edge_feat['r0-rev'] = edge_feat['r0']
+    edge_feat['r1-rev'] = edge_feat['r1']
+
+    hetero_graph.nodes['n0'].data['feat'] = node_feat['n0']
+    hetero_graph.nodes['n1'].data['feat'] = node_feat['n1']
+    hetero_graph.nodes['n0'].data['feat1'] = node_feat1['n0']
+    hetero_graph.nodes['n1'].data['feat1'] = node_feat1['n1']
+    hetero_graph.nodes['n1'].data['label'] = th.randint(10, (hetero_graph.number_of_nodes('n1'), ))
+
+    hetero_graph.edges['r0'].data['feat'] = edge_feat['r0']
+    hetero_graph.edges['r1'].data['feat'] = edge_feat['r1']
+    hetero_graph.edges['r0-rev'].data['feat'] = edge_feat['r0']
+    hetero_graph.edges['r1-rev'].data['feat'] = edge_feat['r1']
+    hetero_graph.edges['r1'].data['label'] = th.randint(10, (hetero_graph.number_of_edges('r1'), ))
+
+    # set train/val/test masks for nodes and edges
+    if gen_mask:
+        target_ntype = ['n1']
+        target_etype = [("n0", "r1", "n1"), ("n0", "r0", "n1")]
+
+        node_train_mask = generate_mask([0,1], data_size)
+        node_val_mask = generate_mask([2,3], data_size)
+        node_test_mask = generate_mask([4,5], data_size)
+        node_val_mask2 = generate_mask([2], data_size)
+        node_test_mask2 = generate_mask([4], data_size)
+
+        edge_train_mask = generate_mask([0,1], 2 * data_size)
+        edge_val_mask = generate_mask([2,3], 2 * data_size)
+        edge_test_mask = generate_mask([4,5], 2 * data_size)
+        edge_val_mask_2 = generate_mask([2], 2 * data_size)
+        edge_test_mask_2 = generate_mask([4], 2 * data_size)
+
+        edge_train_mask2 = generate_mask([i for i in range(data_size//2)], data_size)
+        edge_val_mask2 = generate_mask([2,3], data_size)
+        edge_test_mask2 = generate_mask([4,5], data_size)
+
+        hetero_graph.nodes[target_ntype[0]].data['train_mask'] = node_train_mask
+        hetero_graph.nodes[target_ntype[0]].data['val_mask'] = node_val_mask
+        hetero_graph.nodes[target_ntype[0]].data['test_mask'] = node_test_mask
+        hetero_graph.nodes[target_ntype[0]].data['val_mask2'] = node_val_mask2
+        hetero_graph.nodes[target_ntype[0]].data['test_mask2'] = node_test_mask2
+
+        hetero_graph.edges[target_etype[0]].data['train_mask'] = edge_train_mask
+        hetero_graph.edges[target_etype[0]].data['val_mask'] = edge_val_mask
+        hetero_graph.edges[target_etype[0]].data['test_mask'] = edge_test_mask
+        hetero_graph.edges[target_etype[0]].data['val_mask2'] = edge_val_mask_2
+        hetero_graph.edges[target_etype[0]].data['test_mask2'] = edge_test_mask_2
+
+        hetero_graph.edges[target_etype[1]].data['train_mask'] = edge_train_mask2
+        hetero_graph.edges[target_etype[1]].data['val_mask'] = edge_val_mask2
+        hetero_graph.edges[target_etype[1]].data['test_mask'] = edge_test_mask2
+
+    return hetero_graph
+
 def partion_and_load_distributed_graph(hetero_graph, dirname, graph_name='dummy'):
     """
     Partition a heterogeneous graph into a temporal directory, and reload it as a distributed graph
@@ -911,6 +997,33 @@ def generate_dummy_dist_graph_homogeneous_failure_graph(dirname, size='tiny', gr
     hetero_graph = generate_dummy_homogeneous_failure_graph(size=size, gen_mask=gen_mask, type=type)
     return partion_and_load_distributed_graph(hetero_graph=hetero_graph, dirname=dirname,
                                               graph_name=graph_name)
+
+
+def generate_dummy_dist_graph_hete_rev_edge(dirname, size='tiny', graph_name='dummy',
+                                            return_graph_config=True):
+    """
+    Generate a dummy heterogeneous graph for restoring model artifacts.
+    Parameters
+    ----------
+    dirname : str
+        the directory where the graph will be partitioned and stored.
+    size: str
+        the size of dummy graph data, could be one of tiny, small, medium, large, and largest
+    graph_name: string
+        graph name
+    return_graph_config: bool
+        if return graph construction config
+    """
+    hetero_graph = generate_dummy_hetero_graph_hete_rev_edge(size=size)
+    dist_g, part_config = partion_and_load_distributed_graph(hetero_graph=hetero_graph, dirname=dirname,
+                                              graph_name=graph_name)
+
+    if return_graph_config:
+        graph_config_new = create_dummy_hetero_graph_config(dirname, hetero_graph)
+        return dist_g, part_config, graph_config_new
+    else:
+        return dist_g, part_config
+
 
 def load_lm_graph(part_config):
     with open(part_config) as f:

--- a/tests/unit-tests/test_gsf.py
+++ b/tests/unit-tests/test_gsf.py
@@ -15,8 +15,6 @@
 
 import os
 import json
-from audioop import reverse
-
 import yaml
 import pytest
 import tempfile

--- a/tests/unit-tests/test_gsf.py
+++ b/tests/unit-tests/test_gsf.py
@@ -880,8 +880,7 @@ def test_restore_builtin_model_from_artifacts():
         # create a dummy gdsg dist graph
         g, _, graph_config = generate_dummy_dist_graph(tmpdirname,
                                                        graph_name='test',
-                                                       return_graph_config=True,
-                                                       add_reverse=True)
+                                                       return_graph_config=True)
         # create dummy YAML config 
         yaml_object = create_dummy_config_obj()
         yaml_object["gsf"]["basic"] = {
@@ -925,6 +924,7 @@ def test_restore_builtin_model_from_artifacts():
 
         # restore the model from the current temp file
         graph_config_file = os.path.basename(graph_config)
+        
         nc_model, _, _ = restore_builtin_model_from_artifacts(tmpdirname, graph_config_file, 'nc_basic.yaml')
 
         assert nc_model.gnn_encoder.num_layers == yaml_object["gsf"]["gnn"]["num_layers"]

--- a/tests/unit-tests/test_gsf.py
+++ b/tests/unit-tests/test_gsf.py
@@ -76,7 +76,9 @@ from graphstorm.model.loss_func import (ClassifyLossFunc,
                                         FocalLossFunc,
                                         ShrinkageLossFunc)
 
-from data_utils import generate_dummy_dist_graph, generate_dummy_hetero_graph
+from data_utils import (generate_dummy_dist_graph,
+                        generate_dummy_hetero_graph,
+                        generate_dummy_dist_graph_hete_rev_edge)
 from config_utils import create_dummy_config_obj
 
 
@@ -869,16 +871,22 @@ def test_get_edge_feat_size():
         edge_feat_size = {}
     assert edge_feat_size == {}
 
-def test_restore_builtin_model_from_artifacts():
+@pytest.mark.parametrize("add_reverse_edges", [False, True])
+def test_restore_builtin_model_from_artifacts(add_reverse_edges):
     """ Test restore a builtin mode from artifacts
     
     The test needs three inputs: 1/ model dir path, 2/ josn file name, 3/ yaml file name.
     """
     with tempfile.TemporaryDirectory() as tmpdirname:
         # create a dummy gdsg dist graph
-        g, _, graph_config = generate_dummy_dist_graph(tmpdirname,
+        if not add_reverse_edges:
+            g, _, graph_config = generate_dummy_dist_graph(tmpdirname,
                                                        graph_name='test',
                                                        return_graph_config=True)
+        else:
+            g, _, graph_config = generate_dummy_dist_graph_hete_rev_edge(tmpdirname,
+                                                                         graph_name='test',
+                                                                         return_graph_config=True)
         # create dummy YAML config 
         yaml_object = create_dummy_config_obj()
         yaml_object["gsf"]["basic"] = {
@@ -922,7 +930,7 @@ def test_restore_builtin_model_from_artifacts():
 
         # restore the model from the current temp file
         graph_config_file = os.path.basename(graph_config)
-        
+
         nc_model, _, _ = restore_builtin_model_from_artifacts(tmpdirname, graph_config_file, 'nc_basic.yaml')
 
         assert nc_model.gnn_encoder.num_layers == yaml_object["gsf"]["gnn"]["num_layers"]

--- a/tests/unit-tests/test_gsf.py
+++ b/tests/unit-tests/test_gsf.py
@@ -15,6 +15,8 @@
 
 import os
 import json
+from audioop import reverse
+
 import yaml
 import pytest
 import tempfile
@@ -878,8 +880,8 @@ def test_restore_builtin_model_from_artifacts():
         # create a dummy gdsg dist graph
         g, _, graph_config = generate_dummy_dist_graph(tmpdirname,
                                                        graph_name='test',
-                                                       return_graph_config=True)
-
+                                                       return_graph_config=True,
+                                                       add_reverse=True)
         # create dummy YAML config 
         yaml_object = create_dummy_config_obj()
         yaml_object["gsf"]["basic"] = {
@@ -923,7 +925,6 @@ def test_restore_builtin_model_from_artifacts():
 
         # restore the model from the current temp file
         graph_config_file = os.path.basename(graph_config)
-
         nc_model, _, _ = restore_builtin_model_from_artifacts(tmpdirname, graph_config_file, 'nc_basic.yaml')
 
         assert nc_model.gnn_encoder.num_layers == yaml_object["gsf"]["gnn"]["num_layers"]

--- a/tests/unit-tests/test_metadata.py
+++ b/tests/unit-tests/test_metadata.py
@@ -1103,8 +1103,10 @@ def test_config_json_santiy_check():
     with pytest.raises(NotImplementedError, match='GSGraphMetadata can only be loaded'):
         config_json_sanity_check(gcont_config_json)
 
-def test_load_metadata_from_json():
-    """ Test the load function of json to mateadata.
+
+@pytest.mark.parametrize("add_reverse_edge", [False, True])
+def test_load_metadata_from_json(add_reverse_edge):
+    """ Test the load function of json to metadata.
     
     All field and value checks are done via the config json sanity check function. So will
     test normal cases only.
@@ -1114,6 +1116,7 @@ def test_load_metadata_from_json():
     with tempfile.TemporaryDirectory() as tmpdirname:
         # heterograph
         config_json_hetero = build_gcons_json_example(gtype='heterogeneous')
+        config_json_hetero["add_reverse_edge"] = add_reverse_edge
         with open(os.path.join(tmpdirname, 'gconstruct_acm_output_config_hetero.json'), "w") as f:
             json.dump(config_json_hetero, f, indent=4)
 
@@ -1128,10 +1131,13 @@ def test_load_metadata_from_json():
                            ('paper', 'is-about', 'subject'),
                            ('paper', 'written-by', 'author'),
                            ('subject', 'has', 'paper')]
+        if add_reverse_edge:
+            rev_expected_etypes = [(i[2], i[1] + '-rev', i[0]) for i in expected_etypes]
+            expected_etypes = expected_etypes + rev_expected_etypes
         assert not gmd.is_homogeneous()
         assert sorted(gmd.get_ntypes()) == sorted(expected_ntypes)
         assert set(gmd.get_etypes()) == set(expected_etypes)
-        # predefined ntype shoud be in the metadata
+        # predefined ntype should be in the metadata
         assert all([gmd.has_ntype(ntype) for ntype in expected_ntypes])
         assert all([gmd.has_etype(etype) for etype in expected_etypes])
         # not predefined types should return False
@@ -1151,6 +1157,9 @@ def test_load_metadata_from_json():
             ('paper', 'written-by', 'author'): None,
             ('subject', 'has', 'paper'): None
         }
+        if add_reverse_edge:
+            rev_expected_efeat_dims = {(k[2], k[1] + '-rev', k[0]): v for k, v in expected_efeat_dims.items()}
+            expected_efeat_dims.update(rev_expected_efeat_dims)
         # test feature info
         assert all([gmd.get_nfeat_all_dims(ntype)==nfeat_dims \
                     for ntype, nfeat_dims in expected_nfeat_dims.items()])
@@ -1159,6 +1168,7 @@ def test_load_metadata_from_json():
 
         # homograph
         config_json_homo = build_gcons_json_example(gtype='homogeneous')
+        config_json_homo["add_reverse_edge"] = add_reverse_edge
         with open(os.path.join(tmpdirname, 'gconstruct_acm_output_config_homo.json'), "w") as f:
             json.dump(config_json_homo, f, indent=4)
 
@@ -1182,6 +1192,7 @@ def test_load_metadata_from_json():
     with tempfile.TemporaryDirectory() as tmpdirname:
         # heterograph
         config_json_hetero = build_gsproc_json_example(gtype='heterogeneous')
+        config_json_hetero["graph"]["add_reverse_edge"] = add_reverse_edge
         with open(os.path.join(tmpdirname, 'gsprocess_acm_output_config_hetero.json'), "w") as f:
             json.dump(config_json_hetero, f, indent=4)
 
@@ -1196,6 +1207,9 @@ def test_load_metadata_from_json():
                            ('paper', 'is-about', 'subject'),
                            ('paper', 'written-by', 'author'),
                            ('subject', 'has', 'paper')]
+        if add_reverse_edge:
+            rev_expected_etypes = [(i[2], i[1] + '-rev', i[0]) for i in expected_etypes]
+            expected_etypes = expected_etypes + rev_expected_etypes
         assert not gmd.is_homogeneous()
         assert sorted(gmd.get_ntypes()) == sorted(expected_ntypes)
         assert set(gmd.get_etypes()) == set(expected_etypes)
@@ -1219,6 +1233,9 @@ def test_load_metadata_from_json():
             ('paper', 'written-by', 'author'): None,
             ('subject', 'has', 'paper'): None
         }
+        if add_reverse_edge:
+            rev_expected_efeat_dims = {(k[2], k[1] + '-rev', k[0]): v for k, v in expected_efeat_dims.items()}
+            expected_efeat_dims.update(rev_expected_efeat_dims)
         # test feature info
         assert all([gmd.get_nfeat_all_dims(ntype)==nfeat_dims \
                     for ntype, nfeat_dims in expected_nfeat_dims.items()])
@@ -1227,6 +1244,7 @@ def test_load_metadata_from_json():
 
         # homograph
         config_json_homo = build_gsproc_json_example(gtype='homogeneous')
+        config_json_homo["graph"]["add_reverse_edge"] = add_reverse_edge
         with open(os.path.join(tmpdirname, 'gsprocess_acm_output_config_homo.json'), "w") as f:
             json.dump(config_json_homo, f, indent=4)
 

--- a/tests/unit-tests/test_metadata.py
+++ b/tests/unit-tests/test_metadata.py
@@ -918,7 +918,7 @@ def test_config_json_santiy_check():
 
     gcont_config_json = build_gcons_json_example()
     gcont_config_json.pop('add_reverse_edges')
-    with pytest.raises(AssertionError, match='A \"add_reverse_edges\" field must be defined'):
+    with pytest.raises(AssertionError, match='An \"add_reverse_edges\" field must be defined'):
         config_json_sanity_check(gcont_config_json)
 
     gcont_config_json = build_gcons_json_example()

--- a/tests/unit-tests/test_metadata.py
+++ b/tests/unit-tests/test_metadata.py
@@ -228,7 +228,7 @@ def build_gcons_json_example(gtype='heterogeneous'):
                 "dest_id_col": "dest_id"
             }
         ],
-        "add_reverse_edge": "true",
+        "add_reverse_edge": "false",
         "is_homogeneous": "false"
     }
     elif gtype == 'homogeneous':

--- a/tests/unit-tests/test_metadata.py
+++ b/tests/unit-tests/test_metadata.py
@@ -902,8 +902,8 @@ def test_config_json_santiy_check():
 
     gcont_config_json = build_gcons_json_example()
     gcont_config_json['version'] = 'gconstruct-v1.0'
-    with pytest.raises(AssertionError, match='The \"version\" field must contain a \"runtime\" '
-                                             'field to identify the runtime version.'):
+    with pytest.raises(AssertionError, match='The value of the \"version\" field must contain '
+                                             '\"runtime\" to identify it is a runtime version.'):
         config_json_sanity_check(gcont_config_json)
 
     gcont_config_json = build_gcons_json_example()

--- a/tests/unit-tests/test_metadata.py
+++ b/tests/unit-tests/test_metadata.py
@@ -228,6 +228,7 @@ def build_gcons_json_example(gtype='heterogeneous'):
                 "dest_id_col": "dest_id"
             }
         ],
+        "add_reverse_edge": "true",
         "is_homogeneous": "false"
     }
     elif gtype == 'homogeneous':
@@ -313,6 +314,7 @@ def build_gcons_json_example(gtype='heterogeneous'):
                     ]
                 },
             ],
+            "add_reverse_edge": "false",
             "is_homogeneous": "true"
         }
     else:
@@ -329,6 +331,7 @@ def build_gsproc_json_example(gtype='heterogeneous'):
     if gtype == 'heterogeneous':
         conf = {
         "graph": {
+            "add_reverse_edge": "false",
             "nodes": [
                 {
                     "data": {
@@ -581,6 +584,7 @@ def build_gsproc_json_example(gtype='heterogeneous'):
     elif gtype == 'homogeneous':
         conf = {
         "graph": {
+            "add_reverse_edge": "false",
             "nodes": [
                 {
                     "data": {

--- a/tests/unit-tests/test_metadata.py
+++ b/tests/unit-tests/test_metadata.py
@@ -228,7 +228,7 @@ def build_gcons_json_example(gtype='heterogeneous'):
                 "dest_id_col": "dest_id"
             }
         ],
-        "add_reverse_edge": "false",
+        "add_reverse_edges": "false",
         "is_homogeneous": "false"
     }
     elif gtype == 'homogeneous':
@@ -314,7 +314,7 @@ def build_gcons_json_example(gtype='heterogeneous'):
                     ]
                 },
             ],
-            "add_reverse_edge": "false",
+            "add_reverse_edges": "false",
             "is_homogeneous": "true"
         }
     else:
@@ -331,7 +331,7 @@ def build_gsproc_json_example(gtype='heterogeneous'):
     if gtype == 'heterogeneous':
         conf = {
         "graph": {
-            "add_reverse_edge": "false",
+            "add_reverse_edges": "false",
             "nodes": [
                 {
                     "data": {
@@ -584,7 +584,7 @@ def build_gsproc_json_example(gtype='heterogeneous'):
     elif gtype == 'homogeneous':
         conf = {
         "graph": {
-            "add_reverse_edge": "false",
+            "add_reverse_edges": "false",
             "nodes": [
                 {
                     "data": {
@@ -907,7 +907,17 @@ def test_config_json_santiy_check():
 
     gcont_config_json = build_gcons_json_example()
     gcont_config_json['is_homogeneous'] = 'Yes'
-    with pytest.raises(AssertionError, match='The value of \"is_homogeneous\" can only be'):
+    with pytest.raises(AssertionError, match='The value of \"is_homogeneous\" can only be True/False'):
+        config_json_sanity_check(gcont_config_json)
+
+    gcont_config_json = build_gcons_json_example()
+    gcont_config_json.pop('add_reverse_edges')
+    with pytest.raises(AssertionError, match='A \"add_reverse_edges\" field must be defined'):
+        config_json_sanity_check(gcont_config_json)
+
+    gcont_config_json = build_gcons_json_example()
+    gcont_config_json['add_reverse_edges'] = 'Yes'
+    with pytest.raises(AssertionError, match='The value of \"add_reverse_edges\" can only be True/False'):
         config_json_sanity_check(gcont_config_json)
 
     gcont_config_json = build_gcons_json_example()
@@ -1104,9 +1114,10 @@ def test_config_json_santiy_check():
         config_json_sanity_check(gcont_config_json)
 
 
-@pytest.mark.parametrize("add_reverse_edge", [False, True])
-def test_load_metadata_from_json(add_reverse_edge):
+@pytest.mark.parametrize("add_reverse_edges", [False, True])
+def test_load_metadata_from_json(add_reverse_edges):
     """ Test the load function of json to metadata.
+    For each following case, test with/without reverse edges.
     
     All field and value checks are done via the config json sanity check function. So will
     test normal cases only.
@@ -1116,7 +1127,7 @@ def test_load_metadata_from_json(add_reverse_edge):
     with tempfile.TemporaryDirectory() as tmpdirname:
         # heterograph
         config_json_hetero = build_gcons_json_example(gtype='heterogeneous')
-        config_json_hetero["add_reverse_edge"] = add_reverse_edge
+        config_json_hetero["add_reverse_edges"] = add_reverse_edges
         with open(os.path.join(tmpdirname, 'gconstruct_acm_output_config_hetero.json'), "w") as f:
             json.dump(config_json_hetero, f, indent=4)
 
@@ -1131,7 +1142,7 @@ def test_load_metadata_from_json(add_reverse_edge):
                            ('paper', 'is-about', 'subject'),
                            ('paper', 'written-by', 'author'),
                            ('subject', 'has', 'paper')]
-        if add_reverse_edge:
+        if add_reverse_edges:
             rev_expected_etypes = [(i[2], i[1] + '-rev', i[0]) for i in expected_etypes]
             expected_etypes = expected_etypes + rev_expected_etypes
         assert not gmd.is_homogeneous()
@@ -1157,7 +1168,7 @@ def test_load_metadata_from_json(add_reverse_edge):
             ('paper', 'written-by', 'author'): None,
             ('subject', 'has', 'paper'): None
         }
-        if add_reverse_edge:
+        if add_reverse_edges:
             rev_expected_efeat_dims = {(k[2], k[1] + '-rev', k[0]): v for k, v in expected_efeat_dims.items()}
             expected_efeat_dims.update(rev_expected_efeat_dims)
         # test feature info
@@ -1168,7 +1179,7 @@ def test_load_metadata_from_json(add_reverse_edge):
 
         # homograph
         config_json_homo = build_gcons_json_example(gtype='homogeneous')
-        config_json_homo["add_reverse_edge"] = add_reverse_edge
+        config_json_homo["add_reverse_edges"] = add_reverse_edges
         with open(os.path.join(tmpdirname, 'gconstruct_acm_output_config_homo.json'), "w") as f:
             json.dump(config_json_homo, f, indent=4)
 
@@ -1192,7 +1203,7 @@ def test_load_metadata_from_json(add_reverse_edge):
     with tempfile.TemporaryDirectory() as tmpdirname:
         # heterograph
         config_json_hetero = build_gsproc_json_example(gtype='heterogeneous')
-        config_json_hetero["graph"]["add_reverse_edge"] = add_reverse_edge
+        config_json_hetero["graph"]["add_reverse_edges"] = add_reverse_edges
         with open(os.path.join(tmpdirname, 'gsprocess_acm_output_config_hetero.json'), "w") as f:
             json.dump(config_json_hetero, f, indent=4)
 
@@ -1207,7 +1218,7 @@ def test_load_metadata_from_json(add_reverse_edge):
                            ('paper', 'is-about', 'subject'),
                            ('paper', 'written-by', 'author'),
                            ('subject', 'has', 'paper')]
-        if add_reverse_edge:
+        if add_reverse_edges:
             rev_expected_etypes = [(i[2], i[1] + '-rev', i[0]) for i in expected_etypes]
             expected_etypes = expected_etypes + rev_expected_etypes
         assert not gmd.is_homogeneous()
@@ -1233,7 +1244,7 @@ def test_load_metadata_from_json(add_reverse_edge):
             ('paper', 'written-by', 'author'): None,
             ('subject', 'has', 'paper'): None
         }
-        if add_reverse_edge:
+        if add_reverse_edges:
             rev_expected_efeat_dims = {(k[2], k[1] + '-rev', k[0]): v for k, v in expected_efeat_dims.items()}
             expected_efeat_dims.update(rev_expected_efeat_dims)
         # test feature info
@@ -1244,7 +1255,7 @@ def test_load_metadata_from_json(add_reverse_edge):
 
         # homograph
         config_json_homo = build_gsproc_json_example(gtype='homogeneous')
-        config_json_homo["graph"]["add_reverse_edge"] = add_reverse_edge
+        config_json_homo["graph"]["add_reverse_edges"] = add_reverse_edges
         with open(os.path.join(tmpdirname, 'gsprocess_acm_output_config_homo.json'), "w") as f:
             json.dump(config_json_homo, f, indent=4)
 

--- a/tests/unit-tests/test_metadata.py
+++ b/tests/unit-tests/test_metadata.py
@@ -907,7 +907,7 @@ def test_config_json_santiy_check():
 
     gcont_config_json = build_gcons_json_example()
     gcont_config_json['is_homogeneous'] = 'Yes'
-    with pytest.raises(AssertionError, match='The value of \"is_homogeneous\" can only be True/False'):
+    with pytest.raises(AssertionError, match='The value of \"is_homogeneous\" can only be'):
         config_json_sanity_check(gcont_config_json)
 
     gcont_config_json = build_gcons_json_example()
@@ -917,7 +917,7 @@ def test_config_json_santiy_check():
 
     gcont_config_json = build_gcons_json_example()
     gcont_config_json['add_reverse_edges'] = 'Yes'
-    with pytest.raises(AssertionError, match='The value of \"add_reverse_edges\" can only be True/False'):
+    with pytest.raises(AssertionError, match='The value of \"add_reverse_edges\" can only be'):
         config_json_sanity_check(gcont_config_json)
 
     gcont_config_json = build_gcons_json_example()

--- a/tests/unit-tests/test_metadata.py
+++ b/tests/unit-tests/test_metadata.py
@@ -34,7 +34,7 @@ def build_gcons_json_example(gtype='heterogeneous'):
     """
     if gtype == 'heterogeneous':
         conf = {
-        "version": "gconstruct-v0.1",
+        "version": "gconstruct-runtime-v0.1",
         "nodes": [
             {
                 "node_type": "author",
@@ -233,7 +233,7 @@ def build_gcons_json_example(gtype='heterogeneous'):
     }
     elif gtype == 'homogeneous':
         conf = {
-            "version": "gconstruct-v0.1",
+            "version": "gconstruct-runtime-v0.1",
             "nodes": [
                 {
                     "node_type": "_N",
@@ -579,7 +579,7 @@ def build_gsproc_json_example(gtype='heterogeneous'):
             ],
             "is_homogeneous": "false"
         },
-        "version": "gsprocessing-v1.0"
+        "version": "gsprocessing-runtime-v1.0"
     }
     elif gtype == 'homogeneous':
         conf = {
@@ -693,7 +693,7 @@ def build_gsproc_json_example(gtype='heterogeneous'):
             ],
             "is_homogeneous": "true"
         },
-        "version": "gsprocessing-v1.0"
+        "version": "gsprocessing-runtime-v1.0"
     }
     else:
         raise NotImplementedError('Only support \"heterogeneous\" and \"homogeneous\" options.' \
@@ -898,6 +898,12 @@ def test_config_json_santiy_check():
     gcont_config_json = build_gcons_json_example()
     gcont_config_json.pop('version')
     with pytest.raises(AssertionError, match='A \"version\" field must be defined in the'):
+        config_json_sanity_check(gcont_config_json)
+
+    gcont_config_json = build_gcons_json_example()
+    gcont_config_json['version'] = 'gconstruct-v1.0'
+    with pytest.raises(AssertionError, match='The \"version\" field must contain a \"runtime\" '
+                                             'field to identify the runtime version.'):
         config_json_sanity_check(gcont_config_json)
 
     gcont_config_json = build_gcons_json_example()
@@ -1109,7 +1115,7 @@ def test_config_json_santiy_check():
         config_json_sanity_check(gsproc_config_json)
 
     gcont_config_json = build_gcons_json_example()
-    gcont_config_json['version'] = 'another_version'
+    gcont_config_json['version'] = 'another_version-runtime'
     with pytest.raises(NotImplementedError, match='GSGraphMetadata can only be loaded'):
         config_json_sanity_check(gcont_config_json)
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
* Add `add_reverse_edge` flag to handle the reverse edge case for real time inference endpoint. It will resolve the model loading issue during real time inference.
* Update the version string for gconstruct/gsprocessing.
* Test successfully on sagemaker with acm data.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
