### PR TITLE
[sagemaker] [rt-inference] Add option to deploy real-time endpoint into VPC, allow custom entry point location

### DIFF
--- a/docs/source/cli/model-training-inference/real-time-inference.rst
+++ b/docs/source/cli/model-training-inference/real-time-inference.rst
@@ -56,7 +56,7 @@ In short you can run the following:
     # Will push an image to '123456789012.dkr.ecr.us-east-1.amazonaws.com/graphstorm:sagemaker-endpoint-cpu'
     bash docker/push_graphstorm_image.sh --environment sagemaker-endpoint --device cpu --region "us-east-1" --account "123456789012"
 
-Replace the ``123456789012`` with your own AWS account ID. For more build and push options, see 
+Replace the ``123456789012`` with your own AWS account ID. For more build and push options, see
 ``bash docker/build_graphstorm_image.sh --help`` and ``bash docker/push_graphstorm_image.sh --help``.
 
 .. note::
@@ -88,7 +88,7 @@ during  graph construction (GConstruct/GSProcessing) and model training.
   ``--save-model-path`` or ``--model-artifact-s3`` configuration in model training, this updated YAML file will
   be saved to the location specified.
 
-.. note:: 
+.. note::
 
     Starting with v0.5, GraphStorm will save both updated JSON and YAML files into the same location as the trained model
     automatically, if the ``--save-model-path`` or ``--model-artifact-s3``  configuration is set.
@@ -145,6 +145,12 @@ Arguments of the launch endpoint script include:
   (Default: ``GSF-Model4Realtime``)
 - **-\-log-level**: the level of log. Optional values include 'DEBUG', 'INFO', 'WARNING', 'ERROR', and
   'CRITICAL'. Default is 'INFO'.
+- **-\-vpc-subnet-ids**: Optional list of VPC subnet ids to deploy the endpoint into. Needed to deploy
+  the endpoint in the same VPC as e.g. a Neptune Database instance for online inference. When provided,
+  you also need to provide ``--vpc-security-group-ids``.
+- **-\-vpc-security-group-ids**: Optional list of security group ids to attach to the endpoint. Needed
+  to allow the endpoint to communicate with restricted resources like a Neptune Database instance. Needs
+  to be provided together with ``--vpc-subnet-ids``.
 
 Outputs of this command include the deployed endpoint name based on the value for ``--model-name``, e.g.,
 ``GSF-Model4Realtime-Endpoint-2025-06-04-23-47-11``, and the region based on the value for ``--region``.
@@ -159,7 +165,7 @@ graph, and use the subgraph as input of model, which is similar to how models ar
 critical for real-time inference, it is recommended to use an OLTP graph database, e.g.,
 `Amazon Neptune Database <https://aws.amazon.com/neptune/>`_, as data source for subgraph extraction.
 
-Once the subgraph is extracted, you will need to prepare it as the payload of different APIs for `invoke 
+Once the subgraph is extracted, you will need to prepare it as the payload of different APIs for `invoke
 models for real-time inference
 <https://docs.aws.amazon.com/sagemaker/latest/dg/realtime-endpoints-test-endpoints.html#realtime-endpoints-test-endpoints-api>`_.
 GraphStorm defines a :ref:`specification of the payload contents <rt-request-payload-spec>` for your reference.
@@ -224,7 +230,7 @@ invoke an endpoint.
 
     import json
     import boto3
-    
+
 
     # Create a SageMaker client object,
     sagemaker = boto3.client('sagemaker')
@@ -311,7 +317,7 @@ An example of a successful inference response:
 In this example response for a classification task, the ``prediction`` field contains the logits of model
 predictions. You can use classification method, e.g., `argmax`, to get the final class. For example, the
 `argmax` result of the prediction of the paper node ``p9604`` is 12, which means this paper is predicted
-to belong to the 13th class as classes are normally one-hot encoded from 0. 
+to belong to the 13th class as classes are normally one-hot encoded from 0.
 
 An example of an error response:
 

--- a/docs/source/cli/model-training-inference/real-time-inference.rst
+++ b/docs/source/cli/model-training-inference/real-time-inference.rst
@@ -137,7 +137,7 @@ Arguments of the launch endpoint script include:
   ProductionVariant. For details, please refer to `ProductionVariant Documentation
   <https://docs.aws.amazon.com/sagemaker/latest/APIReference/API_ProductionVariant.html>`_.
 - **-\-async-execution**: the mode of endpoint creation. Set ``True`` to deploy endpoint asynchronously,
-  or ``False`` to wait for deployment to finish before exiting. (Default: ``True``)
+  or ``False`` to wait for deployment to finish before exiting. (Default: ``False``)
 - **-\-model-name**: the name of model. This name will be used to define names of SageMaker Model,
   EndpointConfig, and Endpoint by appending datetime to this model name. The name should follow a regular
   expression pattern: ``^[a-zA-Z0-9]([\-a-zA-Z0-9]*[a-zA-Z0-9])$`` as defined in

--- a/sagemaker/launch/launch_realtime_endpoint.py
+++ b/sagemaker/launch/launch_realtime_endpoint.py
@@ -233,11 +233,13 @@ def deploy_endpoint(input_args):
     if input_args.async_execution.lower() == 'true':
         resp = sm_client.describe_endpoint(EndpointName=sm_ep_name)
         status = resp["EndpointStatus"]
-        logging.info("Creating endpoint name: %s at %s region, current status: %s",
-            sm_ep_name, input_args.region, status)
+        print(
+            f"Creating endpoint name: '{sm_ep_name}' in "
+            f"{input_args.region} region, current status: {status}")
     else:
-        logging.info("Waiting for %s endpoint to be in service at %s region...",
-                     sm_ep_name, input_args.region)
+        print(
+            f"Waiting for endpoint '{sm_ep_name}' to "
+            f"be in service in {input_args.region} region...")
         waiter = sm_client.get_waiter("endpoint_in_service")
 
         try:
@@ -246,9 +248,9 @@ def deploy_endpoint(input_args):
                             'Delay': 30,        # seconds between querying
                             'MaxAttempts': 60   # max retries (~30 minutes here)
                         })
-            logging.info(
-                ("%s endpoint has been successfully created, and ready to be "
-                 "invoked!"), sm_ep_name)
+            print(
+                (f"Endpoint named '{sm_ep_name}' has been successfully created, and ready to be "
+                 "invoked!"), )
         except WaiterError as e:
             logging.error("Timed out while creating  endpoint '%s'  "
                           "or endpoint creation failed with reason: %s", sm_ep_name, e)


### PR DESCRIPTION

*Issue #, if available:*

* To use NeptuneDB as a graph source, the endpoint needs to be able to communicate with the NDB instance, which is always placed inside a VPC. 
* With this PR we add the ability to select VPC subnets to place the endpoint in, and additional security groups that allow it to communicate with other resources in the VPC, e.g. an inference client that acts as an intermediate between NDB and SM endpoint, or directly communicate with NDB.
* We also add an option to provide the location of the entry point to use when launching the endpoint. This allows custom entry point locations to be used (e.g. we use this when using the launch script in isolation on a SageMaker notebook instance)

*Description of changes:*

* Add two new optional arguments to `sagemaker/launch/launch_realtime_endpoint.py`, `--vpc-subnet-ids` and `--vpc-security-group-ids`, that allow us to define which VPC to deploy the endpoint in, and which security groups to attach to it.
* Add new optional `--entry-point-path` argument to allow user to define which entry point to use when launching the endpoint.
* Update docs with new args

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
