### PR TITLE
[Bug] Revise ``targets`` level in real-time inference specification

### DIFF
--- a/docs/source/cli/model-training-inference/real-time-inference-spec.rst
+++ b/docs/source/cli/model-training-inference/real-time-inference-spec.rst
@@ -44,7 +44,8 @@ A ``graph`` object contains two objects: ``nodes``, and ``edges``.
 - ``nodes`` -- (array of JSON objects) Each object specifies a ``node`` object. 
 - ``edges`` -- (array of JSON objects) Each object specifies an ``edge`` object.
 
-**Contents of a ``node`` object listed in a ``nodes`` array**
+Contents of a ``node`` object listed in a ``nodes`` array
+**********************************************************
 
 A ``node`` object listed in a ``nodes`` array can contain the following required fields.
 
@@ -69,7 +70,8 @@ A ``node`` object listed in a ``nodes`` array can contain the following required
   <gconstruction-json>`, or the ``name`` values of ``features`` fields defined in
   :ref:`GSProcessing JSON specification <gsprocessing_input_configuration>`.
 
-**Contents of an ``edge`` object listed in an ``edges`` array**
+Contents of an ``edge`` object listed in an ``edges`` array
+************************************************************
 
 An ``edge`` object listed in an ``edges`` array must contain the following required fields.
 

--- a/docs/source/cli/model-training-inference/real-time-inference-spec.rst
+++ b/docs/source/cli/model-training-inference/real-time-inference-spec.rst
@@ -9,15 +9,16 @@ Specification of Real-time Inference Request and Response
 Specification of Request Payload Contents 
 ------------------------------------------
 
-A payload should be a JSON object. In the highest level, the JSON object contains three fields:
-``version``, ``gml_task``, and ``graph``.
+A payload should be a JSON object. In the highest level, the JSON object contains four fields:
+``version``, ``gml_task``, ``graph``, and ``targets``.
 
 .. code:: json
 
     {
         "version"   : string,
         "gml_task"  : string,
-        "graph"     : [ ... ]
+        "graph"     : object,
+        "targets"   : [ ... ]
     }
 
 - ``version`` -- (String, required) The version of payload to be used. The current version is ``gs-realtime-v0.1``.
@@ -25,29 +26,26 @@ A payload should be a JSON object. In the highest level, the JSON object contain
   supports two options: 
     * ``node_classification``
     * ``node_regression``
-- ``graph`` -- (JSON objects, required) The contents of a payload, with "nodes", "edges" and "targets" keys. See below for details.
-
+- ``graph`` -- (JSON objects, required) The contents of a payload, with "nodes", and "edges" keys. See below for details.
+- ``targets`` -- (Array of JSON objects, required) The contents of target nodes or edges for prediciton.
 
 Contents of objects in the ``graph`` field
-........................................... 
+...........................................
 
-A ``graph`` object contains three objects: ``nodes``, ``edges``, and ``targets``.
+A ``graph`` object contains three objects: ``nodes``, and ``edges``.
 
 .. code:: json
 
     {
         "nodes"     : [ ... ],
-        "edges"     : [ ... ],
-        "targets"   : [ ... ]
+        "edges"     : [ ... ]
     }
 
 - ``nodes`` -- (array of JSON objects) Each object specifies a ``node`` object. 
 - ``edges`` -- (array of JSON objects) Each object specifies an ``edge`` object.
-- ``targets``  -- (array of JSON objects) Each object specifies a ``node`` object or an ``edge`` object,
-  depending on the value of ``gml_task``.
 
 Contents of a ``node`` object listed in a ``nodes`` array
-..........................................................
+**********************************************************
 
 A ``node`` object listed in a ``nodes`` array can contain the following required fields.
 
@@ -73,7 +71,7 @@ A ``node`` object listed in a ``nodes`` array can contain the following required
   :ref:`GSProcessing JSON specification <gsprocessing_input_configuration>`.
 
 Contents of an ``edge`` object listed in an ``edges`` array
-............................................................
+************************************************************
 
 An ``edge`` object listed in an ``edges`` array must contain the following required fields.
 

--- a/docs/source/cli/model-training-inference/real-time-inference-spec.rst
+++ b/docs/source/cli/model-training-inference/real-time-inference-spec.rst
@@ -17,10 +17,7 @@ A payload should be a JSON object. In the highest level, the JSON object contain
     {
         "version"   : string,
         "gml_task"  : string,
-        "graph"     : {
-                           "nodes": [ ... ],
-                           "edges": [ ... ]
-                      },
+        "graph"     : object,
         "targets"   : [ ... ]
     }
 
@@ -35,7 +32,7 @@ A payload should be a JSON object. In the highest level, the JSON object contain
 Contents of objects in the ``graph`` field
 ...........................................
 
-A ``graph`` object contains three objects: ``nodes``, and ``edges``.
+A ``graph`` object contains two objects: ``nodes``, and ``edges``.
 
 .. code:: json
 
@@ -47,8 +44,7 @@ A ``graph`` object contains three objects: ``nodes``, and ``edges``.
 - ``nodes`` -- (array of JSON objects) Each object specifies a ``node`` object. 
 - ``edges`` -- (array of JSON objects) Each object specifies an ``edge`` object.
 
-Contents of a ``node`` object listed in a ``nodes`` array
-**********************************************************
+**Contents of a ``node`` object listed in a ``nodes`` array**
 
 A ``node`` object listed in a ``nodes`` array can contain the following required fields.
 
@@ -73,8 +69,7 @@ A ``node`` object listed in a ``nodes`` array can contain the following required
   <gconstruction-json>`, or the ``name`` values of ``features`` fields defined in
   :ref:`GSProcessing JSON specification <gsprocessing_input_configuration>`.
 
-Contents of an ``edge`` object listed in an ``edges`` array
-************************************************************
+**Contents of an ``edge`` object listed in an ``edges`` array**
 
 An ``edge`` object listed in an ``edges`` array must contain the following required fields.
 

--- a/docs/source/cli/model-training-inference/real-time-inference-spec.rst
+++ b/docs/source/cli/model-training-inference/real-time-inference-spec.rst
@@ -17,7 +17,10 @@ A payload should be a JSON object. In the highest level, the JSON object contain
     {
         "version"   : string,
         "gml_task"  : string,
-        "graph"     : object,
+        "graph"     : {
+                           "nodes": [ ... ],
+                           "edges": [ ... ]
+                      },
         "targets"   : [ ... ]
     }
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This PR fixed the error of the level of ``targets`` objects in real-time inference specification to align with the design doc.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
