### PR TITLE
[Feature] Add edge features support for homogenous GNN: SAGE GATV2

### DIFF
--- a/python/graphstorm/gsf.py
+++ b/python/graphstorm/gsf.py
@@ -1195,6 +1195,7 @@ def set_encoder(model, g, config, train_task):
         gnn_encoder = SAGEEncoder(h_dim=config.hidden_size,
                                   out_dim=out_emb_size,
                                   num_hidden_layers=config.num_layers - 1,
+                                  edge_feat_name=config.edge_feat_name,
                                   dropout=dropout,
                                   aggregator_type='pool',
                                   num_ffn_layers_in_gnn=config.num_ffn_layers_in_gnn,
@@ -1218,6 +1219,7 @@ def set_encoder(model, g, config, train_task):
                                    out_dim=out_emb_size,
                                    num_heads=config.num_heads,
                                    num_hidden_layers=config.num_layers -1,
+                                   edge_feat_name=config.edge_feat_name,
                                    dropout=dropout,
                                    num_ffn_layers_in_gnn=config.num_ffn_layers_in_gnn)
     else:

--- a/python/graphstorm/model/gat_encoder.py
+++ b/python/graphstorm/model/gat_encoder.py
@@ -161,7 +161,7 @@ class GATConvwithEdgeFeat(nn.Module):
 
     Note:
     -----
-    * ``GATConvwithEdgeFeat`` is only effective on homogeneous graphs.
+    * ``GATConvwithEdgeFeat`` is only effective on homogeneous graphs with edge features.
 
     Examples:
     ----------
@@ -228,14 +228,14 @@ class GATConvwithEdgeFeat(nn.Module):
             Features for the default node type and edge type in the format of
             {``dgl.DEFAULT_NTYPE``: tensor, ``dgl.DEFAULT_ETYPE``: tensor}. 
             The definition of ``dgl.DEFAULT_NTYPE`` and ``dgl.DEFAULT_ETYPE`` can
-            be found at `DGL official Github site <https://github.com/dmlc/dgl/blob/
+            be found at DGL official Github site <https://github.com/dmlc/dgl/blob/
             cb4604aca2e9a79eb61827a71f1f781b70ceac83/python/dgl/distributed/constants.py#L8>`_.
 
         Returns
         -------
         dict of Tensor: New node embeddings for the default node type in the format of
