### PR TITLE
fix(trainer): clip gradients before optimizer.step() so --max-grad-norm takes effect

### DIFF
--- a/python/graphstorm/trainer/ep_trainer.py
+++ b/python/graphstorm/trainer/ep_trainer.py
@@ -227,11 +227,11 @@ class GSgnnEdgePredictionTrainer(GSgnnTrainer):
                 self.optimizer.zero_grad()
                 loss.backward()
                 rt_profiler.record('train_backward')
+                if max_grad_norm is not None:
+                    th.nn.utils.clip_grad_norm_(model.parameters(), max_grad_norm, grad_norm_type)
                 self.optimizer.step()
                 rt_profiler.record('train_step')
 
-                if max_grad_norm is not None:
-                    th.nn.utils.clip_grad_norm_(model.parameters(), max_grad_norm, grad_norm_type)
                 self.log_metric("Train loss", loss.item(), total_steps)
 
                 if i % 20 == 0 and get_rank() == 0:

--- a/python/graphstorm/trainer/glem_np_trainer.py
+++ b/python/graphstorm/trainer/glem_np_trainer.py
@@ -238,11 +238,11 @@ class GLEMNodePredictionTrainer(GSgnnNodePredictionTrainer):
             self.optimizer.zero_grad(optimize_sparse_params=module.training_sparse_embed)
             loss.backward()
             profiler.record('train_backward')
+            if max_grad_norm is not None:
+                th.nn.utils.clip_grad_norm_(model.parameters(), max_grad_norm, grad_norm_type)
             self.optimizer.step(optimize_sparse_params=module.training_sparse_embed)
             profiler.record('train_step')
 
-            if max_grad_norm is not None:
-                th.nn.utils.clip_grad_norm_(model.parameters(), max_grad_norm, grad_norm_type)
             self.log_metric("Train loss", loss.item(), total_steps)
 
             if i % 20 == 0 and get_rank() == 0:

--- a/python/graphstorm/trainer/lp_trainer.py
+++ b/python/graphstorm/trainer/lp_trainer.py
@@ -231,11 +231,11 @@ class GSgnnLinkPredictionTrainer(GSgnnTrainer):
                 self.optimizer.zero_grad()
                 loss.backward()
                 rt_profiler.record('train_backward')
+                if max_grad_norm is not None:
+                    th.nn.utils.clip_grad_norm_(model.parameters(), max_grad_norm, grad_norm_type)
                 self.optimizer.step()
                 rt_profiler.record('train_step')
 
-                if max_grad_norm is not None:
-                    th.nn.utils.clip_grad_norm_(model.parameters(), max_grad_norm, grad_norm_type)
                 self.log_metric("Train loss", loss.item(), total_steps)
                 if i % 20 == 0 and get_rank() == 0:
                     rt_profiler.print_stats()

--- a/python/graphstorm/trainer/mt_trainer.py
+++ b/python/graphstorm/trainer/mt_trainer.py
@@ -443,11 +443,11 @@ class GSgnnMultiTaskLearningTrainer(GSgnnTrainer):
                 self.optimizer.zero_grad()
                 loss.backward()
                 rt_profiler.record('train_backward')
+                if max_grad_norm is not None:
+                    th.nn.utils.clip_grad_norm_(model.parameters(), max_grad_norm, grad_norm_type)
                 self.optimizer.step()
                 rt_profiler.record('train_step')
 
-                if max_grad_norm is not None:
-                    th.nn.utils.clip_grad_norm_(model.parameters(), max_grad_norm, grad_norm_type)
                 self.log_metric("Train loss", loss.item(), total_steps)
 
                 if i % 20 == 0 and get_rank() == 0:

--- a/python/graphstorm/trainer/np_trainer.py
+++ b/python/graphstorm/trainer/np_trainer.py
@@ -214,11 +214,11 @@ class GSgnnNodePredictionTrainer(GSgnnTrainer):
                 self.optimizer.zero_grad()
                 loss.backward()
                 rt_profiler.record('train_backward')
+                if max_grad_norm is not None:
+                    th.nn.utils.clip_grad_norm_(model.parameters(), max_grad_norm, grad_norm_type)
                 self.optimizer.step()
                 rt_profiler.record('train_step')
 
-                if max_grad_norm is not None:
-                    th.nn.utils.clip_grad_norm_(model.parameters(), max_grad_norm, grad_norm_type)
                 self.log_metric("Train loss", loss.item(), total_steps)
 
                 if i % 20 == 0 and get_rank() == 0:

--- a/tests/unit-tests/test_trainer.py
+++ b/tests/unit-tests/test_trainer.py
@@ -1042,6 +1042,90 @@ def test_rgcn_nc4ef():
     th.distributed.destroy_process_group()
     dgl.distributed.kvstore.close_kvstore()
 
