### PR TITLE
[WIP] Fix 0 destination node error in HGT encoder

### DIFF
--- a/python/graphstorm/model/hgt_encoder.py
+++ b/python/graphstorm/model/hgt_encoder.py
@@ -320,7 +320,8 @@ class HGTLayer(nn.Module):
                 else:
                     # Handle zero number of dst nodes, which is an extreme case
                     if g.dstnodes[k].data.get('t') is not None:
-                        trans_out = self.a_linears[k](h[k])
+                        dst_h_k = g.dstnodes[k].data.get('t').view(-1, self.out_dim)
+                        trans_out = self.a_linears[k](dst_h_k)
                     else:
                         continue
 
@@ -834,7 +835,9 @@ class HGTLayerwithEdgeFeat(HGTLayer):
                 else:
                     # Handle zero number of dst nodes, which is an extreme case
                     if g.dstnodes[k].data.get('t') is not None:
-                        trans_out = self.a_linears[k](h[k])
+                        dst_h_k = g.dstnodes[k].data.get('t').view(-1, self.out_dim)
+                        trans_out = self.a_linears[k](dst_h_k)
+
                     else:
                         continue
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This PR fix the issue of mismatch between number of nodes and number of features when the number of destination nodes is 0.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