-        {``dgl.DEFAULT_NTYPE``: tensor}. The definition of ``dgl.DEFAULT_NTYPE`` can
-        be found at `DGL official Github site 
+        {``dgl.DEFAULT_NTYPE``: tensor}. The definition of ``dgl.DEFAULT_NTYPE`` and 
+        ``dgl.DEFAULT_ETYPE``can be found at DGL official Github site 
         <https://github.com/dmlc/dgl/blob/cb4604aca2e9a79eb61827a71f1f781b70ceac83/
         python/dgl/distributed/constants.py#L8>`_.
         """
@@ -300,6 +300,8 @@ class GATEncoder(GraphConvEncoder):
         Number of multi-heads attention heads.
     num_hidden_layers: int
         Number of hidden layers. Total GNN layers is equal to ``num_hidden_layers + 1``.
+    edge_feat_name: str
+        Name of the edge features used. 
     dropout: float
         Dropout rate. Default: 0.
     activation: torch.nn.functional

--- a/python/graphstorm/model/gatv2_encoder.py
+++ b/python/graphstorm/model/gatv2_encoder.py
@@ -20,7 +20,11 @@ from torch import nn
 import torch.nn.functional as F
 import dgl
 import dgl.nn as dglnn
-from dgl.distributed.constants import DEFAULT_NTYPE
+import dgl.function as fn
+from dgl.nn.pytorch.conv.gatv2conv import DGLError
+from dgl.ops import edge_softmax
+from dgl.utils import expand_as_pair
+from dgl.distributed.constants import DEFAULT_NTYPE, DEFAULT_ETYPE
 
 from .ngnn_mlp import NGNNMLP
 from .gnn_encoder_base import GraphConvEncoder
@@ -142,6 +146,248 @@ class GATv2Conv(nn.Module):
 
         return {DEFAULT_NTYPE: h_conv}
 
+
+class GATv2ConvWithEdgeFeat(nn.Module):
+    r""" 
+    The formulation of ``GATv2ConvWithEdgeFeat`` are:
+    .. math::
+        h_i^{(l+1)} = W_s^{(l)} h_i^{(l)} + 
+            \sum_{j \in \mathcal{N}(i)} \alpha_{i,j}^{(l)} 
+            ( W^{(l)} h_j^{(l)} + W_e^{(l)} e_{i,j} )
+
+    where :math:`\alpha_{ij}` is the attention score bewteen node :math:`i` and
+    node :math:`j`:
+
+    .. math::
+        \alpha_{i,j}^{(l)} = \mathrm{softmax}_j ( \vec{a}^{(l)\,T} \mathrm{LeakyReLU}
+            \left( W^{(l)} h_i^{(l)} \| W^{(l)} h_j^{(l)} \| W_e^{(l)} e_{i,j} \right) )
+    Note:
+    -----
+    * ``GATv2ConvWithEdgeFeat`` is only effective on homogeneous graphs with edge features.
+
+    Examples:
+    ----------
+
+    .. code:: python
+
+        # suppose graph and input_feature are ready
+        from graphstorm.model import GATv2ConvWithEdgeFeat
+
+        layer = GATv2ConvWithEdgeFeat(h_dim, h_dim, num_heads, num_ffn_layers_in_gnn)
+        h = layer(g, input_feature)
+
+    Parameters
+    ----------
+    in_feat : int
+        Input feature size.
+    out_feat : int
+        Output feature size.
+    num_heads : int
+        Number of heads in Multi-head attention.
+    activation : callable, optional
+        Activation function. Default: relu
+    dropout : float, optional
+        Dropout rate. Default: 0.0
+    bias : bool, optional
+        True if bias is added. Default: True
+    num_ffn_layers_in_gnn: int, optional
+        Number of layers of ngnn between gnn layers. Default: 0
+    ffn_actication: torch.nn.functional, optional
+        Activation Method for ngnn. Default: relu
+    """
+    def __init__(self,
+                 in_feat,
+                 out_feat,
+                 num_heads,
+                 activation=F.relu,
+                 dropout=0.0,
+                 feat_drop=0.0,
+                 attn_drop=0.0,
+                 bias=True,
+                 num_ffn_layers_in_gnn=0,
+                 ffn_activation=F.relu,
+                 negative_slope=0.2):
+        super(GATv2ConvWithEdgeFeat, self).__init__()
+        self._num_heads = num_heads
+        self._in_src_feats, self._in_dst_feats = expand_as_pair(in_feat)
+        self._edge_feats = self._in_src_feats
+        self._out_feats = out_feat // num_heads
+        self._allow_zero_in_degree = True
+        if isinstance(in_feat, tuple):
+            self.fc_src = nn.Linear(
+                self._in_src_feats, self._out_feats * self._num_heads, bias=bias
+            )
+            self.fc_dst = nn.Linear(
+                self._in_dst_feats, self._out_feats * self._num_heads, bias=bias
+            )
+        else:
+            self.fc_src = nn.Linear(
+                self._in_src_feats, self._out_feats * self._num_heads, bias=bias
+            )
+            self.fc_dst = nn.Linear(
+                self._in_src_feats, self._out_feats * self._num_heads, bias=bias
+            )
+            
+        self.attn = nn.Parameter(th.FloatTensor(size=(1, self._num_heads, self._out_feats)))
+        self.feat_drop = nn.Dropout(feat_drop)
+        self.attn_drop = nn.Dropout(attn_drop)
+        self.leaky_relu = nn.LeakyReLU(negative_slope)
+        if self._in_dst_feats != self._out_feats * self._num_heads:
+            self.res_fc = nn.Linear(
+                self._in_dst_feats, self._num_heads * self._out_feats, bias=bias
+            )
+        else:
+            self.res_fc = None
+        self.activation = activation
+        self.bias = bias
+        self.fc_edge = nn.Linear(self._edge_feats, self._out_feats * self._num_heads, bias=False)
+        
+        self.reset_parameters()
+        # ngnn
+        self.num_ffn_layers_in_gnn = num_ffn_layers_in_gnn
+        self.ngnn_mlp = NGNNMLP(
+            self._out_feats * self._num_heads, out_feat,
+            num_ffn_layers_in_gnn, ffn_activation, dropout
+        )
+
+    def reset_parameters(self):
+        """
+        Description
+        -----------
+        Reinitialize learnable parameters.
+
+        Note
+        ----
+        The fc weights :math:`W^{(l)}` are initialized using Glorot uniform initialization.
+        The attention weights are using xavier initialization method.
+        """
+        gain = nn.init.calculate_gain("relu")
+        nn.init.xavier_normal_(self.fc_src.weight, gain=gain)
+        if self.bias:
+            nn.init.constant_(self.fc_src.bias, 0)
+        nn.init.xavier_normal_(self.fc_dst.weight, gain=gain)
+        if self.bias:
+            nn.init.constant_(self.fc_dst.bias, 0)
+        nn.init.xavier_normal_(self.attn, gain=gain)
+        if isinstance(self.res_fc, nn.Linear):
+            nn.init.xavier_normal_(self.res_fc.weight, gain=gain)
+            if self.bias:
+                nn.init.constant_(self.res_fc.bias, 0)
+
+    def forward(self, g, inputs):
+        """ GATv2WithEdgeFeat layer Forward computation.
+
+        Parameters
+        ----------
+        g: DGLHeteroGraph
+            Input DGL heterogenous graph.
+        inputs: dict of Tensor
+            Node features for the default node type in the format of
+            {``dgl.DEFAULT_NTYPE``: tensor, ``dgl.DEFAULT_ETYPE``: tensor}. 
+            The definition of ``dgl.DEFAULT_NTYPE`` and ``dgl.DEFAULT_ETYPE`` 
+            can be found at DGL official Github site <https://github.com/dmlc/dgl/blob/
+            cb4604aca2e9a79eb61827a71f1f781b70ceac83/python/dgl/distributed/constants.py#L8>`_.
+
+        Returns
+        -------
+        dict of Tensor: New node embeddings for the default node type in the format of
+            {``dgl.DEFAULT_NTYPE``: tensor}. The definition of ``dgl.DEFAULT_NTYPE``   
+            can be found at DGL official Github site <https://github.com/dmlc/dgl/blob/
+            cb4604aca2e9a79eb61827a71f1f781b70ceac83/python/dgl/distributed/constants.py#L8>`_.
+        """
+        # add self-loop during computation.
+        assert DEFAULT_NTYPE in inputs and DEFAULT_ETYPE in inputs, \
+            "Both node and edge features are needed to for GATConvwithEdgeFeat."
+        
+        node_inputs = inputs[DEFAULT_NTYPE]
+        edge_inputs = inputs[DEFAULT_ETYPE]
+
+        feat = node_inputs
+        with g.local_scope():
+            if not self._allow_zero_in_degree:
+                if (g.in_degrees() == 0).any():
+                    raise DGLError(
+                        "There are 0-in-degree nodes in the graph, "
+                        "output for those nodes will be invalid. "
+                        "This is harmful for some applications, "
+                        "causing silent performance regression. "
+                        "Adding self-loop on the input graph by "
+                        "calling `g = dgl.add_self_loop(g)` will resolve "
+                        "the issue. Setting ``allow_zero_in_degree`` "
+                        "to be `True` when constructing this module will "
+                        "suppress the check and let the code run."
+                    )
+
+            if isinstance(feat, tuple):
+                h_src = self.feat_drop(feat[0])
+                h_dst = self.feat_drop(feat[1])
+                feat_src = self.fc_src(h_src).view(
+                    -1, self._num_heads, self._out_feats
+                )
+                feat_dst = self.fc_dst(h_dst).view(
+                    -1, self._num_heads, self._out_feats
+                )
+            else:
+                h_src = h_dst = self.feat_drop(feat)
+                feat_src = self.fc_src(h_src).view(
+                    -1, self._num_heads, self._out_feats
+                )
+                feat_dst = self.fc_dst(h_dst).view(
+                    -1, self._num_heads, self._out_feats
+                )
+                if g.is_block:
+                    feat_dst = feat_dst[: g.number_of_dst_nodes()]
+                    h_dst = h_dst[: g.number_of_dst_nodes()]
+            
+            # (num_edges, num_heads, out_dim)
+            feat_edge = self.fc_edge(edge_inputs).view(
+                -1, self._num_heads, self._out_feats
+            )
+            g.srcdata.update({"ft_src": feat_src})
+            g.dstdata.update({"ft_dst": feat_dst})
+            g.edata.update({"ft_edge": feat_edge})
+            
+            # Compute attention scores using message function
+            g.apply_edges(fn.u_add_v("ft_src", "ft_dst", "ft_tmp"))
+            g.edata["ft_tmp"] = g.edata["ft_tmp"] + g.edata["ft_edge"]
+            
+            # (num_edges, num_heads, out_dim)
+            e = self.leaky_relu(g.edata["ft_tmp"])
+            # (num_edges, num_heads)
+            e = (e * self.attn).sum(dim=-1).unsqueeze(-1)
+            # compute softmax
+            g.edata["a"] = self.attn_drop(edge_softmax(g, e))
+            
+            # Create new edges features that combine the
+            # features of the source node and the edge features.
+            g.srcdata.update({"ft": feat_src})
+            g.apply_edges(fn.u_add_e("ft", "ft_edge", "ft_combined"))
+            # For each edge, element-wise multiply the combined features with
+            # the attention coefficient.
+            g.edata["m_combined"] = (
+                g.edata["ft_combined"] * g.edata["a"]
+            )
+            g.update_all(fn.copy_e("m_combined", "m"), fn.sum("m", "ft"))
+            h_conv = g.dstdata["ft"]
+
+            # residual
+            if self.res_fc is not None:
+                if h_dst.numel() != 0:
+                    resval = self.res_fc(h_dst).view(
+                        h_dst.shape[0], -1, self._out_feats
+                    )
+                    h_conv = h_conv + resval
+            
+            # activation
+            if self.activation:
+                h_conv = self.activation(h_conv)
+
+        h_conv = h_conv.view(h_conv.shape[0], h_conv.shape[1] * h_conv.shape[2])
+        if self.num_ffn_layers_in_gnn > 0:
+            h_conv = self.ngnn_mlp(h_conv)
+        return {DEFAULT_NTYPE: h_conv}
+
+
 class GATv2Encoder(GraphConvEncoder):
     r""" GATv2 Conv Encoder.
 