+def test_node_trainer_grad_clip_before_step():
+    """ Test that ``--max-grad-norm`` clips gradients *before* the optimizer step.
+
+    Gradient clipping (``th.nn.utils.clip_grad_norm_``) must run between
+    ``loss.backward()`` and ``optimizer.step()``; otherwise the optimizer applies
+    the un-clipped gradients and the clip becomes a no-op for that update (issue
+    #1366). This test spies on ``clip_grad_norm_`` and ``GSOptimizer.step`` and
+    asserts the clip is observed before the step on every training iteration.
+    """
+    from graphstorm.model import GSOptimizer
+
+    # initialize the torch distributed environment
+    th.distributed.init_process_group(backend='gloo',
+                                      init_method='tcp://127.0.0.1:23456',
+                                      rank=0,
+                                      world_size=1)
+
+    setup_device(0)
+    device = get_device()
+
+    with tempfile.TemporaryDirectory() as tmpdirname:
+        _, part_config = generate_dummy_dist_graph(tmpdirname)
+        gdata = GSgnnData(part_config=part_config)
+
+        create_config4ef(Path(tmpdirname), 'gnn_nc.yaml', use_ef=False)
+        args = Namespace(yaml_config_file=os.path.join(Path(tmpdirname), 'gnn_nc.yaml'),
+                            local_rank=0)
+        config = GSConfig(args)
+
+        model = create_builtin_node_gnn_model(gdata.g, config, True)
+        trainer = GSgnnNodePredictionTrainer(model)
+        trainer.setup_device(device)
+
+        train_dataloader = GSgnnNodeDataLoader(
+            gdata,
+            target_idx=gdata.get_node_train_set(config.target_ntype),
+            fanout=config.fanout,
+            batch_size=config.batch_size,
+            label_field=config.label_field,
+            node_feats=config.node_feat_name,
+            edge_feats=None,
+            train_task=True)
+
+        # Record the relative order in which clipping and the optimizer step are
+        # called; both spies call through to the originals so fit() runs for real.
+        call_order = []
+        orig_clip = th.nn.utils.clip_grad_norm_
+        orig_step = GSOptimizer.step
+
+        def spy_clip(*args, **kwargs):
+            call_order.append("clip")
+            return orig_clip(*args, **kwargs)
+
+        def spy_step(self, *args, **kwargs):
+            call_order.append("step")
+            return orig_step(self, *args, **kwargs)
+
+        with patch.object(th.nn.utils, "clip_grad_norm_", side_effect=spy_clip), \
+             patch.object(GSOptimizer, "step", autospec=True, side_effect=spy_step):
+            trainer.fit(
+                train_loader=train_dataloader,
+                num_epochs=1,
+                max_grad_norm=1.0)
+
+    # At every point in the call sequence the number of observed clips must be
+    # >= the number of observed steps; this holds iff each clip precedes its
+    # paired step. On the buggy ordering the first event is a step, so the
+    # invariant fails immediately.
+    clips = steps = 0
+    for event in call_order:
+        if event == "clip":
+            clips += 1
+        else:
+            steps += 1
+        assert clips >= steps, (
+            "clip_grad_norm_ must be called before optimizer.step() on every "
+            f"iteration, but observed a step before its clip. Order: {call_order}")
+    assert steps > 0, "optimizer.step() was never called; the training loop did not run"
+    assert clips == steps, (
+        f"expected one clip per step, got {clips} clips and {steps} steps")
+
+    th.distributed.destroy_process_group()
+    dgl.distributed.kvstore.close_kvstore()
+
 def test_rgat_nc4ef():
     """ Test RGAT model Node Classification traning pipeline with/without edge features.
     """


### PR DESCRIPTION
## Summary

Fixes #1366.

`--max-grad-norm` is meant to clip gradients for training stability, but every
trainer calls `th.nn.utils.clip_grad_norm_` **after** `optimizer.step()`:

```python
self.optimizer.zero_grad()
loss.backward()
rt_profiler.record('train_backward')
self.optimizer.step()          # <-- optimizer already used the un-clipped grads
rt_profiler.record('train_step')

if max_grad_norm is not None:
    th.nn.utils.clip_grad_norm_(model.parameters(), max_grad_norm, grad_norm_type)
```

Since `optimizer.step()` has already consumed the gradients to update the
parameters, clipping afterward is a no-op for that update — the gradients are
zeroed at the start of the next iteration before they're ever used. The result
is that `--max-grad-norm` silently does nothing.

The correct contract is `backward → clip → step`, so the optimizer applies the
clipped gradients.

## Changes

Moved the clip block to run immediately after `loss.backward()` and before
`optimizer.step()`. The issue names `np_trainer`, but the same wrong ordering is
present in all five trainers, so I've fixed them together:

- `python/graphstorm/trainer/np_trainer.py`
- `python/graphstorm/trainer/ep_trainer.py`
- `python/graphstorm/trainer/lp_trainer.py`
- `python/graphstorm/trainer/mt_trainer.py`
- `python/graphstorm/trainer/glem_np_trainer.py`

This is a pure statement reorder — no signature or API change. The
`if max_grad_norm is not None:` guard is preserved, so the default
(`max_grad_norm=None`) path is unchanged; behavior only changes when a user
explicitly sets the flag, where it was already broken.

> **Scope note for maintainers:** the issue only mentions `np_trainer`. I scoped
> the fix to all five trainers since the bug is identical in each, but I'm happy
> to narrow this PR to just `np_trainer` (or np/ep/lp) if you'd prefer a smaller
> change — just let me know.

## Testing

Added `tests/unit-tests/test_trainer.py::test_node_trainer_grad_clip_before_step`:
it spies on `clip_grad_norm_` and `GSOptimizer.step` (both call through to the
originals so `fit()` runs for real), runs `trainer.fit(num_epochs=1,
max_grad_norm=1.0)` on the existing tiny CPU/gloo dummy graph, and asserts the
clip is observed before the step on every iteration.

- Fails on the current ordering (records `['step', 'clip']`).
- Passes after the reorder.
- Full `test_trainer.py` suite: **17 passed** (CPU/gloo, `world_size=1`).
- `pylint --rcfile=tests/lint/pylintrc python/graphstorm/trainer/`: 10.00/10.
