### PR TITLE
[GSProcessing] Ensure GSProcessing Entry point is backwards compatible with versions < 0.5

### DIFF
--- a/graphstorm-processing/graphstorm_processing/distributed_executor.py
+++ b/graphstorm-processing/graphstorm_processing/distributed_executor.py
@@ -87,8 +87,8 @@ try:
         update_gsprocessing_config,
     )
 except ImportError:
-    from graphstorm_processing.config.config_parser import create_config_objects
     update_gsprocessing_config = None
+    from graphstorm_processing.config.config_parser import create_config_objects
 
 
 @dataclasses.dataclass

--- a/graphstorm-processing/graphstorm_processing/distributed_executor.py
+++ b/graphstorm-processing/graphstorm_processing/distributed_executor.py
@@ -81,13 +81,13 @@ from graphstorm_processing.graph_loaders.row_count_utils import verify_metadata_
 from graphstorm_processing.constants import ExecutionEnv, FilesystemType, HOMOGENEOUS_FLAG
 
 # Avoid entry script version issue
-update_imported_successfully = False
+UPDATE_IMPORTED_SUCCESSFULLY = False
 try:
     from graphstorm_processing.config.config_parser import (
         create_config_objects,
         update_gsprocessing_config,
     )
-    update_imported_successfully = True
+    UPDATE_IMPORTED_SUCCESSFULLY = True
 except ImportError:
     from graphstorm_processing.config.config_parser import create_config_objects
 
@@ -261,7 +261,7 @@ class DistributedExecutor:
         self.spark = spark_utils.create_spark_session(self.execution_env, self.filesystem_type)
 
         # Initialize the graph loader