@@ -187,6 +433,8 @@ class GATv2Encoder(GraphConvEncoder):
         Number of multi-heads attention heads.
     num_hidden_layers: int
         Number of hidden layers. Total GNN layers is equal to ``num_hidden_layers + 1``.
+    edge_feat_name: str
+        Name of the edge features used.
     dropout: float
         Dropout rate. Default: 0.
     activation: torch.nn.functional
@@ -197,27 +445,55 @@ class GATv2Encoder(GraphConvEncoder):
         Number of fnn layers between GNN layers. Default: 0.
     """
     def __init__(self,
-                 h_dim, out_dim,
+                 h_dim, 
+                 out_dim,
                  num_heads,
                  num_hidden_layers=1,
+                 edge_feat_name=None,
                  dropout=0,
                  activation=F.relu,
                  last_layer_act=False,
                  num_ffn_layers_in_gnn=0):
         super(GATv2Encoder, self).__init__(h_dim, out_dim, num_hidden_layers)
-
+         # check edge type string format
+        if edge_feat_name:
+            assert len(edge_feat_name) == 1, 'Single edge type for homogenous graph.'
+            etype = list(edge_feat_name.keys())[0]
+            assert len(etype) == 3, 'The edge type should be in canonical type format:' + \
+                                    f'(src_ntype, etype, dst_ntype), but got \"{etype}\".'
+        
+        self.edge_feat_name = edge_feat_name
         self.layers = nn.ModuleList()
-        for _ in range(num_hidden_layers):
-            self.layers.append(GATv2Conv(h_dim, h_dim, num_heads,
-                                        activation=activation,
-                                        dropout=dropout, bias=True,
-                                        num_ffn_layers_in_gnn=num_ffn_layers_in_gnn))
+        if edge_feat_name is not None:
+            for _ in range(num_hidden_layers):
+                self.layers.append(GATv2ConvWithEdgeFeat(
+                    h_dim, h_dim, num_heads,
+                    activation=activation,
+                    dropout=dropout, bias=True,
+                    num_ffn_layers_in_gnn=num_ffn_layers_in_gnn)
+                )
 
-        self.layers.append(GATv2Conv(h_dim, out_dim, num_heads,
-                                    activation=activation if last_layer_act else None,
-                                    dropout=dropout, bias=True))
+            self.layers.append(GATv2ConvWithEdgeFeat(
+                h_dim, out_dim, num_heads,
+                activation=activation if last_layer_act else None,
+                dropout=dropout, bias=True)
+            )
+        else:
+            for _ in range(num_hidden_layers):
+                self.layers.append(GATv2Conv(
+                    h_dim, h_dim, num_heads,
+                    activation=activation,
+                    dropout=dropout, bias=True,
+                    num_ffn_layers_in_gnn=num_ffn_layers_in_gnn)
+                )
 
-    def forward(self, blocks, h):
+            self.layers.append(GATv2Conv(
+                h_dim, out_dim, num_heads,
+                activation=activation if last_layer_act else None,
+                dropout=dropout, bias=True)
+            )
+
+    def forward(self, blocks, h, edge_feats=None):
         """ GATv2 encoder forward computation.
 
         Parameters
@@ -232,6 +508,10 @@ class GATv2Encoder(GraphConvEncoder):
             {``dgl.DEFAULT_NTYPE``: tensor}. The definition of ``dgl.DEFAULT_NTYPE`` can
             be found at `DGL official Github site <https://github.com/dmlc/dgl/blob/
             cb4604aca2e9a79eb61827a71f1f781b70ceac83/python/dgl/distributed/constants.py#L8>`_.
+        edge_feats: list of dict of Tensor
+            Input edge features for each edge type in the format of [{etype: tensor}, ...],
+            or [{}, {}. ...] for zero number of edges in input blocks. The length of edge_feats
+            should be equal to the number of gnn layers. Default is None.
 
         Returns
         -------
@@ -241,6 +521,43 @@ class GATv2Encoder(GraphConvEncoder):
             be found at `DGL official Github site <https://github.com/dmlc/dgl/blob/
             cb4604aca2e9a79eb61827a71f1f781b70ceac83/python/dgl/distributed/constants.py#L8>`_.
         """
-        for layer, block in zip(self.layers, blocks):
-            h = layer(block, h)
+        if self.edge_feat_name is not None:
+            assert edge_feats is not None,\
+             f"edge features for the edge_feat_name {self.edge_feat_name} should not be None"
+
+        if edge_feats is not None:
+            assert len(edge_feats) == len(blocks), \
+                'The layer of edge features should be equal to ' + \
+                f'the number of blocks, but got {len(edge_feats)} layers of edge features ' + \
+                f'and {len(blocks)} blocks.'
+
+            for layer, block, e_h in zip(self.layers, blocks, edge_feats):
+                # Prepare input features for the layer
+                layer_input = {DEFAULT_NTYPE: h[DEFAULT_NTYPE]}
+
+                # Add edge features if available and encoder supports them
+                if self.edge_feat_name is not None:
+                    if isinstance(e_h, dict) and DEFAULT_ETYPE in e_h:
+                        layer_input[DEFAULT_ETYPE] = e_h[DEFAULT_ETYPE]
+                    else:
+                        raise NotImplementedError(
+                            f"Edge features must be a dict containing "
+                            f"'{DEFAULT_ETYPE}' key, but got {type(e_h)}"
+                        )
+                # Call the layer with the prepared input
+                h = layer(block, layer_input)
+        else:
+            for layer, block in zip(self.layers, blocks):
+                h = layer(block, h)
         return h
+
+    def is_support_edge_feat(self):
+        """ Overwrite ``GraphConvEncoder`` class' method, indicating GATv2Encoder
+        supports edge features which is previously obtained by edge_feat_name.
+        
+        Returns
+        -------
+        bool
+            True indicating that GATv2Encoder supports edge features.
+        """
+        return self.edge_feat_name is not None

--- a/python/graphstorm/model/sage_encoder.py
+++ b/python/graphstorm/model/sage_encoder.py
@@ -15,10 +15,13 @@
 
     Sage layer implementation.
 """