-        if update_imported_successfully:
+        if UPDATE_IMPORTED_SUCCESSFULLY:
             update_gsprocessing_config(self.gsp_config_dict, self.add_reverse_edges)
         data_configs = create_config_objects(self.gsp_config_dict)
         loader_config = HeterogeneousLoaderConfig(

--- a/graphstorm-processing/graphstorm_processing/distributed_executor.py
+++ b/graphstorm-processing/graphstorm_processing/distributed_executor.py
@@ -79,6 +79,7 @@ from graphstorm_processing.repartition_files import (
 )
 from graphstorm_processing.graph_loaders.row_count_utils import verify_metadata_match
 from graphstorm_processing.constants import ExecutionEnv, FilesystemType, HOMOGENEOUS_FLAG
+
 # Avoid entry script version issue
 try:
     from graphstorm_processing.config.config_parser import (
@@ -87,6 +88,7 @@ try:
     )
 except ImportError:
     from graphstorm_processing.config.config_parser import create_config_objects
+
 
 @dataclasses.dataclass
 class ExecutorConfig:

--- a/graphstorm-processing/graphstorm_processing/distributed_executor.py
+++ b/graphstorm-processing/graphstorm_processing/distributed_executor.py
@@ -81,16 +81,15 @@ from graphstorm_processing.graph_loaders.row_count_utils import verify_metadata_
 from graphstorm_processing.constants import ExecutionEnv, FilesystemType, HOMOGENEOUS_FLAG
 
 # Avoid entry script version issue
-UPDATE_IMPORTED_SUCCESSFULLY = False
 try:
     from graphstorm_processing.config.config_parser import (
         create_config_objects,
         update_gsprocessing_config,
     )
-
-    UPDATE_IMPORTED_SUCCESSFULLY = True
 except ImportError:
     from graphstorm_processing.config.config_parser import create_config_objects
+
+    update_gsprocessing_config = None
 
 
 @dataclasses.dataclass
@@ -262,8 +261,13 @@ class DistributedExecutor:
         self.spark = spark_utils.create_spark_session(self.execution_env, self.filesystem_type)
 
         # Initialize the graph loader
-        if UPDATE_IMPORTED_SUCCESSFULLY:
+        if update_gsprocessing_config:
             update_gsprocessing_config(self.gsp_config_dict, self.add_reverse_edges)
+        else:
+            logging.warning(
+                "The installed GSProcessing version is outdated. "
+                "Please upgrade to version > 0.5 to prevent incorrect script behavior."
+            )
         data_configs = create_config_objects(self.gsp_config_dict)
         loader_config = HeterogeneousLoaderConfig(
             is_homogeneous=self.gsp_config_dict[HOMOGENEOUS_FLAG],

--- a/graphstorm-processing/graphstorm_processing/distributed_executor.py
+++ b/graphstorm-processing/graphstorm_processing/distributed_executor.py
@@ -83,7 +83,7 @@ from graphstorm_processing.constants import ExecutionEnv, FilesystemType, HOMOGE
 try:
     from graphstorm_processing.config.config_parser import (
         create_config_objects,
-        update_dict_if_homogeneous,
+        update_gsprocessing_config,
     )
 except ImportError:
     from graphstorm_processing.config.config_parser import create_config_objects

--- a/graphstorm-processing/graphstorm_processing/distributed_executor.py
+++ b/graphstorm-processing/graphstorm_processing/distributed_executor.py
@@ -81,11 +81,13 @@ from graphstorm_processing.graph_loaders.row_count_utils import verify_metadata_
 from graphstorm_processing.constants import ExecutionEnv, FilesystemType, HOMOGENEOUS_FLAG
 
 # Avoid entry script version issue
+update_imported_successfully = False
 try:
     from graphstorm_processing.config.config_parser import (
         create_config_objects,
         update_gsprocessing_config,
     )
+    update_imported_successfully = True
 except ImportError:
     from graphstorm_processing.config.config_parser import create_config_objects
 
@@ -259,7 +261,8 @@ class DistributedExecutor:
         self.spark = spark_utils.create_spark_session(self.execution_env, self.filesystem_type)
 
         # Initialize the graph loader
-        update_gsprocessing_config(self.gsp_config_dict, self.add_reverse_edges)
+        if update_imported_successfully:
+            update_gsprocessing_config(self.gsp_config_dict, self.add_reverse_edges)
         data_configs = create_config_objects(self.gsp_config_dict)
         loader_config = HeterogeneousLoaderConfig(
             is_homogeneous=self.gsp_config_dict[HOMOGENEOUS_FLAG],

--- a/graphstorm-processing/graphstorm_processing/distributed_executor.py
+++ b/graphstorm-processing/graphstorm_processing/distributed_executor.py
@@ -88,7 +88,6 @@ try:
     )
 except ImportError:
     from graphstorm_processing.config.config_parser import create_config_objects
-
     update_gsprocessing_config = None
 
 

--- a/graphstorm-processing/graphstorm_processing/distributed_executor.py
+++ b/graphstorm-processing/graphstorm_processing/distributed_executor.py
@@ -69,10 +69,6 @@ from graphstorm_processing.graph_loaders.dist_heterogeneous_loader import (
     HeterogeneousLoaderConfig,
     ProcessedGraphRepresentation,
 )
-from graphstorm_processing.config.config_parser import (
-    create_config_objects,
-    update_gsprocessing_config,
-)
 from graphstorm_processing.config.config_conversion import GConstructConfigConverter
 from graphstorm_processing.constants import TRANSFORMATIONS_FILENAME
 from graphstorm_processing.data_transformations import spark_utils, s3_utils
@@ -83,7 +79,14 @@ from graphstorm_processing.repartition_files import (
 )
 from graphstorm_processing.graph_loaders.row_count_utils import verify_metadata_match
 from graphstorm_processing.constants import ExecutionEnv, FilesystemType, HOMOGENEOUS_FLAG
-
+# Avoid entry script version issue
+try:
+    from graphstorm_processing.config.config_parser import (
+        create_config_objects,
+        update_dict_if_homogeneous,
+    )
+except ImportError:
+    from graphstorm_processing.config.config_parser import create_config_objects
 
 @dataclasses.dataclass
 class ExecutorConfig:

--- a/graphstorm-processing/graphstorm_processing/distributed_executor.py
+++ b/graphstorm-processing/graphstorm_processing/distributed_executor.py
@@ -87,6 +87,7 @@ try:
         create_config_objects,
         update_gsprocessing_config,
     )
+
     UPDATE_IMPORTED_SUCCESSFULLY = True
 except ImportError:
     from graphstorm_processing.config.config_parser import create_config_objects

--- a/graphstorm-processing/graphstorm_processing/distributed_executor.py
+++ b/graphstorm-processing/graphstorm_processing/distributed_executor.py
@@ -265,7 +265,7 @@ class DistributedExecutor:
         else:
             logging.warning(
                 "The installed GSProcessing version is outdated. "
-                "Please upgrade to version > 0.5 to prevent incorrect script behavior."
+                "Please upgrade image/installation to version > 0.5 for the latest features."
             )
         data_configs = create_config_objects(self.gsp_config_dict)
         loader_config = HeterogeneousLoaderConfig(


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