+import torch as th
 from torch import nn
-import torch.nn.functional as F
 import dgl.nn as dglnn
-from dgl.distributed.constants import DEFAULT_NTYPE
+import dgl.function as fn
+import torch.nn.functional as F
+from dgl.distributed.constants import DEFAULT_NTYPE, DEFAULT_ETYPE 
+from dgl.utils import expand_as_pair
 
 from .ngnn_mlp import NGNNMLP
 from .gnn_encoder_base import GraphConvEncoder
@@ -147,6 +150,292 @@ class SAGEConv(nn.Module):
         return {DEFAULT_NTYPE: h_conv}
 
 
+class SAGEConvWithEdgeFeat(nn.Module):
+    r"""
+    The message passing formulas of ``SAGEConvWithEdgeFeat`` are:
+
+    .. math::
+        h_{\mathcal{N}(i)}^{(l+1)} &= \mathrm{aggregate}
+        \left(\{h_{j}^{l}, \forall j \in \mathcal{N}(i) \}\right)
+
+        h_{i}^{(l+1)} &= \sigma \left(W \cdot \mathrm{concat}
+        (h_{i}^{l}, h_{\mathcal{N}(i)}^{l+1}) \right)
+
+        h_{i}^{(l+1)} &= \mathrm{norm}(h_{i}^{(l+1)})
+
+    Note:
+    -----
+    * ``SAGEConvWithEdgeFeat`` is only effective on homogeneous graphs.
+
+    Examples:
+    ----------
+
+    .. code:: python
+
+        # suppose graph and input_feature are ready
+        from graphstorm.model import SAGEConv
+
+        layer = SAGEConv(h_dim, h_dim, aggregator_type,
+                         bias, activation, dropout,
+                         num_ffn_layers_in_gnn, norm)
+        h = layer(g, input_feature)
+
+    Parameters
+    ----------
+    in_feat: int
+        Input feature size.
+    out_feat: int
+        Output feature size.
+    aggregator_type: str
+        Message aggregation type. Options: ``mean``, ``gcn``, ``pool``, ``lstm``.
+        Default: ``mean``.
+    bias: bool
+        Whether to add bias. Default: True.
+    dropout: float
+        Dropout rate. Default: 0.
+    activation: torch.nn.functional
+        Activation function. Default: relu.
+    num_ffn_layers_in_gnn: int
+        Number of fnn layers between gnn layers. Default: 0.
+    ffn_actication: torch.nn.functional
+        Activation for ffn. Default: relu.
+    norm: str
+        Normalization methods. Options:``batch``, ``layer``, and ``None``. Default: None,
+        meaning no normalization.
+    """
+    def __init__(self,
+                 in_feat,
+                 out_feat,
+                 aggregator_type='mean',
+                 bias=True,
+                 dropout=0.0,
+                 feat_drop=0.0,
+                 activation=F.relu,
+                 num_ffn_layers_in_gnn=0,
+                 ffn_activation=F.relu,
+                 norm=None):
+        super(SAGEConvWithEdgeFeat, self).__init__()
+        self.in_feat, self.out_feat = in_feat, out_feat
+        self.aggregator_type = aggregator_type
+
+        valid_aggre_types = {"mean", "gcn", "pool", "lstm"}
+        if aggregator_type not in valid_aggre_types:
+            raise DGLError(
+                "Invalid aggregator_type. Must be one of {}. "
+                "But got {!r} instead.".format(
+                    valid_aggre_types, aggregator_type
+                )
+            )
+
+        self._in_src_feats, self._in_dst_feats = expand_as_pair(in_feat)
+        self._in_edge_feats = self._in_src_feats
+        self._out_feats = out_feat
+        self._aggre_type = aggregator_type
+        self.norm = norm
+        self.feat_drop = nn.Dropout(feat_drop)
+        self.activation = activation
+
+        self.fc_edge  = nn.Linear(self._in_edge_feats, self._in_edge_feats)
+        # aggregator type: mean/pool/lstm/gcn
+        if aggregator_type == "pool":
+            self.fc_pool = nn.Linear(self._in_src_feats + self._in_edge_feats, self._in_src_feats + self._in_edge_feats)
+        if aggregator_type == "lstm":
+            self.lstm = nn.LSTM(
+                self._in_src_feats + self._in_edge_feats, self._in_src_feats + self._in_edge_feats, batch_first=True
+            )
+        self.fc_neigh = nn.Linear(self._in_src_feats + self._in_edge_feats, self._out_feats, bias=False)
+
+        if aggregator_type != "gcn":
+            self.fc_self = nn.Linear(self._in_dst_feats, self._out_feats, bias=bias)
+        elif bias:
+            self.bias = nn.parameter.Parameter(th.zeros(self._out_feats))
+        else:
+            self.register_buffer("bias", None)
+
+        self.reset_parameters()
+        self.activation = activation
+        # normalization
+        self.norm = None
+        if activation is None and norm is not None:
+            raise ValueError("Cannot set gnn norm layer when activation layer is None")
+        if norm == "batch":
+            self.norm = nn.BatchNorm1d(out_feat)
+        elif norm == "layer":
+            self.norm = nn.LayerNorm(out_feat)
+        else:
+            # by default we don't apply any normalization
+            self.norm = None
+        # ngnn
+        self.num_ffn_layers_in_gnn = num_ffn_layers_in_gnn
+        self.ngnn_mlp = NGNNMLP(out_feat, out_feat,
+                                 num_ffn_layers_in_gnn, ffn_activation, dropout)
+    
+    def reset_parameters(self):
+        r"""
+
+        Description
+        -----------
+        Reinitialize learnable parameters.
+
+        Note
+        ----
+        The linear weights :math:`W^{(l)}` are initialized using Glorot uniform initialization.
+        The LSTM module is using xavier initialization method for its weights.
+        """
+        gain = nn.init.calculate_gain("relu")
+        if self._aggre_type == "pool":
+            nn.init.xavier_uniform_(self.fc_pool.weight, gain=gain)
+        if self._aggre_type == "lstm":
+            self.lstm.reset_parameters()
+        if self._aggre_type != "gcn":
+            nn.init.xavier_uniform_(self.fc_self.weight, gain=gain)
+        nn.init.xavier_uniform_(self.fc_neigh.weight, gain=gain)
+
+    def forward(self, g, inputs, edge_weight=None):
+        """ GraphSage layer forward computation.
+
+        Parameters
+        ----------
+        g: DGLHeteroGraph
+            Input DGL heterogenous graph.
+        inputs: dict of Tensor
+            Features for the default node type and edge type in the format of
+            {``dgl.DEFAULT_NTYPE``: tensor, ``dgl.DEFAULT_ETYPE``: tensor}. 
+            The definition of ``dgl.DEFAULT_NTYPE`` and ``dgl.DEFAULT_ETYPE`` can
+            be found at DGL official Github site <https://github.com/dmlc/dgl/blob/
+            cb4604aca2e9a79eb61827a71f1f781b70ceac83/python/dgl/distributed/constants.py#L8>`_.
+        edge_weight : torch.Tensor, optional
+            Optional tensor on the edge. If given, the convolution will weight
+            with regard to the message.
+
+        Returns
+        -------
+        dict of Tensor: New node embeddings for the default node type in the format of
+        {``dgl.DEFAULT_NTYPE``: tensor}. The definition of ``dgl.DEFAULT_NTYPE`` and
+        ``dgl.DEFAULT_ETYPE``can be found at DGL official Github site 
+        <https://github.com/dmlc/dgl/blob/cb4604aca2e9a79eb61827a71f1f781b70ceac83/
+        python/dgl/distributed/constants.py#L8>`_.
+        """
+        g = g.local_var()
+
+        node_inputs = inputs[DEFAULT_NTYPE]
+        edge_inputs = inputs[DEFAULT_ETYPE]
+
+        g.edata["ft_edge"] = self.fc_edge(edge_inputs)
+        with g.local_scope():
+            if isinstance(node_inputs, tuple):
+                feat_src = self.feat_drop(node_inputs[0])
+                feat_dst = self.feat_drop(node_inputs[1])
+            else:
+                feat_src = feat_dst = self.feat_drop(node_inputs)
+                if g.is_block:
+                    feat_dst = feat_src[:g.number_of_dst_nodes()]
+            
+            msg_fn = fn.copy_u("h", "m")
+            if edge_weight is not None:
+                assert edge_weight.shape[0] == graph.num_edges()
+                g.edata["_edge_weight"] = edge_weight
+                msg_fn = fn.u_mul_e("h", "_edge_weight", "m")
+
+            h_self = feat_dst
+
+            # Handle the case of graphs without edges
+            if g.num_edges() == 0:
+                g.dstdata["neigh"] = th.zeros(
+                    feat_dst.shape[0], self._in_src_feats + self._in_edge_feats
+                ).to(feat_dst)
+
+            # Message Passing
+            if self._aggre_type == "mean":
+                g.srcdata["h"] = feat_src
+                g.apply_edges(fn.copy_u("h", "m"))
+                g.edata["m"] = th.cat([g.edata['m'], edge_inputs], dim=-1)
+                g.update_all(fn.copy_e("m", "m"), fn.mean("m", "neigh"))
+                h_neigh = g.dstdata["neigh"]
+                h_neigh = self.fc_neigh(h_neigh)
+
+            elif self._aggre_type == "gcn":
+                check_eq_shape(feat)
+                g.srcdata["h"] = feat_src
+                if isinstance(feat, tuple): 
+                    g.dstdata["h"] = feat_dst
+                else:
+                    if g.is_block:
+                        g.dstdata["h"] = g.srcdata["h"][:g.num_dst_nodes()]
+                    else:
+                        g.dstdata["h"] = g.srcdata["h"]
+                g.apply_edges(fn.copy_u("h", "m"))
+                g.edata["m"] = th.cat([g.edata['m'], edge_inputs], dim=-1)
+                g.update_all(fn.copy_e("m", "m"), fn.sum("m", "neigh"))
+                # divide in_degrees
+                degs = g.in_degrees().to(feat_dst)
+                h_neigh = (g.dstdata["neigh"] + g.dstdata["h"]) / (
+                    degs.unsqueeze(-1) + 1
+                )
+                h_neigh = self.fc_neigh(h_neigh)
+            
+            elif self._aggre_type == "pool":
+                g.srcdata["h"] = F.relu(self.fc_pool(h))
+                g.apply_edges(fn.copy_u("h", "m"))
+                g.edata["m"] = th.cat([g.edata['m'], edge_inputs], dim=-1)
+                g.update_all(fn.copy_e("m", "m"), fn.max("m", "neigh"))
+                h_neigh = self.fc_neigh(g.dstdata["neigh"])
+            
+            elif self._aggre_type == "lstm":
+                g.srcdata["h"] = feat_src
+                g.apply_edges(fn.copy_u("h", "m"))
+                g.edata['m']  = th.cat([g.edata['m'], edge_inputs], dim=-1)
+                g.update_all(fn.copy_e("m", "m"), self._lstm_reducer)
+                h_neigh = self.fc_neigh(g.dstdata["neigh"])
+            
+            else:
+                raise KeyError(
+                    "Aggregator type {} not recognized.".format(
+                        self._aggre_type
+                    )
+                )
+
+            # GraphSAGE GCN does not require fc_self.
+            if self._aggre_type == "gcn":
+                h_conv = h_neigh
+                # add bias manually for GCN
+                if self.bias is not None:
+                    h_conv = h_conv + self.bias
+            else:
+                h_conv = self.fc_self(h_self) + h_neigh
+
+            # activation
+            if self.activation is not None:
+                h_conv = self.activation(h_conv)
+            
+            # normalization
+            if self.norm is not None:
+                h_conv = self.norm(h_conv)
+
+        if self.norm:
+            h_conv = self.norm(h_conv)
+        if self.activation:
+            h_conv = self.activation(h_conv)
+        if self.num_ffn_layers_in_gnn > 0:
+            h_conv = self.ngnn_mlp(h_conv)
+
+        return {DEFAULT_NTYPE: h_conv}
+
+    def _lstm_reducer(self, nodes):
+        """LSTM reducer
+        NOTE(zihao): lstm reducer with default schedule (degree bucketing)
+        is slow, we could accelerate this with degree padding in the future.
+        """
+        m = nodes.mailbox["m"]  # (B, L, D)
+        batch_size = m.shape[0]
+        h = (
+            m.new_zeros((1, batch_size, self._in_src_feats)),
+            m.new_zeros((1, batch_size, self._in_src_feats)),
+        )
+        _, (rst, _) = self.lstm(m, h)
+        return {"neigh": rst.squeeze(0)}
+
+
 class SAGEEncoder(GraphConvEncoder):
     r""" GraphSage Conv Encoder.
 
@@ -161,6 +450,8 @@ class SAGEEncoder(GraphConvEncoder):
         Output dimension size.
     num_hidden_layers: int
         Number of hidden layers. Total GNN layers is equal to ``num_hidden_layers + 1``.
+    edge_feat_name: str
+        Name of the edge features used.
     dropout: float
         Dropout rate. Default: 0.
     aggregator_type: str
@@ -208,27 +499,47 @@ class SAGEEncoder(GraphConvEncoder):
     def __init__(self,
                  h_dim, out_dim,
                  num_hidden_layers=1,
+                 edge_feat_name=None,
                  dropout=0,
                  aggregator_type='mean',
                  activation=F.relu,
                  num_ffn_layers_in_gnn=0,
                  norm=None):
         super(SAGEEncoder, self).__init__(h_dim, out_dim, num_hidden_layers)
+        if edge_feat_name:
+            assert len(edge_feat_name) == 1, 'Single edge type for homogenous graph.'
+            etype = list(edge_feat_name.keys())[0]
+            assert len(etype) == 3, 'The edge type should be in canonical type format:' + \
+                                    f'(src_ntype, etype, dst_ntype), but got \"{etype}\".'
+        self.edge_feat_name = edge_feat_name
 
         self.layers = nn.ModuleList()
-        for _ in range(num_hidden_layers):
-            self.layers.append(SAGEConv(h_dim, h_dim, aggregator_type,
+        if edge_feat_name is not None:
+            for _ in range(num_hidden_layers):
+                self.layers.append(SAGEConvWithEdgeFeat(h_dim, h_dim, aggregator_type,
+                                            bias=False, activation=activation,
+                                            dropout=dropout,
+                                            num_ffn_layers_in_gnn=num_ffn_layers_in_gnn,
+                                            norm=norm))
+
+            self.layers.append(SAGEConvWithEdgeFeat(h_dim, out_dim, aggregator_type,
                                         bias=False, activation=activation,
                                         dropout=dropout,
-                                        num_ffn_layers_in_gnn=num_ffn_layers_in_gnn,
-                                        norm=norm))
+                                        num_ffn_layers_in_gnn=num_ffn_layers_in_gnn))
+        else:
+            for _ in range(num_hidden_layers):
+                self.layers.append(SAGEConv(h_dim, h_dim, aggregator_type,
+                                            bias=False, activation=activation,
+                                            dropout=dropout,
+                                            num_ffn_layers_in_gnn=num_ffn_layers_in_gnn,
+                                            norm=norm))
 
-        self.layers.append(SAGEConv(h_dim, out_dim, aggregator_type,
-                                    bias=False, activation=activation,
-                                    dropout=dropout,
-                                    num_ffn_layers_in_gnn=num_ffn_layers_in_gnn))
+            self.layers.append(SAGEConv(h_dim, out_dim, aggregator_type,
+                                        bias=False, activation=activation,
+                                        dropout=dropout,
+                                        num_ffn_layers_in_gnn=num_ffn_layers_in_gnn))
 
-    def forward(self, blocks, h):
+    def forward(self, blocks, h, edge_feats=None):
         """ GraphSage encoder forward computation.
 
         Parameters
@@ -238,11 +549,15 @@ class SAGEEncoder(GraphConvEncoder):
             detailed information about DGL MFG can be found in `DGL Neighbor Sampling
             Overview
             <https://docs.dgl.ai/stochastic_training/neighbor_sampling_overview.html>`_.
-        h: dict of Tensor
+         h: dict of Tensor
             Node features for the default node type in the format of
             {``dgl.DEFAULT_NTYPE``: tensor}. The definition of ``dgl.DEFAULT_NTYPE`` can
             be found at `DGL official Github site <https://github.com/dmlc/dgl/blob/
             cb4604aca2e9a79eb61827a71f1f781b70ceac83/python/dgl/distributed/constants.py#L8>`_.
+        edge_feats: list of dict of Tensor
+            Input edge features for each edge type in the format of [{etype: tensor}, ...],
+            or [{}, {}. ...] for zero number of edges in input blocks. The length of edge_feats
+            should be equal to the number of gnn layers. Default is None.
 
         Returns
         -------
@@ -252,6 +567,45 @@ class SAGEEncoder(GraphConvEncoder):
             be found at `DGL official Github site <https://github.com/dmlc/dgl/blob/
             cb4604aca2e9a79eb61827a71f1f781b70ceac83/python/dgl/distributed/constants.py#L8>`_.
         """
-        for layer, block in zip(self.layers, blocks):
-            h = layer(block, h)
+        if self.edge_feat_name is not None:
+            assert edge_feats is not None,\
+             f"edge features for the edge_feat_name {self.edge_feat_name} should not be None"
+        if edge_feats is not None:
+            assert len(edge_feats) == len(blocks), \
+                'The layer of edge features should be equal to ' + \
+                f'the number of blocks, but got {len(edge_feats)} layers of edge features ' + \
+                f'and {len(blocks)} blocks.'
+            for layer, block, e_h in zip(self.layers, blocks, edge_feats):
+                # Prepare input features for the layer
+                layer_input = {DEFAULT_NTYPE: h[DEFAULT_NTYPE]}
+
+                # Add edge features if available and encoder supports them
+                if self.edge_feat_name is not None:
+                    if isinstance(e_h, dict) and DEFAULT_ETYPE in e_h:
+                        layer_input[DEFAULT_ETYPE] = e_h[DEFAULT_ETYPE]
+                    else:
+                        raise NotImplementedError(
+                            f"Edge features must be a dict containing "
+                            f"'{DEFAULT_ETYPE}' key, but got {type(e_h)}"
+                        )
+                # Call the layer with the prepared input
+                h = layer(block, layer_input)
+
+        else:
+            for layer, block in zip(self.layers, blocks):
+                # Prepare input features for the layer (no edge features)
+                layer_input = {DEFAULT_NTYPE: h[DEFAULT_NTYPE]}
+                # Call the layer with the prepared input
+                h = layer(block, layer_input)
         return h
+
+    def is_support_edge_feat(self):
+        """ Overwrite ``GraphConvEncoder`` class' method, indicating SAGEEncoder
+        supports edge features which is previously obtained by edge_feat_name.
+        
+        Returns
+        -------
+        bool
+            True indicating that SAGEEncoder supports edge features.
+        """
+        return self.edge_feat_name is not None


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This PR adds the usage of edge_feat in the GATV2 and SAGE model for homogeneous graph in gsf.py, gat_encoder.py, sage_encoder.py. The corresponding unit-test is added in test_nn_encoder.py and test_nn_model.py.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
